### PR TITLE
Dropdown: Ensure focus/scrollIntoView behaviour is available for dropdowns

### DIFF
--- a/src/elements/checkbox-input/package-lock.json
+++ b/src/elements/checkbox-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.checkbox-input",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -135,9 +135,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.grid": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-1.0.5.tgz",
-			"integrity": "sha512-65JfLGBDhE6+uqqzJqivRZumurF6pFTHt6ajixUUfoU16kSUeljoeTNhMR45YUzl73m3EfDjDxVn4NSPVBiJmQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-1.0.6.tgz",
+			"integrity": "sha512-h/qnpwHM3Drg3Wmzh+K+dkKhBdYD30eOJKOEa+3xD6liFhRStQNm2DwiMOKcnunbzPT8n94J6pgDbD2icVuprg==",
 			"requires": {
 				"@emotion/core": "^10.0.22",
 				"@uswitch/trustyle.styles": "^0.4.11",

--- a/src/elements/drop-down/package-lock.json
+++ b/src/elements/drop-down/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/elements/fieldset/package-lock.json
+++ b/src/elements/fieldset/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.fieldset",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -135,9 +135,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.grid": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-1.0.5.tgz",
-			"integrity": "sha512-65JfLGBDhE6+uqqzJqivRZumurF6pFTHt6ajixUUfoU16kSUeljoeTNhMR45YUzl73m3EfDjDxVn4NSPVBiJmQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-1.0.6.tgz",
+			"integrity": "sha512-h/qnpwHM3Drg3Wmzh+K+dkKhBdYD30eOJKOEa+3xD6liFhRStQNm2DwiMOKcnunbzPT8n94J6pgDbD2icVuprg==",
 			"dev": true,
 			"requires": {
 				"@emotion/core": "^10.0.22",

--- a/src/elements/tile-input/package-lock.json
+++ b/src/elements/tile-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.tile-input",
-	"version": "1.0.34",
+	"version": "1.0.35",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -135,9 +135,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.grid": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-1.0.5.tgz",
-			"integrity": "sha512-65JfLGBDhE6+uqqzJqivRZumurF6pFTHt6ajixUUfoU16kSUeljoeTNhMR45YUzl73m3EfDjDxVn4NSPVBiJmQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-1.0.6.tgz",
+			"integrity": "sha512-h/qnpwHM3Drg3Wmzh+K+dkKhBdYD30eOJKOEa+3xD6liFhRStQNm2DwiMOKcnunbzPT8n94J6pgDbD2icVuprg==",
 			"dev": true,
 			"requires": {
 				"@emotion/core": "^10.0.22",

--- a/src/layout/grid/package-lock.json
+++ b/src/layout/grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.grid",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
The ref is not currently available for the select on the initial render, so focus will fail on the featured input. Since the element might not be displayed, we use `useImperativeHandle` to control its behaviour.