### PR TITLE
Upgrade typescript and switch to optional chaining operator

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,19 @@
 module.exports = api => {
   api.cache(true)
 
-  const presets = ['@babel/typescript', '@babel/preset-react']
-
   return {
     env: {
       test: {
-        plugins: ['@babel/plugin-transform-modules-commonjs', 'require-context-hook']
+        plugins: [
+          '@babel/plugin-transform-modules-commonjs',
+          'require-context-hook'
+        ]
       },
       development: {
         plugins: ['@babel/plugin-transform-modules-commonjs']
       }
     },
-    presets
+    presets: ['@babel/typescript', '@babel/preset-react'],
+    plugins: ['@babel/plugin-proposal-optional-chaining']
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6496,22 +6496,42 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.17.0.tgz",
-      "integrity": "sha512-tg/OMOtPeXlvk0ES8mZzEZ4gd1ruSE03nsKcK+teJhxYv5CPCXK6Mb/OK6NpB4+CqGTHs4MVeoSZXNFqpT1PyQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.10.2.tgz",
+      "integrity": "sha512-7449RhjE1oLFIy5E/5rT4wG5+KsfPzakJuhvpzXJ3C46lq7xywY0/Rjo9ZBcwrfbk0nRZ5xmUHkk7DZ67tSBKw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.17.0",
-        "eslint-utils": "^1.4.3",
+        "@typescript-eslint/experimental-utils": "1.10.2",
+        "eslint-utils": "^1.3.1",
         "functional-red-black-tree": "^1.0.1",
-        "regexpp": "^3.0.0",
-        "tsutils": "^3.17.1"
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.7.0"
       },
       "dependencies": {
-        "regexpp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+        "@typescript-eslint/experimental-utils": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.10.2.tgz",
+          "integrity": "sha512-Hf5lYcrnTH5Oc67SRrQUA7KuHErMvCf5RlZsyxXPIT6AXa8fKTyfFO6vaEnUmlz48RpbxO4f0fY3QtWkuHZNjg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/typescript-estree": "1.10.2",
+            "eslint-scope": "^4.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.10.2.tgz",
+          "integrity": "sha512-Kutjz0i69qraOsWeI8ETqYJ07tRLvD9URmdrMoF10bG8y8ucLmPtSxROvVejWvlJUGl2et/plnMiKRDW+rhEhw==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         }
       }
@@ -14942,6 +14962,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+      "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
     "lodash.uniq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -642,6 +642,24 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
@@ -730,6 +748,23 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-typescript": {
@@ -6273,9 +6308,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
     "@types/lodash": {
@@ -6461,56 +6496,103 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
-      "integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.17.0.tgz",
+      "integrity": "sha512-tg/OMOtPeXlvk0ES8mZzEZ4gd1ruSE03nsKcK+teJhxYv5CPCXK6Mb/OK6NpB4+CqGTHs4MVeoSZXNFqpT1PyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "1.13.0",
-        "eslint-utils": "^1.3.1",
+        "@typescript-eslint/experimental-utils": "2.17.0",
+        "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
-        "regexpp": "^2.0.1",
-        "tsutils": "^3.7.0"
+        "regexpp": "^3.0.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
+      "integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-scope": "^4.0.0"
+        "@typescript-eslint/typescript-estree": "2.17.0",
+        "eslint-scope": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.17.0.tgz",
+      "integrity": "sha512-k1g3gRQ4fwfJoIfgUpz78AovicSWKFANmvTfkAHP24MgJHjWfZI6ya7tsQZt1sLczvP4G9BE5G5MgADHdmJB/w==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "1.13.0",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "@typescript-eslint/experimental-utils": "2.17.0",
+        "@typescript-eslint/typescript-estree": "2.17.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
+      "integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
       "dev": true,
       "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -14862,12 +14944,6 @@
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -17031,9 +17107,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-error": {
@@ -20242,9 +20318,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
-      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -20309,9 +20385,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "@emotion/core": "^10.0.10",
@@ -44,8 +45,8 @@
     "@types/react-input-mask": "^2.0.3",
     "@types/react-transition-group": "^2.9.2",
     "@types/theme-ui": "^0.2.6",
-    "@typescript-eslint/eslint-plugin": "^1.10.2",
-    "@typescript-eslint/parser": "^1.10.2",
+    "@typescript-eslint/eslint-plugin": "^2.17.0",
+    "@typescript-eslint/parser": "^2.17.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-require-context-hook": "^1.0.0",
@@ -64,11 +65,11 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.9.0",
     "lerna": "^3.16.4",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "react": "^16.8.6",
     "react-imgix": "^8.6.1",
     "react-test-renderer": "^16.8.6",
     "theme-ui": "^0.2.52",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react-input-mask": "^2.0.3",
     "@types/react-transition-group": "^2.9.2",
     "@types/theme-ui": "^0.2.6",
-    "@typescript-eslint/eslint-plugin": "^2.17.0",
+    "@typescript-eslint/eslint-plugin": "^1.10.2",
     "@typescript-eslint/parser": "^2.17.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",

--- a/src/elements/call-out/src/index.tsx
+++ b/src/elements/call-out/src/index.tsx
@@ -12,7 +12,6 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 
 const CallOut: React.FC<Props> = ({ title, text, icon }) => {
   const { theme }: any = useThemeUI()
-  const getTheme = (key: string) => theme.callOut && theme.callOut[key]
 
   const mainText = (
     <React.Fragment>
@@ -21,13 +20,13 @@ const CallOut: React.FC<Props> = ({ title, text, icon }) => {
           sx={{
             marginTop: '-3px',
             marginBottom: 'xxs',
-            ...getTheme('heading')
+            ...theme.callOut?.heading
           }}
         >
           {title}
         </Styled.h3>
       )}
-      <Styled.p sx={{ marginY: 0, ...getTheme('text') }}>{text}</Styled.p>
+      <Styled.p sx={{ marginY: 0, ...theme.callOut?.text }}>{text}</Styled.p>
     </React.Fragment>
   )
 
@@ -37,7 +36,7 @@ const CallOut: React.FC<Props> = ({ title, text, icon }) => {
         borderRadius: 4,
         paddingX: 'sm',
         paddingY: 'sm',
-        ...getTheme('main')
+        ...theme.callOut?.main
       }}
     >
       {icon ? (
@@ -48,7 +47,7 @@ const CallOut: React.FC<Props> = ({ title, text, icon }) => {
                 backgroundColor: 'primary',
                 borderRadius: '50%',
                 padding: '20%',
-                ...getTheme('icon')
+                ...theme.callOut?.icon
               }}
             >
               <Icon color="white" glyph={icon} />

--- a/src/elements/category/src/index.tsx
+++ b/src/elements/category/src/index.tsx
@@ -10,15 +10,13 @@ interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const Category: React.FC<ListProps> = ({ title, text }) => {
   const { theme }: any = useThemeUI()
-  const getTheme = (key: string) =>
-    theme.categoryTitle && theme.categoryTitle[key]
 
   return (
     <div
       sx={{
         paddingX: ['sm', 'md'],
         paddingY: ['md', 'lg'],
-        ...getTheme('main')
+        ...theme.categoryTitle?.main
       }}
     >
       <Styled.h1
@@ -26,13 +24,13 @@ const Category: React.FC<ListProps> = ({ title, text }) => {
         sx={{
           padding: 0,
           margin: 0,
-          ...getTheme('heading')
+          ...theme.categoryTitle?.heading
         }}
       >
         {title}
       </Styled.h1>
       {text && (
-        <Styled.p sx={{ marginBottom: 0, ...getTheme('text') }}>
+        <Styled.p sx={{ marginBottom: 0, ...theme.categoryTitle?.text }}>
           {text}
         </Styled.p>
       )}

--- a/src/elements/cta/src/index.tsx
+++ b/src/elements/cta/src/index.tsx
@@ -13,17 +13,15 @@ interface CTAProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const CTA: React.FC<CTAProps> = ({ title, text, buttonLink, buttonText }) => {
   const { theme }: any = useThemeUI()
-  const getTheme = (key: string) => theme.cta && theme.cta[key]
-  const buttonTheme = getTheme('button')
 
   return (
-    <div sx={getTheme('main')}>
-      <Styled.h3 sx={getTheme('title')}>{title}</Styled.h3>
-      <Styled.p sx={getTheme('text')}>{text}</Styled.p>
+    <div sx={theme.cta?.main}>
+      <Styled.h3 sx={theme.cta?.title}>{title}</Styled.h3>
+      <Styled.p sx={theme.cta?.text}>{text}</Styled.p>
       <ButtonLink
         href={buttonLink}
-        variant={(buttonTheme && buttonTheme.variant) || 'primary'}
-        sx={buttonTheme}
+        variant={theme.cta?.button?.variant || 'primary'}
+        sx={theme.cta?.button}
       >
         {buttonText}
       </ButtonLink>

--- a/src/elements/icon/src/stories.tsx
+++ b/src/elements/icon/src/stories.tsx
@@ -21,14 +21,14 @@ const glyphChoices: Glyph[] = [
 
 const directionChoices: Direction[] = ['up', 'down', 'right', 'left']
 
-storiesOf(
-  'Elements|Icon',
-  module
-).add('With selectable glyph and color', () => (
-  <Icon
-    glyph={select('glyph', glyphChoices, 'arrow')}
-    color={select('color', colors, colors.battleshipGrey)}
-    direction={select('direction', directionChoices, 'up')}
-    size={number('Size', 0)}
-  />
-))
+storiesOf('Elements|Icon', module).add(
+  'With selectable glyph and color',
+  () => (
+    <Icon
+      glyph={select('glyph', glyphChoices, 'arrow')}
+      color={select('color', colors, colors.battleshipGrey)}
+      direction={select('direction', directionChoices, 'up')}
+      size={number('Size', 0)}
+    />
+  )
+)

--- a/src/elements/icon/src/stories.tsx
+++ b/src/elements/icon/src/stories.tsx
@@ -21,14 +21,14 @@ const glyphChoices: Glyph[] = [
 
 const directionChoices: Direction[] = ['up', 'down', 'right', 'left']
 
-storiesOf('Elements|Icon', module).add(
-  'With selectable glyph and color',
-  () => (
-    <Icon
-      glyph={select('glyph', glyphChoices, 'arrow')}
-      color={select('color', colors, colors.battleshipGrey)}
-      direction={select('direction', directionChoices, 'up')}
-      size={number('Size', 0)}
-    />
-  )
-)
+storiesOf(
+  'Elements|Icon',
+  module
+).add('With selectable glyph and color', () => (
+  <Icon
+    glyph={select('glyph', glyphChoices, 'arrow')}
+    color={select('color', colors, colors.battleshipGrey)}
+    direction={select('direction', directionChoices, 'up')}
+    size={number('Size', 0)}
+  />
+))

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -91,14 +91,13 @@ const Pagination: React.FC<Props> = ({
   numberToLink
 }) => {
   const { theme }: any = useThemeUI()
-  const getTheme = (key: string) => theme.pagination && theme.pagination[key]
 
   const numbers = getNumbers(currentPage, totalPages)
 
   const liStyling = {
     display: 'inline-block',
     padding: 'xs',
-    ...getTheme('li')
+    ...theme.pagination?.li
   }
 
   const anchorStyling = {
@@ -113,12 +112,12 @@ const Pagination: React.FC<Props> = ({
         listStyleType: 'none',
         marginLeft: 0,
         paddingLeft: 0,
-        ...getTheme('main')
+        ...theme.pagination?.main
       }}
     >
       <li
         sx={{
-          ...(currentPage === 1 && getTheme('arrowDisabled')),
+          ...(currentPage === 1 && theme.pagination?.arrowDisabled),
           ...liStyling
         }}
       >
@@ -138,9 +137,9 @@ const Pagination: React.FC<Props> = ({
         <li
           key={i}
           sx={{
-            ...getTheme(
-              number === currentPage ? 'currentPage' : 'nonCurrentPage'
-            ),
+            ...(number === currentPage
+              ? theme.pagination?.currentPage
+              : theme.pagination?.nonCurrentPage),
             ...liStyling
           }}
         >
@@ -159,7 +158,7 @@ const Pagination: React.FC<Props> = ({
       ))}
       <li
         sx={{
-          ...(currentPage === totalPages && getTheme('arrowDisabled')),
+          ...(currentPage === totalPages && theme.pagination?.arrowDisabled),
           ...liStyling
         }}
       >


### PR DESCRIPTION
Shouldn't have had to add the optional chaining plugin, but for some reason even though @babel/plugin-typescript is supposed to support the syntax from 7.8.3, it was erroring when building (worked in storybook though)

Spent a bit of time attempting a proper fix, but made no progress and this isn't the worst fix ever 🤷‍♂ 