### PR TITLE
Button: support variant = tertiary

### DIFF
--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -6,7 +6,7 @@ import { JustifyContentProperty } from 'csstype'
 
 import * as st from './styles'
 
-export type Variant = 'primary' | 'secondary'
+export type Variant = 'primary' | 'secondary' | 'tertiary'
 
 interface Props {
   children: React.ReactNode

--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -21,6 +21,10 @@ storiesOf('Elements|Button', module).add('primary variant', () => (
 
     <Spacer />
 
+    <Button variant="tertiary">{text('Tertiary label', 'Tertiary')}</Button>
+
+    <Spacer />
+
     <Button disabled variant="secondary">
       {text('Disabled Label', 'Loading...')}
     </Button>

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -21,6 +21,11 @@ const secondary = (disabled: boolean) =>
     ':hover, :focus': disabled ? {} : secondaryFocus
   })
 
+const tertiary = css({
+  color: colors.cerulean,
+  textDecoration: 'underline'
+})
+
 const disabledStyle = css({
   cursor: 'not-allowed'
 })
@@ -57,6 +62,7 @@ export const button = (
     },
     variant === 'primary' && primary,
     variant === 'secondary' && secondary(disabled),
+    variant === 'tertiary' && tertiary,
     disabled && disabledStyle
   ])
 


### PR DESCRIPTION
Adds support for `tertiary` style of button, used for the 'Plan info >' button on the results page.

Screenshot:

![image](https://user-images.githubusercontent.com/951457/63928944-76236d00-ca48-11e9-8a00-6afb9b9a5ea5.png)

From Zeplin:

![image](https://user-images.githubusercontent.com/951457/63928950-79b6f400-ca48-11e9-8797-b7398f4bf900.png)
