### PR TITLE
Add color style to DropDown for Edge

### DIFF
--- a/src/elements/drop-down/src/styles.ts
+++ b/src/elements/drop-down/src/styles.ts
@@ -23,14 +23,14 @@ export const root = (hasError: boolean, hasFocus: boolean) =>
       border: `solid 1px ${colors.lightGreyBlue}`,
       borderRadius: '3px',
       boxSizing: 'border-box',
-      color: 'transparent', // rm FF default focus
+      color: colors.black,
       outline: 'none', // rm Chrome mobile default focus
       padding: pxToRem(16, spacers.orange, 16, 16),
       verticalAlign: 'middle',
       width: '100%',
-      textShadow: `0 0 0 ${colors.black}`, // FF compensate for color
-      '& option': {
-        color: colors.black // Chrome compensate for color
+      '&:-moz-focusring': {
+        color: 'transparent',
+        textShadow: `0 0 0 ${colors.black}`
       }
     },
     inputs.emphasis(hasError, hasFocus)


### PR DESCRIPTION
color was previously set to transparent so that the 'focus-ring' in Firefox does not show up around the text of a Dropdown. But this causes Edge to display the text color as transparent. This PR defines a color for the Dropdown text and introduces a specific override for ::-moz-focusring