### PR TITLE
Standardise how component variants are structured in themes

### DIFF
--- a/src/elements/accordion/src/index.tsx
+++ b/src/elements/accordion/src/index.tsx
@@ -26,7 +26,7 @@ const Accordion: React.FC<Props> = ({
           cursor: 'pointer',
           variant: !isOpen
             ? 'accordion.base.button'
-            : 'accordion.isActive.button'
+            : 'accordion.variants.isActive.button'
         }}
         onClick={() => setIsOpen(!isOpen)}
       >
@@ -41,7 +41,7 @@ const Accordion: React.FC<Props> = ({
         <Icon
           color={
             isOpen
-              ? colors[accordionTheme?.isActive?.caret?.color]
+              ? colors[accordionTheme?.variants?.isActive?.caret?.color]
               : colors[accordionTheme?.base?.caret?.color]
           }
           glyph="caret"

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import * as React from 'react'
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx } from 'theme-ui'
 
 export type Variant = 'primary' | 'secondary' | 'continue'
 type IconPosition = 'left' | 'center' | 'right' | null
@@ -19,19 +19,16 @@ export const Button: React.FC<Props> = ({
   onClick,
   ...props
 }) => {
-  const { theme }: any = useThemeUI()
-
   return (
     <button
       sx={{
-        ...theme.buttons.base,
         cursor: 'pointer',
         backgroundImage: 'none',
         fontFamily: 'base',
         fontSize: 'base',
         paddingX: 'sm',
         paddingY: 'base',
-        variant: `buttons.${variant}`,
+        variant: `buttons.variants.${variant}`,
 
         ...(iconPosition
           ? {

--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -18,7 +18,7 @@ export default {
 export const AllVariants = () => (
   <div css={css({ padding: number('Padding', 10) })}>
     {theme() &&
-      Object.keys(theme().buttons).map((key, index) => (
+      Object.keys(theme().buttons.variants).map((key, index) => (
         <React.Fragment key={index}>
           <Button
             variant={key as Variant}

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -209,12 +209,14 @@
         "color": "plum"
       }
     },
-    "isActive": {
-      "button": {
-        "variant": "accordion.base.button"
-      },
-      "caret": {
-        "color": "fuschia"
+    "variants": {
+      "isActive": {
+        "button": {
+          "variant": "accordion.base.button"
+        },
+        "caret": {
+          "color": "fuschia"
+        }
       }
     }
   },
@@ -410,48 +412,47 @@
 
   "buttons": {
 
-    "primary": {
-      "color": "experimental-text",
+    "base": {
       "fontSize": "md",
       "fontWeight": "bold",
       "border": "none",
-      "backgroundColor": "primary",
       "borderRadius": "50vh",
       "paddingX": "lg",
-      ":hover:not(:disabled)": {
-        "backgroundColor": "primary--dark"
-      },
-      ":focus": {
-        "backgroundColor": "primary--dark"
-      },
       ":disabled": {
         "opacity": "0.3",
         "cursor": "not-allowed"
-      },
-      ":active": {
-        "backgroundColor": "primary--dark"
       }
     },
 
-    "secondary": {
-      "color": "grey-0",
-      "fontSize": "md",
-      "fontWeight": "bold",
-      "backgroundColor": "secondary",
-      "borderRadius": "50vh",
-      "paddingX": "lg",
-      ":hover:not(:disabled)": {
-        "backgroundColor": "secondary--dark"
+    "variants": {
+      "primary": {
+        "variant": "buttons.base",
+        "color": "experimental-text",
+        "backgroundColor": "primary",
+        ":hover:not(:disabled)": {
+          "backgroundColor": "primary--dark"
+        },
+        ":focus": {
+          "backgroundColor": "primary--dark"
+        },
+        ":active": {
+          "backgroundColor": "primary--dark"
+        }
       },
-      ":focus": {
-        "backgroundColor": "secondary--dark"
-      },
-      ":disabled": {
-        "opacity": "0.3",
-        "cursor": "not-allowed"
-      },
-      ":active": {
-        "backgroundColor": "secondary--dark"
+
+      "secondary": {
+        "variant": "buttons.base",
+        "color": "grey-0",
+        "backgroundColor": "secondary",
+        ":hover:not(:disabled)": {
+          "backgroundColor": "secondary--dark"
+        },
+        ":focus": {
+          "backgroundColor": "secondary--dark"
+        },
+        ":active": {
+          "backgroundColor": "secondary--dark"
+        }
       }
     }
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -391,63 +391,66 @@
   },
 
   "buttons": {
-    "primary": {
-      "backgroundColor": "uswitch-navy",
-      "color": "white",
+    "base": {
+      "paddingX": "lg",
       "textAlign": "center",
-      "width": ["100%"],
-      "paddingX": "lg",
-      "border": "none",
-      "fontWeight": "bold",
-      ":hover": {
-        "backgroundColor": "grey-70"
-      },
-      ":disabled": {
-        "backgroundColor": "grey-20",
-        "cursor": "not-allowed"
-      },
-      ":visited": {
-        "color": "white"
-      }
+      "fontWeight": "bold"
     },
-
-    "secondary": {
-      "color": "uswitch-navy",
-      "background": "none",
-      "border": "2px solid",
-      "borderColor": "uswitch-navy",
-      "paddingX": "lg",
-      ":hover": {
-        "backgroundColor": "grey-10"
+    "variants": {
+      "primary": {
+        "variant": "buttons.base",
+        "backgroundColor": "uswitch-navy",
+        "color": "white",
+        "width": [
+          "100%"
+        ],
+        "border": "none",
+        ":hover": {
+          "backgroundColor": "grey-70"
+        },
+        ":disabled": {
+          "backgroundColor": "grey-20",
+          "cursor": "not-allowed"
+        },
+        ":visited": {
+          "color": "white"
+        }
       },
-      ":disabled": {
-        "color": "grey-40",
-        "borderColor": "grey-20",
-        "cursor": "not-allowed"
+      "secondary": {
+        "variant": "buttons.base",
+        "color": "uswitch-navy",
+        "background": "none",
+        "border": "2px solid",
+        "borderColor": "uswitch-navy",
+        ":hover": {
+          "backgroundColor": "grey-10"
+        },
+        ":disabled": {
+          "color": "grey-40",
+          "borderColor": "grey-20",
+          "cursor": "not-allowed"
+        },
+        ":visited": {
+          "color": "uswitch-navy"
+        }
       },
-      ":visited": {
-        "color": "uswitch-navy"
-      }
-    },
-
-    "reversed": {
-      "color": "white",
-      "backgroundColor": "uswitch-navy",
-      "paddingX": "lg",
-      "border": "2px solid",
-      "borderColor": "white",
-      "textAlign": "center",
-      "fontWeight": "bold",
-      ":hover": {
-        "backgroundColor": "grey-80"
-      },
-      ":disabled": {
-        "borderColor": "grey-60",
-        "color": "grey-60",
-        "cursor": "not-allowed"
-      },
-      ":visited": {
-        "color": "white"
+      "reversed": {
+        "variant": "buttons.base",
+        "color": "white",
+        "backgroundColor": "uswitch-navy",
+        "border": "2px solid",
+        "borderColor": "white",
+        ":hover": {
+          "backgroundColor": "grey-80"
+        },
+        ":disabled": {
+          "borderColor": "grey-60",
+          "color": "grey-60",
+          "cursor": "not-allowed"
+        },
+        ":visited": {
+          "color": "white"
+        }
       }
     }
   },


### PR DESCRIPTION
# Description

After a conversation with barney, we decided to move variants into a `variants` object under a component.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [x] Small non-breaking change: patch version
- [ ] Larger non-breaking change: minor version
- [ ] Breaking change: major version

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] ~Work has been tested in multiple browsers~
- [x] PR description includes description of change
- [x] ~PR description includes screenshot of change~
- [x] ~If new component, designer has approved screenshot~
- [x] ~If the change will affect other teams, that team knows about this change~
- [x] ~If introducing a new component behaviour, added a story to cover that case.~
