### PR TITLE
Button: add 'outline' variant

### DIFF
--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -6,7 +6,7 @@ import { JustifyContentProperty } from 'csstype'
 
 import * as st from './styles'
 
-export type Variant = 'primary' | 'secondary'
+export type Variant = 'primary' | 'secondary' | 'outline'
 
 interface Props {
   children: React.ReactNode

--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -21,6 +21,14 @@ storiesOf('Elements|Button', module).add('primary variant', () => (
 
     <Spacer />
 
+    <Button variant="outline">{text('Outline Label', 'Outline')}</Button>
+
+    <Spacer />
+
+    <Button disabled variant="outline">{text('Disabled Outline Label', 'Outline')}</Button>
+
+    <Spacer />
+
     <Button disabled variant="secondary">
       {text('Disabled Label', 'Loading...')}
     </Button>

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -21,6 +21,15 @@ const secondary = (disabled: boolean) =>
     ':hover, :focus': disabled ? {} : secondaryFocus
   })
 
+const outlineFocus = css({
+  borderColor: colors.azure
+})
+
+const outline = (disabled: boolean) => css({
+  borderColor: colors.lightGreyBlue,
+  ':hover, :focus': disabled ? {} : outlineFocus
+})
+
 const disabledStyle = css({
   cursor: 'not-allowed'
 })
@@ -47,16 +56,17 @@ export const button = (
       letterSpacing: 'normal',
 
       /* layout */
-      border: 0,
+      border: '1px solid transparent',
       borderRadius: '4px',
       display: 'flex',
       height: pxToRem(50),
       justifyContent,
-      padding: pxToRem(16),
+      padding: pxToRem(15),
       width: '100%'
     },
     variant === 'primary' && primary,
     variant === 'secondary' && secondary(disabled),
+    variant === 'outline' && outline(disabled),
     disabled && disabledStyle
   ])
 

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -26,6 +26,7 @@ const outlineFocus = css({
 })
 
 const outline = (disabled: boolean) => css({
+  backgroundColor: colors.white,
   borderColor: colors.lightGreyBlue,
   ':hover, :focus': disabled ? {} : outlineFocus
 })

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/core'
-import { colors, pxToRem, typography } from '@uswitch/trustyle.styles'
+import { colors, helpers, pxToRem, typography } from '@uswitch/trustyle.styles'
 import { JustifyContentProperty } from 'csstype'
 
 import { Variant } from '.'
@@ -22,7 +22,8 @@ const secondary = (disabled: boolean) =>
   })
 
 const outlineFocus = css({
-  borderColor: colors.azure
+  borderColor: colors.azure,
+  boxShadow: helpers.insetBorder(colors.azure)
 })
 
 const outline = (disabled: boolean) => css({


### PR DESCRIPTION
Adds a third style of button for the 'Edit Info' and 'Filter' buttons on the results page.

![image](https://user-images.githubusercontent.com/951457/64107020-628e4400-cd71-11e9-9beb-58576d0bdfdd.png)

![image](https://user-images.githubusercontent.com/951457/64107052-7df94f00-cd71-11e9-98f1-38243536a622.png)
