### PR TITLE
Input: useScrollIntoView effect to ensure keyboard does not hide input on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3213,6 +3213,21 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.138",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
+      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
+      "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@storybook/addon-viewport": "^5.1.9",
     "@storybook/addons": "^5.1.9",
     "@storybook/react": "^5.1.9",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/react": "^16.8.21",
     "@types/react-dom": "^16.8.4",
     "@types/react-input-mask": "^2.0.3",

--- a/src/elements/input/package-lock.json
+++ b/src/elements/input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.input",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -274,6 +274,11 @@
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"loose-envify": {
 			"version": "1.4.0",

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -15,6 +15,7 @@
     "@emotion/core": "^10.0.10",
     "@uswitch/trustyle.frozen-input": "^0.3.4",
     "@uswitch/trustyle.styles": "^0.3.4",
+    "lodash.debounce": "^4.0.8",
     "react-input-mask": "^2.0.4"
   }
 }

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -5,6 +5,7 @@ import { jsx } from '@emotion/core'
 import { FrozenInput } from '@uswitch/trustyle.frozen-input'
 import { inputs } from '@uswitch/trustyle.styles'
 import * as ReactInputMask from 'react-input-mask'
+import debounce from 'lodash.debounce'
 
 import * as st from './styles'
 
@@ -38,7 +39,7 @@ const useScrollIntoView = (
   const [isResizing, setIsResizing] = useState(false)
 
   useEffect(() => {
-    const handleResize = () => setIsResizing(true)
+    const handleResize = debounce(() => setIsResizing(true), 50)
     window.addEventListener('resize', handleResize)
 
     return () => {


### PR DESCRIPTION
On Android, there is a behaviour where the keyboard may sometimes open ON TOP of a focused input. This effect fixes the problem by calling scrollIntoView on a window resize event - this event is fired when the keyboard opens and pushes up the viewport.