### PR TITLE
Update package-lock.json after lerna publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start": "start-storybook -p 6006",
     "--------------- BUILDING": "----------------------",
     "build-storybook": "build-storybook",
-    "version": "lerna exec \"npm install --ignore-scripts --package-lock-only\" && git add .",
     "--------------- LINTING": "-----------------------",
     "lint:fix": "npm run typescript:check && npm run prettier:fix && npm run eslint:fix",
     "lint:check": "npm run typescript:check && npm run prettier:check && npm run eslint:check",

--- a/publish.sh
+++ b/publish.sh
@@ -12,4 +12,14 @@ publish_branch=publish_$v
 git checkout -b $publish_branch
 git push origin $publish_branch
 
-npx lerna publish
+npx lerna publish --no-push
+
+# Run `npm install` to update the package-lock.json files, copying over the git tags to the
+# new commit.
+tags=$(git tag --points-at HEAD)
+message=$(git log -1 HEAD --pretty=%B)
+npx lerna exec "npm install --ignore-scripts --package-lock-only"
+git commit --all --amend -m "(With package-lock.json changes) ${message}"
+echo "$tags" | xargs -L 1 git tag -d
+echo "$tags" | xargs -L 1 git tag
+git push --follow-tags


### PR DESCRIPTION
Currently, we run npm install after lerna version, but before the packages are published. This means that the integrity and version parts of package-lock.json cannot be updated.

This PR ensures that package-lock.json are updated after lerna publish. It copies over the tags to the newly-created commit.