### PR TITLE
TS: turn on esModuleInterop flag so that Input can be imported into energy-journey

### DIFF
--- a/src/elements/side-drawer/src/index.tsx
+++ b/src/elements/side-drawer/src/index.tsx
@@ -3,7 +3,7 @@
 import { createRef, Fragment, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Transition, TransitionGroup } from 'react-transition-group'
-import * as FocusTrap from 'focus-trap-react'
+import FocusTrap from 'focus-trap-react'
 import { css, jsx } from '@emotion/core'
 import { Icon } from '@uswitch/trustyle.icon'
 import { colors } from '@uswitch/trustyle.styles'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es5",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
The Input component cannot currently be imported into `energy-journey` because of the way it imports `lodash.throttle`. This PR enables the `esModuleInterop` flag, thanks @peterhorne . 