### PR TITLE
fix: make two shortcuts for getting List and ListItem as default exports

### DIFF
--- a/src/elements/list/list-item.js
+++ b/src/elements/list/list-item.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib').ListItem;

--- a/src/elements/list/list.js
+++ b/src/elements/list/list.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib').List;


### PR DESCRIPTION
You can only use default exports with loadable(), apparently