### PR TITLE
Tweak Button for uSwitch

### DIFF
--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -3,14 +3,19 @@
 import * as React from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 
+export type Variant = 'primary' | 'secondary' | 'continue'
+type IconPosition = 'left' | 'center' | 'right' | null
+
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant: string
+  variant: Variant
+  iconPosition?: IconPosition
 }
 
 export const Button: React.FC<Props> = ({
   children,
   disabled = false,
   variant,
+  iconPosition = null,
   onClick,
   ...props
 }) => {
@@ -26,7 +31,19 @@ export const Button: React.FC<Props> = ({
         fontSize: 'base',
         paddingX: 'sm',
         paddingY: 'base',
-        variant: `buttons.${variant}`
+        variant: `buttons.${variant}`,
+
+        ...(iconPosition
+          ? {
+              display: 'flex',
+              justifyContent:
+                iconPosition === 'left'
+                  ? 'align-left'
+                  : iconPosition === 'right'
+                  ? 'space-between'
+                  : 'center'
+            }
+          : {})
       }}
       disabled={disabled}
       type={onClick ? 'button' : 'submit'}

--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -8,7 +8,7 @@ import { action } from '@storybook/addon-actions'
 import theme from '../../../utils/theme-selector'
 import { Icon } from '../../icon/src'
 
-import { Button } from './'
+import { Button, Variant } from './'
 
 const Spacer = () => <div css={css({ minHeight: 20 })} />
 
@@ -18,7 +18,7 @@ storiesOf('Elements|Button', module).add('primary variant', () => (
       Object.keys(theme().buttons).map((key, index) => (
         <React.Fragment key={index}>
           <Button
-            variant={key}
+            variant={key as Variant}
             disabled={boolean('Disabled', false)}
             onClick={action(`${key}-click`)}
           >
@@ -31,6 +31,37 @@ storiesOf('Elements|Button', module).add('primary variant', () => (
                 size={20}
               />
             )}
+          </Button>
+          <Spacer />
+          <Button
+            variant={key as Variant}
+            disabled={boolean('Disabled', false)}
+            onClick={action(`${key}-click`)}
+            iconPosition="right"
+          >
+            {text(`${key} label`, `${key} button`)}
+
+            <Icon
+              color={theme().colors.primary}
+              direction="right"
+              glyph="caret"
+              size={20}
+            />
+          </Button>
+          <Spacer />
+          <Button
+            variant={key as Variant}
+            disabled={boolean('Disabled', false)}
+            onClick={action(`${key}-click`)}
+            iconPosition="left"
+          >
+            <Icon
+              color={theme().colors.primary}
+              direction="right"
+              glyph="caret"
+              size={20}
+            />
+            {text(`${key} label`, `${key} button`)}
           </Button>
           <Spacer />
         </React.Fragment>

--- a/src/elements/list/package-lock.json
+++ b/src/elements/list/package-lock.json
@@ -1,14 +1,14 @@
 {
-	"name": "@uswitch/trustyle.list",
-	"version": "0.1.1",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"typescript": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-			"integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
-			"dev": true
-		}
-	}
+  "name": "@uswitch/trustyle.list",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "dev": true
+    }
+  }
 }

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1,7 +1,7 @@
 {
   "name": "uSwitch",
 
-  "breakpoints": [ "768px", "990px" ],
+  "breakpoints": ["768px", "990px"],
 
   "zIndices": {
     "min": 0,
@@ -9,7 +9,8 @@
   },
 
   "shadows": {
-    "box": "2px 2px 25px #0004"
+    "box": "2px 2px 25px #0004",
+    "linkInset": "inset 0 0 0 1px #008fe9"
   },
 
   "fonts": {
@@ -123,6 +124,7 @@
     "light-3": "#e6e6e6",
     "hero": "#99e2ff",
     "light-blue": "#caefff",
+    "light-grey-blue": "#b0b8bf",
     "anakiwa": "#99e2ff"
   },
 
@@ -135,7 +137,6 @@
 
   "----------------------------- Variants": "-----------------------------",
   "modules": {
-
     "content-hero-module": {
       "h1": {
         "mb": "sm",
@@ -158,7 +159,6 @@
         "textDecoration": "underline"
       },
 
-
       "content": {
         "display": "flex",
         "alignItems": "flex-end",
@@ -177,11 +177,9 @@
         }
       }
     }
-
   },
 
   "compounds": {
-
     "card": {
       "display": "flex",
       "width": ["100%", "49%", "grid.lg.3"],
@@ -227,7 +225,6 @@
       "my": "sm",
       "mx": 0
     }
-
   },
 
   "container": {
@@ -273,7 +270,6 @@
   },
 
   "card": {
-
     "sm": {
       "image": { "width": "100%", "height": "auto" }
     },
@@ -281,7 +277,6 @@
     "lg": {
       "image": { "width": 278, "height": 230 }
     }
-
   },
 
   "buttons": {
@@ -289,12 +284,13 @@
       "backgroundColor": "primary",
       "color": "light-1",
       "textAlign": "center",
-      "width": [ "100%", "grid.md.3", "grid.lg.2" ],
+      "width": ["100%"],
       "border": "none",
       "fontWeight": "bold",
       "borderRadius": "sm",
       ":hover": {
-        "backgroundColor": "primary-hover"
+        "backgroundColor": "primary-hover",
+        "boxShadow": "inset 0 0 0 1px ${color}"
       },
       ":disabled": {
         "backgroundColor": "primary",
@@ -303,8 +299,8 @@
       }
     },
 
-    "secondary": {
-      "color": "brand",
+    "continue": {
+      "color": "link-2",
       "backgroundColor": "light-blue",
       ":hover": {
         "backgroundColor": "secondary-hover"
@@ -316,54 +312,26 @@
       }
     },
 
-    "outline": {
+    "secondary": {
       "color": "black",
-      "fontWeight": "normal",
       "backgroundColor": "light-1",
-      "border": "1px solid black",
+      "border": "1px solid",
+      "borderColor": "light-grey-blue",
       ":hover": {
         "backgroundColor": "light-1",
-        "borderColor": "link"
+        "borderColor": "link",
+        "boxShadow": "linkInset"
       },
       ":disabled": {
-        "borderColor": "black",
+        "borderColor": "light-grey-blue",
         "opacity": "0.6",
-        "cursor": "not-allowed"
-      }
-    },
-
-    "primary-icon": {
-      "color": "light-1",
-      "border": "none",
-      "borderRadius": "sm",
-      "backgroundColor": "primary",
-      "textAlign": "left",
-      "display": "flex",
-      "justifyContent": "space-between",
-      ":hover": {
-        "backgroundColor": "primary-hover"
-      }
-    },
-
-    "secondary-icon": {
-      "color": "brand",
-      "backgroundColor": "light-blue",
-      "textAlign": "left",
-      "display": "flex",
-      "justifyContent": "space-between",
-      ":hover": {
-        "backgroundColor": "secondary-hover"
-      },
-      ":disabled": {
-        "backgroundColor": "light-blue",
-        "opacity": "0.6",
-        "cursor": "not-allowed"
+        "cursor": "not-allowed",
+        "boxShadow": "none"
       }
     }
   },
 
   "styles": {
-
     "root": {
       "fontFamily": "base",
       "fontSize": "base",
@@ -404,13 +372,12 @@
     },
 
     "a": {
-      "color": "link-2",
-      "stroke": "link-2",
+      "color": "link",
+      "stroke": "link",
       "transition": "all 0.2s ease",
-      ":visited": { "color": "link-2", "stroke": "link-2" },
+      ":visited": { "color": "link", "stroke": "link" },
       ":hover": { "color": "link", "stroke": "link" },
       "> *": { "transition": "all 0.2s ease" }
     }
-
   }
 }


### PR DESCRIPTION
* Add type back to Variant. I feel the theme should not be driving the semantics of the button, and having variant typed as a string makes it a little more difficult to use. Think we should discuss this at some point.
* Add `iconPosition` prop to Button. This supports left/right/center aligned icon button formats. (Essentially replaces justifyContent we had before).
* Update theme for reasonable Button styles.