### PR TITLE
Set button height to 50

### DIFF
--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -31,16 +31,20 @@ export const button = (
   justifyContent: JustifyContentProperty = 'center'
 ) =>
   css([
-    typography.buttonText,
     {
       /* cross-browser styling resets */
       backgroundImage: 'none',
       cursor: 'pointer',
-      lineHeight: 1,
       textDecoration: 'none',
       transition: 'none',
       verticalAlign: 'middle',
       whiteSpace: 'nowrap',
+
+      /* text */
+      fontFamily: typography.defaultFontFamily,
+      fontSize: pxToRem(16),
+      fontWeight: 600,
+      letterSpacing: 'normal',
 
       /* layout */
       border: 0,

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -45,6 +45,7 @@ export const button = (
       border: 0,
       borderRadius: '4px',
       display: 'flex',
+      height: pxToRem(50),
       justifyContent,
       padding: pxToRem(16),
       width: '100%'

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -36,6 +36,7 @@ export const button = (
       /* cross-browser styling resets */
       backgroundImage: 'none',
       cursor: 'pointer',
+      lineHeight: 1,
       textDecoration: 'none',
       transition: 'none',
       verticalAlign: 'middle',

--- a/src/styles/src/typography.ts
+++ b/src/styles/src/typography.ts
@@ -74,14 +74,6 @@ export const small = css({
   color: battleshipGrey
 })
 
-export const buttonText = css({
-  fontFamily: defaultFontFamily,
-  fontSize: pxToRem(16),
-  fontWeight: 600,
-  lineHeight: '1.43',
-  letterSpacing: 'normal'
-})
-
 export const linkText = css({
   fontFamily: defaultFontFamily,
   color: cerulean,


### PR DESCRIPTION
It's possible to achieve something similar by shrinking the lineHeight, but then you also need to be careful about the size of the icons you pass in. It's less dependent on the consumer to just set the height of the button. I can't think of any situation where we would need two rows in a button, so I don't foresee any problems. 

Note: it's 50px with the base font-size. Because it uses pxToRem, it'll still scale if the user has increased their font size.