### PR TITLE
added default value to dropdown onblur

### DIFF
--- a/src/elements/drop-down/src/index.tsx
+++ b/src/elements/drop-down/src/index.tsx
@@ -42,7 +42,7 @@ export const DropDown: React.FC<Props> = ({
   dataProps = {},
   freezable,
   hasError = false,
-  onBlur,
+  onBlur = () => {},
   onChange,
   onFocus = () => {},
   name,


### PR DESCRIPTION
we were seeing a console error if we didn't pass a value to onBlur on the dropdown component, looks like because it didn't have a default set up