### PR TITLE
Force color for a:visited links

### DIFF
--- a/src/styles/src/typography.ts
+++ b/src/styles/src/typography.ts
@@ -79,7 +79,10 @@ export const linkText: SerializedStyles = css({
   color: cerulean,
   fontSize: pxToRem(16),
   fontWeight: 600,
-  textDecoration: 'underline'
+  textDecoration: 'underline',
+  '&:visited': {
+    color: cerulean
+  }
 })
 
 export const alertText: SerializedStyles = css({


### PR DESCRIPTION
The latest change to uStyle has introduced unwanted styles for a:visited.