### PR TITLE
Focus state

### DIFF
--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -50,5 +50,7 @@ storiesOf('Elements|Button', module).add('primary variant', () => (
         size={20}
       />
     </Button>
+
+    <Spacer />
   </div>
 ))

--- a/src/elements/button/src/styles.ts
+++ b/src/elements/button/src/styles.ts
@@ -4,13 +4,17 @@ import { JustifyContentProperty } from 'csstype'
 
 import { Variant } from '.'
 
+const focusBorder = {
+  borderColor: colors.azure,
+  boxShadow: helpers.insetBorder(colors.azure),
+  outline: 0,
+  '&::-moz-focus-inner': { border: 0 }
+}
+
 const primary = css({
   backgroundColor: colors.copper,
-  color: colors.white
-})
-
-const secondaryFocus = css({
-  backgroundColor: colors.robinsEggBlue
+  color: colors.white,
+  ':focus': focusBorder
 })
 
 const secondary = (disabled: boolean) =>
@@ -18,19 +22,20 @@ const secondary = (disabled: boolean) =>
     backgroundColor: colors.lightSkyBlue,
     color: colors.cobaltBlue,
     textAlign: 'left',
-    ':hover, :focus': disabled ? {} : secondaryFocus
+    ':hover': disabled
+      ? {}
+      : {
+          backgroundColor: colors.robinsEggBlue
+        },
+    ':focus': focusBorder
   })
 
-const outlineFocus = css({
-  borderColor: colors.azure,
-  boxShadow: helpers.insetBorder(colors.azure)
-})
-
-const outline = (disabled: boolean) => css({
-  backgroundColor: colors.white,
-  borderColor: colors.lightGreyBlue,
-  ':hover, :focus': disabled ? {} : outlineFocus
-})
+const outline = (disabled: boolean) =>
+  css({
+    backgroundColor: colors.white,
+    borderColor: colors.lightGreyBlue,
+    ':hover, :focus': disabled ? {} : focusBorder
+  })
 
 const disabledStyle = css({
   cursor: 'not-allowed'
@@ -55,7 +60,6 @@ export const button = (
       fontFamily: typography.defaultFontFamily,
       fontSize: pxToRem(16),
       fontWeight: 600,
-      letterSpacing: 'normal',
 
       /* layout */
       border: '1px solid transparent',

--- a/src/elements/drop-down/src/stories.tsx
+++ b/src/elements/drop-down/src/stories.tsx
@@ -1,5 +1,8 @@
-import * as React from 'react'
+/** @jsx jsx */
+import { useState } from 'react'
+import { css, jsx } from '@emotion/core'
 import { storiesOf } from '@storybook/react'
+import { number } from '@storybook/addon-knobs'
 
 import { DropDown } from './'
 
@@ -9,12 +12,34 @@ const options = [
   { value: 'yellow', text: 'Yellow' }
 ]
 
+const Spacer = () => <div css={css({ minHeight: 20 })} />
+
+const ColourSelect = () => {
+  const [val, setVal] = useState('red')
+  return (
+    <DropDown
+      name="example"
+      onBlur={() => {}}
+      onChange={setVal}
+      options={options}
+      value={val}
+    />
+  )
+}
+
 storiesOf('Elements|DropDown', module).add('example', () => (
-  <DropDown
-    name="example"
-    onBlur={() => {}}
-    onChange={() => {}}
-    options={options}
-    value={null}
-  />
+  <div css={css({ padding: number('Padding', 10) })}>
+    <ColourSelect />
+
+    <Spacer />
+
+    <DropDown
+      hasError
+      name="withError"
+      onBlur={() => {}}
+      onChange={() => {}}
+      options={[{ value: '', text: 'Incorrect' }]}
+      value={''}
+    />
+  </div>
 ))

--- a/src/elements/drop-down/src/styles.ts
+++ b/src/elements/drop-down/src/styles.ts
@@ -18,14 +18,19 @@ export const root = (hasError: boolean, hasFocus: boolean) =>
   css([
     typography.input,
     {
-      width: '100%',
-      padding: pxToRem(16, spacers.orange, 16, 16),
-      borderRadius: '3px',
-      border: `solid 1px ${colors.lightGreyBlue}`,
+      appearance: 'none',
       backgroundColor: colors.white,
-      verticalAlign: 'middle',
+      border: `solid 1px ${colors.lightGreyBlue}`,
+      borderRadius: '3px',
       boxSizing: 'border-box',
-      appearance: 'none'
+      color: 'transparent',
+      padding: pxToRem(16, spacers.orange, 16, 16),
+      verticalAlign: 'middle',
+      width: '100%',
+      textShadow: `0 0 0 ${colors.black}`,
+      '& option': {
+        color: colors.black
+      }
     },
     inputs.emphasis(hasError, hasFocus)
   ])

--- a/src/elements/drop-down/src/styles.ts
+++ b/src/elements/drop-down/src/styles.ts
@@ -23,13 +23,14 @@ export const root = (hasError: boolean, hasFocus: boolean) =>
       border: `solid 1px ${colors.lightGreyBlue}`,
       borderRadius: '3px',
       boxSizing: 'border-box',
-      color: 'transparent',
+      color: 'transparent', // rm FF default focus
+      outline: 'none', // rm Chrome mobile default focus
       padding: pxToRem(16, spacers.orange, 16, 16),
       verticalAlign: 'middle',
       width: '100%',
-      textShadow: `0 0 0 ${colors.black}`,
+      textShadow: `0 0 0 ${colors.black}`, // FF compensate for color
       '& option': {
-        color: colors.black
+        color: colors.black // Chrome compensate for color
       }
     },
     inputs.emphasis(hasError, hasFocus)

--- a/src/elements/frozen-input/src/styles.ts
+++ b/src/elements/frozen-input/src/styles.ts
@@ -30,7 +30,11 @@ export const edit = css({
   cursor: 'pointer',
   height: pxToRem(28),
   padding: pxToRem(0, spacers.teal),
-  width: editIconWidth
+  width: editIconWidth,
+  ':focus': {
+    outline: `2px solid ${colors.azure}`,
+  },
+  '&::-moz-focus-inner': { border: 0 }
 })
 
 export const hidden = css({

--- a/src/styles/src/inputs.ts
+++ b/src/styles/src/inputs.ts
@@ -52,6 +52,9 @@ export const keyboardInput = css([
     height: pxToRem(
       inputLineHeight * inputFontSize + inputPadding + inputPadding
     ),
-    width: '100%'
+    width: '100%',
+    '&:focus': {
+      outline: 'none'
+    }
   }
 ])

--- a/src/styles/src/inputs.ts
+++ b/src/styles/src/inputs.ts
@@ -52,9 +52,6 @@ export const keyboardInput = css([
     height: pxToRem(
       inputLineHeight * inputFontSize + inputPadding + inputPadding
     ),
-    width: '100%',
-    '&:focus': {
-      outline: 'none'
-    }
+    width: '100%'
   }
 ])


### PR DESCRIPTION
1. Adds a focus border to buttons
2. Removes the default FF dashed-border around the buttons' text
3. Removes the FF dashed-border around selects' text
4. Adds a focus border around the frozen-input edit button
5. Removes the chrome-mobile orange focus border around drop-downs

I've tested it on most of the major browsers, but you can play with it on https://uswitch.github.io/trustyle/?path=/story/styles-colours--swatches. There is an external Safari bug (default behaviour) where it ignores buttons when tabbing. 