### PR TITLE
Drawer trigger

### DIFF
--- a/src/elements/side-drawer/src/index.tsx
+++ b/src/elements/side-drawer/src/index.tsx
@@ -47,7 +47,8 @@ export const Drawer: React.FC<ModalProps> = ({
 
   const [isOpen, setIsOpen] = useState(false)
 
-  const openModal = () => {
+  const openModal = (event: React.MouseEvent<HTMLHtmlElement>) => {
+    event.preventDefault()
     setIsOpen(true)
     if (disableScrolling) lockBackground()
   }

--- a/src/elements/side-drawer/src/index.tsx
+++ b/src/elements/side-drawer/src/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { createRef, Fragment, useEffect, useState } from 'react'
+import { cloneElement, createRef, Fragment, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Transition, TransitionGroup } from 'react-transition-group'
 import FocusTrap from 'focus-trap-react'
@@ -15,8 +15,7 @@ interface ModalProps {
   children: React.ReactNode
   disableScrolling: boolean
   side: 'left' | 'right'
-  triggerElement: React.ReactNode
-  triggerProps?: object
+  triggerElement: React.ReactElement
 }
 
 const lockBackground = () => {
@@ -40,8 +39,7 @@ export const Drawer: React.FC<ModalProps> = ({
   children,
   disableScrolling,
   side,
-  triggerElement,
-  triggerProps
+  triggerElement
 }) => {
   const triggerRef: React.RefObject<HTMLButtonElement> = createRef()
   const backgroundRef: React.RefObject<HTMLElement> = createRef()
@@ -74,15 +72,7 @@ export const Drawer: React.FC<ModalProps> = ({
 
   return (
     <Fragment>
-      <button
-        type="button"
-        css={st.trigger}
-        onClick={openModal}
-        ref={triggerRef}
-        {...triggerProps}
-      >
-        {triggerElement}
-      </button>
+      {cloneElement(triggerElement, { onClick: openModal, ref: triggerRef })}
       <TransitionGroup component={null}>
         <Transition timeout={st.transitionDuration} key={isOpen.toString()}>
           {transitionState =>

--- a/src/elements/side-drawer/src/stories.tsx
+++ b/src/elements/side-drawer/src/stories.tsx
@@ -23,12 +23,18 @@ const Padding = ({ children }: { children: React.ReactNode }) => (
   <div css={css({ padding: 20 })}>{children}</div>
 )
 
+const triggerButton = css({
+  appearance: 'none',
+  backgroundColor: 'transparent',
+  border: 'none',
+  color: colors.cerulean,
+  cursor: 'pointer',
+  textAlign: 'left',
+  textDecoration: 'underline'
+})
+
 const ExampleDrawer = () => {
-  const trigger = (
-    <span style={{ color: colors.cerulean, textDecoration: 'underline' }}>
-      Click to learn more
-    </span>
-  )
+  const trigger = <button css={triggerButton}>Click to learn more</button>
   return (
     <Drawer
       ariaLabel="An example modal element"
@@ -42,14 +48,6 @@ const ExampleDrawer = () => {
           This space will be used to give help to users. We’ll try to explain
           solutions to most common problems users encounter when trying to
           complete a comparison.
-        </p>
-      </Padding>
-      <hr />
-      <Padding>
-        <h2>Still stuck?</h2>
-        <p>Call uSwitch free on</p>
-        <p>
-          <a href="tel:0800 1234 123">0800 1234 123</a>
         </p>
       </Padding>
     </Drawer>

--- a/src/elements/side-drawer/src/styles.ts
+++ b/src/elements/side-drawer/src/styles.ts
@@ -7,14 +7,6 @@ import { colors, pxToRem, spacers } from '@uswitch/trustyle.styles'
 
 export const transitionDuration = 400
 
-export const trigger = css({
-  appearance: 'none',
-  backgroundColor: 'transparent',
-  border: 'none',
-  cursor: 'pointer',
-  textAlign: 'left'
-})
-
 export const background = css({
   left: 0,
   height: '100%',


### PR DESCRIPTION
## Change
Rather than wrap the triggerElement in a button, the api should allow the consumer to supply any element. The documentation should describe how to use it semantically, but doesn't need to enforce that. 

I'm prevent the default event handler on that click, which means that you can use an `<a>` component. In this scenario, clicking the link will open the modal,  but the user will be able to right-click and open the href in a new window. 