### PR TITLE
(With package-lock.json changes) Publish

### DIFF
--- a/src/compounds/side-nav/package-lock.json
+++ b/src/compounds/side-nav/package-lock.json
@@ -1,29 +1,29 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.accordion": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.accordion/-/trustyle.accordion-0.1.8.tgz",
-      "integrity": "sha512-Vj746A3vf3NcwhI5369HwTuwQwVuCQD1Ggwk106Mj373nznUXPT3CAt0bKHPWzh5SrMy1SOv1hLsRVKwRx7aXg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.accordion/-/trustyle.accordion-0.1.9.tgz",
+      "integrity": "sha512-yCTUTg0fYuHDxzKv9XIdtTNOGVXQvKnSzmpYS+ZnNiyU/21BcmYXf6xjlwb6HmjthyNne4g/ViebCpMA4JE7Og==",
       "requires": {
-        "@uswitch/trustyle.icon": "^0.2.47"
+        "@uswitch/trustyle.icon": "^0.2.48"
       }
     },
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.1.8"
+    "@uswitch/trustyle.accordion": "^0.1.9"
   }
 }

--- a/src/elements/accordion/package-lock.json
+++ b/src/elements/accordion/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,6 +21,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47"
+    "@uswitch/trustyle.icon": "^0.2.48"
   }
 }

--- a/src/elements/author/package-lock.json
+++ b/src/elements/author/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@uswitch/trustyle.author",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.date": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.date/-/trustyle.date-0.0.5.tgz",
-      "integrity": "sha512-o03Ee59hmrAInXnVv2G+YdNxSL2DU3OQnT1ubWDQJOkZamUaBPNJkgCXFIrDRoclieAL/B368EOZY05vaCQ9OA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.date/-/trustyle.date-0.0.6.tgz",
+      "integrity": "sha512-HZMXpun1L1npZ9CDYfiy4tE44x5eC43uBw/lIknBIla7/zfxovTm9QYvEPditst9uBRVj7SMYI1iKiSkC/Uc2g==",
       "requires": {
         "dayjs": "^1.8.19"
       }

--- a/src/elements/author/package.json
+++ b/src/elements/author/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.date": "^0.0.5"
+    "@uswitch/trustyle.date": "^0.0.6"
   }
 }

--- a/src/elements/breadcrumbs/package-lock.json
+++ b/src/elements/breadcrumbs/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@uswitch/trustyle.breadcrumbs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/elements/breadcrumbs/package.json
+++ b/src/elements/breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.breadcrumbs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47"
+    "@uswitch/trustyle.icon": "^0.2.48"
   }
 }

--- a/src/elements/bullet-list-highlight/package-lock.json
+++ b/src/elements/bullet-list-highlight/package-lock.json
@@ -1,21 +1,21 @@
 {
 	"name": "@uswitch/trustyle.bullet-list-highlight",
-	"version": "0.2.48",
+	"version": "0.2.49",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.icon": {
-			"version": "0.2.47",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-			"integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+			"version": "0.2.48",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+			"integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
 			"requires": {
-				"@uswitch/trustyle.styles": "^0.4.23"
+				"@uswitch/trustyle.styles": "^0.4.24"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/bullet-list-highlight/package.json
+++ b/src/elements/bullet-list-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bullet-list-highlight",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47",
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.icon": "^0.2.48",
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/bullet-list-timeline/package-lock.json
+++ b/src/elements/bullet-list-timeline/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@uswitch/trustyle.bullet-list-timeline",
-	"version": "0.2.41",
+	"version": "0.2.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/bullet-list-timeline/package.json
+++ b/src/elements/bullet-list-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bullet-list-timeline",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/button-link/package-lock.json
+++ b/src/elements/button-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button-link",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/elements/button-link/package.json
+++ b/src/elements/button-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button-link",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button/package-lock.json
+++ b/src/elements/button/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.button",
-	"version": "0.7.7",
+	"version": "0.7.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/call-out/package-lock.json
+++ b/src/elements/call-out/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47"
+    "@uswitch/trustyle.icon": "^0.2.48"
   }
 }

--- a/src/elements/category/package-lock.json
+++ b/src/elements/category/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1
 }

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/checkbox-input/package-lock.json
+++ b/src/elements/checkbox-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.checkbox-input",
-	"version": "0.0.22",
+	"version": "0.0.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -135,19 +135,19 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.grid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-2.0.0.tgz",
-			"integrity": "sha512-cuiYbZ1D7WecuaLCe9GqXgZMc8eUJcQlARS/ISpAVqF6pUVYDvdrBl7nd11cTV6tHjRA2S1OdvwIyEc3VDsPOQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-2.0.1.tgz",
+			"integrity": "sha512-3kSLVHobyWo2grQYcHyzO3MMomBOIKh6Y9firAyFU5NnYTLTXMMibhc6HM6yVhcWOoj3AhPWIfwBvU+4cqy7ow==",
 			"requires": {
 				"@emotion/core": "^10.0.27",
-				"@uswitch/trustyle.styles": "^0.4.23",
+				"@uswitch/trustyle.styles": "^0.4.24",
 				"facepaint": "^1.2.1"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/checkbox-input/package.json
+++ b/src/elements/checkbox-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.checkbox-input",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,8 +13,8 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.grid": "^2.0.0",
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.grid": "^2.0.1",
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/cta/package-lock.json
+++ b/src/elements/cta/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@uswitch/trustyle.cta",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.button-link": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.button-link/-/trustyle.button-link-0.3.8.tgz",
-      "integrity": "sha512-A0nidGQDcXXtgb5VoePv/nbRF2g3aQqkJJmPvEAELITMLX6vCp9DH7Gz2wG0yT/l51tBA9aiaL/HwtF3oWjkvw=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.button-link/-/trustyle.button-link-0.4.0.tgz",
+      "integrity": "sha512-XllryVCfJmnN+DVd+mIdv88PeGwupkSHEFsPdgWusG+Uyx0rMe2zxXqqXy/PApJNkFLPHT9Ji7nVcbQfFBSddw=="
     }
   }
 }

--- a/src/elements/cta/package.json
+++ b/src/elements/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.cta",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.button-link": "^0.3.8"
+    "@uswitch/trustyle.button-link": "^0.4.0"
   }
 }

--- a/src/elements/drop-down/package-lock.json
+++ b/src/elements/drop-down/package-lock.json
@@ -1,30 +1,30 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "0.4.55",
+  "version": "0.4.56",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.frozen-input": {
-      "version": "0.3.48",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.frozen-input/-/trustyle.frozen-input-0.3.48.tgz",
-      "integrity": "sha512-tEwFtZh28PyXFXrEWxdVtpVBIsMdTmk74drjGVokfLaIHanQPFK3Jk0avsrBsGx9fIAkfohBPPOxhnLDnRKL0A==",
+      "version": "0.3.49",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.frozen-input/-/trustyle.frozen-input-0.3.49.tgz",
+      "integrity": "sha512-BzdZbPN8UknBPCGVx7tE5VKUoOrNJVgU0pike4JQhYzIUv7/G4S8oVHRst1NLCA8TPGAb9v4G5RVFDHyIEdgIQ==",
       "requires": {
-        "@uswitch/trustyle.icon": "^0.2.47",
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.icon": "^0.2.48",
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "0.4.55",
+  "version": "0.4.56",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,9 +13,9 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^0.3.48",
-    "@uswitch/trustyle.icon": "^0.2.47",
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.frozen-input": "^0.3.49",
+    "@uswitch/trustyle.icon": "^0.2.48",
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/embedded-video/package-lock.json
+++ b/src/elements/embedded-video/package-lock.json
@@ -1,29 +1,29 @@
 {
 	"name": "@uswitch/trustyle.embedded-video",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.accordion": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.accordion/-/trustyle.accordion-0.1.8.tgz",
-			"integrity": "sha512-Vj746A3vf3NcwhI5369HwTuwQwVuCQD1Ggwk106Mj373nznUXPT3CAt0bKHPWzh5SrMy1SOv1hLsRVKwRx7aXg==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.accordion/-/trustyle.accordion-0.1.9.tgz",
+			"integrity": "sha512-yCTUTg0fYuHDxzKv9XIdtTNOGVXQvKnSzmpYS+ZnNiyU/21BcmYXf6xjlwb6HmjthyNne4g/ViebCpMA4JE7Og==",
 			"requires": {
-				"@uswitch/trustyle.icon": "^0.2.47"
+				"@uswitch/trustyle.icon": "^0.2.48"
 			}
 		},
 		"@uswitch/trustyle.icon": {
-			"version": "0.2.47",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-			"integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+			"version": "0.2.48",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+			"integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
 			"requires": {
-				"@uswitch/trustyle.styles": "^0.4.23"
+				"@uswitch/trustyle.styles": "^0.4.24"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -22,6 +22,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.1.8"
+    "@uswitch/trustyle.accordion": "^0.1.9"
   }
 }

--- a/src/elements/fieldset/package-lock.json
+++ b/src/elements/fieldset/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.fieldset",
-	"version": "0.0.22",
+	"version": "0.0.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -152,20 +152,20 @@
 			"dev": true
 		},
 		"@uswitch/trustyle.grid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-2.0.0.tgz",
-			"integrity": "sha512-cuiYbZ1D7WecuaLCe9GqXgZMc8eUJcQlARS/ISpAVqF6pUVYDvdrBl7nd11cTV6tHjRA2S1OdvwIyEc3VDsPOQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-2.0.1.tgz",
+			"integrity": "sha512-3kSLVHobyWo2grQYcHyzO3MMomBOIKh6Y9firAyFU5NnYTLTXMMibhc6HM6yVhcWOoj3AhPWIfwBvU+4cqy7ow==",
 			"dev": true,
 			"requires": {
 				"@emotion/core": "^10.0.27",
-				"@uswitch/trustyle.styles": "^0.4.23",
+				"@uswitch/trustyle.styles": "^0.4.24",
 				"facepaint": "^1.2.1"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/fieldset/package.json
+++ b/src/elements/fieldset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.fieldset",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,10 +13,10 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
-    "@uswitch/trustyle.grid": "^2.0.0",
+    "@uswitch/trustyle.grid": "^2.0.1",
     "typescript": "^3.6.2"
   },
   "peerDependencies": {

--- a/src/elements/frozen-input/package-lock.json
+++ b/src/elements/frozen-input/package-lock.json
@@ -1,21 +1,21 @@
 {
 	"name": "@uswitch/trustyle.frozen-input",
-	"version": "0.3.48",
+	"version": "0.3.49",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.icon": {
-			"version": "0.2.47",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-			"integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+			"version": "0.2.48",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+			"integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
 			"requires": {
-				"@uswitch/trustyle.styles": "^0.4.23"
+				"@uswitch/trustyle.styles": "^0.4.24"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,8 +13,8 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47",
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.icon": "^0.2.48",
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/funnel-progress/package-lock.json
+++ b/src/elements/funnel-progress/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@uswitch/trustyle.funnel-progress",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/elements/funnel-progress/package.json
+++ b/src/elements/funnel-progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.funnel-progress",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {
@@ -16,6 +16,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47"
+    "@uswitch/trustyle.icon": "^0.2.48"
   }
 }

--- a/src/elements/global-styles/package-lock.json
+++ b/src/elements/global-styles/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.global-styles",
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/elements/global-styles/package.json
+++ b/src/elements/global-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.global-styles",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/icon/package-lock.json
+++ b/src/elements/icon/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@uswitch/trustyle.icon",
-	"version": "0.2.47",
+	"version": "0.2.48",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/icon/package.json
+++ b/src/elements/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.icon",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/imgix-image/package-lock.json
+++ b/src/elements/imgix-image/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.imgix-image",
-	"version": "0.1.24",
+	"version": "0.1.25",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/elements/imgix-image/package.json
+++ b/src/elements/imgix-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.imgix-image",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/input-alert/package-lock.json
+++ b/src/elements/input-alert/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@uswitch/trustyle.input-alert",
-	"version": "0.2.41",
+	"version": "0.2.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/input-alert/package.json
+++ b/src/elements/input-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input-alert",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/input/package-lock.json
+++ b/src/elements/input/package-lock.json
@@ -1,30 +1,30 @@
 {
 	"name": "@uswitch/trustyle.input",
-	"version": "0.3.48",
+	"version": "0.3.49",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.frozen-input": {
-			"version": "0.3.48",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.frozen-input/-/trustyle.frozen-input-0.3.48.tgz",
-			"integrity": "sha512-tEwFtZh28PyXFXrEWxdVtpVBIsMdTmk74drjGVokfLaIHanQPFK3Jk0avsrBsGx9fIAkfohBPPOxhnLDnRKL0A==",
+			"version": "0.3.49",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.frozen-input/-/trustyle.frozen-input-0.3.49.tgz",
+			"integrity": "sha512-BzdZbPN8UknBPCGVx7tE5VKUoOrNJVgU0pike4JQhYzIUv7/G4S8oVHRst1NLCA8TPGAb9v4G5RVFDHyIEdgIQ==",
 			"requires": {
-				"@uswitch/trustyle.icon": "^0.2.47",
-				"@uswitch/trustyle.styles": "^0.4.23"
+				"@uswitch/trustyle.icon": "^0.2.48",
+				"@uswitch/trustyle.styles": "^0.4.24"
 			}
 		},
 		"@uswitch/trustyle.icon": {
-			"version": "0.2.47",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-			"integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+			"version": "0.2.48",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+			"integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
 			"requires": {
-				"@uswitch/trustyle.styles": "^0.4.23"
+				"@uswitch/trustyle.styles": "^0.4.24"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,8 +13,8 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^0.3.48",
-    "@uswitch/trustyle.styles": "^0.4.23",
+    "@uswitch/trustyle.frozen-input": "^0.3.49",
+    "@uswitch/trustyle.styles": "^0.4.24",
     "lodash.debounce": "^4.0.8",
     "react-input-mask": "^2.0.4"
   },

--- a/src/elements/list/package-lock.json
+++ b/src/elements/list/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.list",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/elements/list/package.json
+++ b/src/elements/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.list",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/loading-spinner/package-lock.json
+++ b/src/elements/loading-spinner/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@uswitch/trustyle.loading-spinner",
-	"version": "0.2.41",
+	"version": "0.2.42",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/loading-spinner/package.json
+++ b/src/elements/loading-spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.loading-spinner",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/pagination/package-lock.json
+++ b/src/elements/pagination/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@uswitch/trustyle.icon": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-      "integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+      "integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
       "requires": {
-        "@uswitch/trustyle.styles": "^0.4.23"
+        "@uswitch/trustyle.styles": "^0.4.24"
       }
     },
     "@uswitch/trustyle.styles": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-      "integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+      "integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
       "requires": {
         "facepaint": "^1.2.1"
       }

--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47"
+    "@uswitch/trustyle.icon": "^0.2.48"
   }
 }

--- a/src/elements/progress-bar/package-lock.json
+++ b/src/elements/progress-bar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.progress-bar",
-	"version": "0.3.15",
+	"version": "0.3.16",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/progress-bar/package.json
+++ b/src/elements/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.progress-bar",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "@types/facepaint": "^1.2.1",

--- a/src/elements/radio-input/package-lock.json
+++ b/src/elements/radio-input/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@uswitch/trustyle.radio-input",
-	"version": "1.1.13",
+	"version": "1.1.14",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/radio-input/package.json
+++ b/src/elements/radio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.radio-input",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.styles": "^0.4.23"
+    "@uswitch/trustyle.styles": "^0.4.24"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/side-drawer/package-lock.json
+++ b/src/elements/side-drawer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.side-drawer",
-	"version": "0.2.35",
+	"version": "0.2.36",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -13,17 +13,17 @@
 			}
 		},
 		"@uswitch/trustyle.icon": {
-			"version": "0.2.47",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.47.tgz",
-			"integrity": "sha512-aoyIDYsbBD/O4nnyjfnbkS5D8Ee/ice/datANqsa8AvQv+uLFjq7ArhLVrOK088Ll5N8FqrFCHceqRaosPH6pA==",
+			"version": "0.2.48",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.icon/-/trustyle.icon-0.2.48.tgz",
+			"integrity": "sha512-0tCoHWYV08NUt+jjVqNHTssyjCsp6n2WScPnJNPHoxPbwvwZQZ/L2S3x8quRVqSd9WC78LobVBXQqCUnazKe0g==",
 			"requires": {
-				"@uswitch/trustyle.styles": "^0.4.23"
+				"@uswitch/trustyle.styles": "^0.4.24"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/side-drawer/package.json
+++ b/src/elements/side-drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-drawer",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,8 +13,8 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^0.2.47",
-    "@uswitch/trustyle.styles": "^0.4.23",
+    "@uswitch/trustyle.icon": "^0.2.48",
+    "@uswitch/trustyle.styles": "^0.4.24",
     "focus-trap-react": "^6.0.0",
     "react-dom": "^16.7.0",
     "react-transition-group": "^4.2.2"

--- a/src/elements/tile-input/package-lock.json
+++ b/src/elements/tile-input/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.tile-input",
-	"version": "1.0.49",
+	"version": "1.0.50",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -135,20 +135,20 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.grid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-2.0.0.tgz",
-			"integrity": "sha512-cuiYbZ1D7WecuaLCe9GqXgZMc8eUJcQlARS/ISpAVqF6pUVYDvdrBl7nd11cTV6tHjRA2S1OdvwIyEc3VDsPOQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.grid/-/trustyle.grid-2.0.1.tgz",
+			"integrity": "sha512-3kSLVHobyWo2grQYcHyzO3MMomBOIKh6Y9firAyFU5NnYTLTXMMibhc6HM6yVhcWOoj3AhPWIfwBvU+4cqy7ow==",
 			"dev": true,
 			"requires": {
 				"@emotion/core": "^10.0.27",
-				"@uswitch/trustyle.styles": "^0.4.23",
+				"@uswitch/trustyle.styles": "^0.4.24",
 				"facepaint": "^1.2.1"
 			}
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/elements/tile-input/package.json
+++ b/src/elements/tile-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.tile-input",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -14,11 +14,11 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@uswitch/trustyle.styles": "^0.4.23",
+    "@uswitch/trustyle.styles": "^0.4.24",
     "react": "^16.7.0"
   },
   "devDependencies": {
-    "@uswitch/trustyle.grid": "^2.0.0",
+    "@uswitch/trustyle.grid": "^2.0.1",
     "typescript": "^3.6.2"
   }
 }

--- a/src/helpers/date/package-lock.json
+++ b/src/helpers/date/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.date",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/helpers/date/package.json
+++ b/src/helpers/date/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.date",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/layout/arrangement/package-lock.json
+++ b/src/layout/arrangement/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.arrangement",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -141,9 +141,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/layout/arrangement/package.json
+++ b/src/layout/arrangement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.arrangement",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@uswitch/trustyle.styles": "^0.4.23",
+    "@uswitch/trustyle.styles": "^0.4.24",
     "facepaint": "^1.2.1"
   },
   "devDependencies": {

--- a/src/layout/grid/package-lock.json
+++ b/src/layout/grid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.grid",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -141,9 +141,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@uswitch/trustyle.styles": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.23.tgz",
-			"integrity": "sha512-iT25hrDM6/Nd+xjW7ihK5nw8wse7ItlOY2u/HY/qRWmSMEyfo9mQiqb+ELpmdw62PCrnMWZ/BYVITmaj7lJNNA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/@uswitch/trustyle.styles/-/trustyle.styles-0.4.24.tgz",
+			"integrity": "sha512-+3/fBD4g6rb7NN8MXiIN6OGUwYpzQu4d3bZ1p1y9GH/vcBFaH5ACeVWgrv0msgkXmWiC42iEG91IsAmjft6gWw==",
 			"requires": {
 				"facepaint": "^1.2.1"
 			}

--- a/src/layout/grid/package.json
+++ b/src/layout/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.grid",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@uswitch/trustyle.styles": "^0.4.23",
+    "@uswitch/trustyle.styles": "^0.4.24",
     "facepaint": "^1.2.1"
   },
   "devDependencies": {

--- a/src/styles/package-lock.json
+++ b/src/styles/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/trustyle.styles",
-	"version": "0.4.23",
+	"version": "0.4.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/styles/package.json
+++ b/src/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.styles",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.ts",

--- a/src/themes/money/package-lock.json
+++ b/src/themes/money/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1
 }

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/package-lock.json
+++ b/src/themes/uswitch/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1
 }

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
Nearly everything changed, because of the ts:main change in all the package.json files.

 - @uswitch/trustyle.side-nav@0.1.3
 - @uswitch/trustyle.accordion@0.1.9
 - @uswitch/trustyle.author@0.1.4
 - @uswitch/trustyle.breadcrumbs@0.0.9
 - @uswitch/trustyle.bullet-list-highlight@0.2.49
 - @uswitch/trustyle.bullet-list-timeline@0.2.42
 - @uswitch/trustyle.button-link@0.4.0
 - @uswitch/trustyle.button@0.7.8
 - @uswitch/trustyle.call-out@0.1.9
 - @uswitch/trustyle.category@0.1.8
 - @uswitch/trustyle.checkbox-input@0.0.23
 - @uswitch/trustyle.cta@0.2.0
 - @uswitch/trustyle.drop-down@0.4.56
 - @uswitch/trustyle.embedded-video@0.1.4
 - @uswitch/trustyle.fieldset@0.0.23
 - @uswitch/trustyle.frozen-input@0.3.49
 - @uswitch/trustyle.funnel-progress@1.0.1
 - @uswitch/trustyle.global-styles@0.3.8
 - @uswitch/trustyle.icon@0.2.48
 - @uswitch/trustyle.imgix-image@0.1.25
 - @uswitch/trustyle.input-alert@0.2.42
 - @uswitch/trustyle.input@0.3.49
 - @uswitch/trustyle.list@0.2.8
 - @uswitch/trustyle.loading-spinner@0.2.42
 - @uswitch/trustyle.pagination@0.1.9
 - @uswitch/trustyle.progress-bar@0.3.16
 - @uswitch/trustyle.radio-input@1.1.14
 - @uswitch/trustyle.side-drawer@0.2.36
 - @uswitch/trustyle.tile-input@1.0.50
 - @uswitch/trustyle.date@0.0.6
 - @uswitch/trustyle.arrangement@2.0.7
 - @uswitch/trustyle.grid@2.0.1
 - @uswitch/trustyle.styles@0.4.24
 - @uswitch/trustyle.money-theme@0.3.5
 - @uswitch/trustyle.uswitch-theme@0.1.5
