### PR TITLE
fix grid to match designs

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -40,8 +40,15 @@ const newViewports = {
       height: '667px'
     }
   },
-  iPhone: {
-    name: 'iPhone', // iPhone 6/7/8 dimensions
+  iPhone5: {
+    name: 'iPhone 5/se', // iPhone 6/7/8 dimensions
+    styles: {
+      width: '320px',
+      height: '568px'
+    }
+  },
+  iPhone6: {
+    name: 'iPhone 6/7/8', // iPhone 6/7/8 dimensions
     styles: {
       width: '375px',
       height: '667px'

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,5 @@
+<style>
+  body {
+    margin: 0;
+  }
+</style>

--- a/src/layout/grid/src/stories.tsx
+++ b/src/layout/grid/src/stories.tsx
@@ -16,7 +16,84 @@ const exampleColumnStyle = css({
 })
 
 const exampleRowStyle = css({
-  fontFamily: typography.defaultFontFamily
+  fontFamily: typography.defaultFontFamily,
+  paddingBottom: '16px'
+})
+
+storiesOf('Layout|Grid', module).add('Basic Example', () => (
+  <Container css={{ backgroundColor: colors.slateGrey, paddingBottom: '16px' }}>
+    <Row css={exampleRowStyle}>
+      <Column s={6 / 12} m={6 / 12} l={1 / 2}>
+        <div css={{ backgroundColor: 'white' }}>
+          <h2>A 6 / 12 column</h2>
+        </div>
+      </Column>
+
+      <Column s={6 / 12} m={1 / 2} l={1 / 2}>
+        <div css={{ backgroundColor: 'white' }}>
+          <h2>A 6 / 12 column</h2>
+        </div>
+      </Column>
+    </Row>
+
+    <Row css={exampleRowStyle}>
+      <Column s={2 / 12} m={2 / 12} l={2 / 12}>
+        <div css={{ backgroundColor: 'white' }}>2/12</div>
+      </Column>
+
+      <Column s={2 / 12} m={2 / 12} l={2 / 12}>
+        <div css={{ backgroundColor: 'white' }}>2/12</div>
+      </Column>
+
+      <Column s={2 / 12} m={2 / 12} l={2 / 12}>
+        <div css={{ backgroundColor: 'white' }}>2/12</div>
+      </Column>
+
+      <Column s={2 / 12} m={2 / 12} l={2 / 12}>
+        <div css={{ backgroundColor: 'white' }}>2/12</div>
+      </Column>
+
+      <Column s={2 / 12} m={2 / 12} l={2 / 12}>
+        <div css={{ backgroundColor: 'white' }}>2/12</div>
+      </Column>
+
+      <Column s={2 / 12} m={2 / 12} l={2 / 12}>
+        <div css={{ backgroundColor: 'white' }}>2/12</div>
+      </Column>
+    </Row>
+
+    <div css={{ backgroundColor: 'white' }}>
+      A normal block element in the container not in a row or column
+    </div>
+  </Container>
+))
+
+storiesOf('Layout|Grid', module).add('Custom gutters', () => {
+  const gutterWidths = [8, 16, 24]
+  return (
+    <Container
+      gutterWidths={gutterWidths}
+      css={{ backgroundColor: colors.offWhite, paddingBottom: '16px' }}
+    >
+      <Row css={exampleRowStyle}>
+        <Column m={1 / 2} l={1 / 2}>
+          <div css={{ backgroundColor: 'white' }}>
+            <h2>A 6 / 12 column</h2>
+          </div>
+        </Column>
+
+        <Column m={1 / 2} l={1 / 2}>
+          <div css={{ backgroundColor: 'white' }}>
+            <h2>A 6 / 12 column</h2>
+          </div>
+        </Column>
+      </Row>
+
+      <div css={{ backgroundColor: 'white' }}>
+        A normal block element in the container not in a row or column
+      </div>
+    </Container>
+  )
 })
 
 storiesOf('Layout|Grid', module).add('Example 1 - basics', () => (

--- a/src/layout/grid/src/styles.ts
+++ b/src/layout/grid/src/styles.ts
@@ -1,15 +1,26 @@
 import { mq } from '@uswitch/trustyle.styles'
 import { DynamicStyle } from 'facepaint'
 
-const defaultGutterWidths = [8, 16, 24]
+const defaultGutterWidths = [16]
 const defaultContainerWidths = ['100%', 640, 1152]
+
+const getWidthPercentageFromSizes = (sizes: number[]) =>
+  sizes.map(size => `${100 * size}%`)
+
+// Not currently used
+// const getMsFlexPreferredSizes = (sizes: number[], paddings: string[]) =>
+//   sizes.map((size, ind) => {
+//     const padding = paddings[Math.min(ind, paddings.length - 1)]
+
+//     return `calc(${100 * size}% - ${padding} * 2)`
+//   })
 
 export const container = (
   outerMargin: string[] = ['0 auto'],
   containerWidths: (string | number)[] = defaultContainerWidths,
   gutterWidths: number[] = defaultGutterWidths
 ): DynamicStyle[] => {
-  const paddings = gutterWidths.map(gw => `${gw / 2}px`)
+  const paddings = gutterWidths.map(gw => `${gw}px`)
 
   return mq({
     position: 'relative',
@@ -21,15 +32,26 @@ export const container = (
   })
 }
 
-const getWidthPercentageFromSizes = (sizes: number[]) =>
-  sizes.map(size => `${100 * size}%`)
+export const row = (
+  centerX: boolean = false,
+  topSpacing: number[] = [],
+  bottomSpacing: number[] = [],
+  gutterWidths: number[] = defaultGutterWidths
+): DynamicStyle[] => {
+  const margins = gutterWidths.map(gw => `-${gw / 2}px`)
 
-const getMsFlexPreferredSizes = (sizes: number[], paddings: string[]) =>
-  sizes.map((size, ind) => {
-    const padding = paddings[Math.min(ind, paddings.length - 1)]
-
-    return `calc(${100 * size}% - ${padding} * 2)`
+  return mq({
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'row',
+    marginLeft: margins,
+    marginRight: margins,
+    marginTop: topSpacing,
+    marginBottom: bottomSpacing,
+    justifyContent: centerX ? 'center' : 'flex-start',
+    flexWrap: 'wrap'
   })
+}
 
 export const column = (
   sizes: number[] = [],
@@ -47,30 +69,6 @@ export const column = (
     paddingRight: paddings,
     paddingTop: hasPaddingTop ? paddings : [],
     paddingBottom: hasPaddingBottom ? paddings : [],
-    flexBasis: getWidthPercentageFromSizes(sizes),
-
-    // IE 11 does not correctly take the padding into account when using border-box
-    msFlexPreferredSize: getMsFlexPreferredSizes(sizes, paddings)
-  })
-}
-
-export const row = (
-  centerX: boolean = false,
-  topSpacing: number[] = [],
-  bottomSpacing: number[] = [],
-  gutterWidths: number[] = defaultGutterWidths
-): DynamicStyle[] => {
-  const paddings = gutterWidths.map(gw => `${gw / 2}px`)
-
-  return mq({
-    boxSizing: 'border-box',
-    display: 'flex',
-    flexDirection: 'row',
-    marginLeft: paddings.map(padding => `-${padding}`),
-    marginRight: paddings.map(padding => `-${padding}`),
-    marginTop: topSpacing,
-    marginBottom: bottomSpacing,
-    justifyContent: centerX ? 'center' : 'flex-start',
-    flexWrap: 'wrap'
+    width: getWidthPercentageFromSizes(sizes)
   })
 }


### PR DESCRIPTION
# Description

<!-- Explain the purpose of this Pull Request. -->


we now have 16px padding on the `<Container>`, -8px margin on `<Row>` and 8px padding on `<Column>`

this gives a grid of 16px at either side of the container, and 16px between columns, which is *not* like ustyle which has 15px either side of the container and 15px * 2 = 30px between columns

![Layout___Grid_-_Basic_Example_⋅_Storybook_-_Firefox_Developer_Edition](https://user-images.githubusercontent.com/4057948/73860296-423c4700-4833-11ea-905e-38b1b23247d1.jpg)


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [ ] Small non-breaking change: patch version
- [ ] Larger non-breaking change: minor version
- [x] Breaking change: major version

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.