### PR TITLE
Make button props transparent

### DIFF
--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -8,11 +8,8 @@ import * as st from './styles'
 
 export type Variant = 'primary' | 'secondary' | 'outline'
 
-interface Props {
-  children: React.ReactNode
-  disabled?: boolean
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   justifyContent?: JustifyContentProperty
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   variant: Variant
 }
 
@@ -21,13 +18,15 @@ export const Button: React.FC<Props> = ({
   disabled = false,
   justifyContent,
   variant,
-  onClick
+  onClick,
+  ...props
 }) => (
   <button
     css={css(st.button(variant, disabled, justifyContent))}
     disabled={disabled}
     type={onClick ? 'button' : 'submit'}
     onClick={onClick}
+    {...props}
   >
     {children}
   </button>

--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -54,5 +54,11 @@ storiesOf('Elements|Button', module).add('primary variant', () => (
     </Button>
 
     <Spacer />
+
+    <Button data-stuff="button-stuff" variant="outline">
+      With extra attributes
+    </Button>
+
+    <Spacer />
   </div>
 ))

--- a/src/elements/icon/src/index.tsx
+++ b/src/elements/icon/src/index.tsx
@@ -11,7 +11,14 @@ import { Filters } from './filters'
 import { Phone } from './phone'
 import { Plus } from './plus'
 
-export type Glyph = 'arrow' | 'caret' | 'close' | 'edit' | 'filters' | 'phone' | 'plus'
+export type Glyph =
+  | 'arrow'
+  | 'caret'
+  | 'close'
+  | 'edit'
+  | 'filters'
+  | 'phone'
+  | 'plus'
 export type Direction = 'up' | 'down' | 'left' | 'right'
 
 interface Props {

--- a/src/elements/icon/src/plus.tsx
+++ b/src/elements/icon/src/plus.tsx
@@ -12,8 +12,14 @@ interface Props {
 
 export const Plus: React.FC<Props> = ({ color, size }) => (
   <svg css={css([st.icon, { fill: color }, st.size(size)])} viewBox="0 0 17 17">
-    <g fill="none" fillRule="evenodd" stroke={color} strokeLinecap="square" strokeWidth="1.71">
-        <path d="M8.522 1.021v15.04M16.024 8.522H.984"/>
+    <g
+      fill="none"
+      fillRule="evenodd"
+      stroke={color}
+      strokeLinecap="square"
+      strokeWidth="1.71"
+    >
+      <path d="M8.522 1.021v15.04M16.024 8.522H.984" />
     </g>
   </svg>
 )

--- a/src/elements/icon/src/stories.tsx
+++ b/src/elements/icon/src/stories.tsx
@@ -13,7 +13,7 @@ const glyphChoices: Glyph[] = [
   'edit',
   'filters',
   'phone',
-  'plus',
+  'plus'
 ]
 
 const directionChoices: Direction[] = ['up', 'down', 'right', 'left']


### PR DESCRIPTION
Allows any valid button attributes as props to the button element, which will be applied directly to the button, with the exception of the type prop which works as it did before.

The goal is to have transparent props for any element which is basically just a styled html element. 