### PR TITLE
Focus on the input after it is unfrozen

### DIFF
--- a/src/elements/drop-down/src/index.tsx
+++ b/src/elements/drop-down/src/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { forwardRef, useState } from 'react'
+import { forwardRef, useState, useRef, useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { colors, inputs } from '@uswitch/trustyle.styles'
 import { Icon } from '@uswitch/trustyle.icon'
@@ -39,6 +39,21 @@ export interface Option {
   text: string
 }
 
+const useEnsureRef = (otherRef: React.Ref<HTMLSelectElement>) => {
+  const targetRef: React.MutableRefObject<HTMLSelectElement | null> = useRef<HTMLSelectElement | null>(null)
+
+  useEffect(() => {
+      if (!otherRef) return
+
+      if (typeof otherRef === 'function') {
+        otherRef(targetRef.current)
+      } else {
+        targetRef.current = otherRef.current
+      }
+  },[targetRef, otherRef])
+  return targetRef
+}
+
 export const DropDown = forwardRef(
   (
     {
@@ -59,11 +74,17 @@ export const DropDown = forwardRef(
     const [hasFocus, setHasFocus] = useState(false)
     const option = options.find(_ => _.value === value)
     const frozenText = option && option.text
+    const combinedRef = useEnsureRef(ref)
+
     return (
-      <FrozenInput text={frozenText} freezable={freezable}>
+      <FrozenInput
+        text={frozenText}
+        freezable={freezable}
+        inputRef={combinedRef}
+      >
         <div css={container}>
           <select
-            ref={ref}
+            ref={combinedRef}
             onFocus={() => {
               setHasFocus(true)
               onFocus()

--- a/src/elements/drop-down/src/stories.tsx
+++ b/src/elements/drop-down/src/stories.tsx
@@ -27,9 +27,27 @@ const ColourSelect = () => {
   )
 }
 
+const FrozenColourSelect = () => {
+  const [val, setVal] = useState('red')
+  return (
+    <DropDown
+      freezable
+      name="frozen-example"
+      onBlur={() => {}}
+      onChange={setVal}
+      options={options}
+      value={val}
+    />
+  )
+}
+
 storiesOf('Elements|DropDown', module).add('example', () => (
   <div css={css({ padding: number('Padding', 10) })}>
     <ColourSelect />
+
+    <Spacer />
+
+    <FrozenColourSelect />
 
     <Spacer />
 

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { Fragment, useState } from 'react'
+import { Fragment, useState, useEffect, createRef } from 'react'
 import { jsx } from '@emotion/core'
 import { Icon } from '@uswitch/trustyle.icon'
 import { colors } from '@uswitch/trustyle.styles'
@@ -10,10 +10,17 @@ import * as st from './styles'
 interface Props {
   text?: string
   freezable?: boolean
+  inputRef?: React.RefObject<HTMLInputElement>
 }
 
-export const FrozenInput: React.FC<Props> = ({ text, freezable, children }) => {
+export const FrozenInput: React.FC<Props> = ({ text, freezable, inputRef, children }) => {
   const [frozen, setFrozen] = useState(freezable && !!text)
+
+  useEffect(() => {
+    if (freezable && !frozen && inputRef && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [frozen])
 
   if (!frozen) {
     return <Fragment>{children}</Fragment>

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -17,7 +17,7 @@ export const FrozenInput: React.FC<Props> = ({ text, freezable, inputRef, childr
   const [frozen, setFrozen] = useState(freezable && !!text)
 
   useEffect(() => {
-    if (freezable && !frozen && inputRef && inputRef.current) {
+    if (freezable && !frozen && !!text && inputRef && inputRef.current) {
       inputRef.current.focus()
     }
   }, [frozen])

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { Fragment, useState, useEffect, createRef } from 'react'
+import { Fragment, useState, useEffect } from 'react'
 import { jsx } from '@emotion/core'
 import { Icon } from '@uswitch/trustyle.icon'
 import { colors } from '@uswitch/trustyle.styles'
@@ -10,7 +10,7 @@ import * as st from './styles'
 interface Props {
   text?: string
   freezable?: boolean
-  inputRef?: React.RefObject<HTMLInputElement>
+  inputRef?: React.RefObject<HTMLElement | HTMLElement>
 }
 
 export const FrozenInput: React.FC<Props> = ({ text, freezable, inputRef, children }) => {

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -102,6 +102,7 @@ export const Input: React.FC<Props> = ({
     <FrozenInput
       text={inputProps.value || inputProps.defaultValue || ''}
       freezable={freezable}
+      inputRef={inputRef}
     >
       <div css={[inputs.keyboardInputContainer(hasError, hasFocus), st[width]]}>
         {prefix && <span css={st.prefix(hasError, hasFocus)}>{prefix}</span>}


### PR DESCRIPTION
When the user clicks on the edit button of a frozen input it should give focus to the element that is unfrozen. This will only happen if a ref to the input is passed and the element is freezable in the first place.

This is currently used by Input and Dropdown components.