### PR TITLE
Tweak funnel progress bar styles

### DIFF
--- a/src/elements/funnel-progress/src/index.tsx
+++ b/src/elements/funnel-progress/src/index.tsx
@@ -60,10 +60,18 @@ const FunnelPhase: React.FC<FunnelPhaseProps> = ({
     }}
   >
     <div
-      sx={{ variant: 'funnelProgress.base.progress.base' }}
+      sx={{
+        variant:
+          progress !== 0 || !open
+            ? 'funnelProgress.base.progress.base'
+            : 'funnelProgress.base.progress.variants.start'
+      }}
       style={{
-        width: `${STARTING_PROGRESS * 100 +
-          progress * (1 - STARTING_PROGRESS) * 100}%`
+        width:
+          progress !== 0 || !open
+            ? `${STARTING_PROGRESS * 100 +
+                progress * (1 - STARTING_PROGRESS) * 100}%`
+            : '0%'
       }}
     />
     <div sx={{ variant: 'funnelProgress.base.phaseLabel.base' }}>

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -538,9 +538,9 @@
         "variants": {
           "open": {
             "variant": "funnelProgress.base.phaseIcon.base",
-            "background": "#FFFFFF",
-            "borderColor": "#A1E7FE",
-            "color": "#008FE9"
+            "background": "transparent",
+            "borderColor": "transparent",
+            "color": "progress-label"
           },
 
           "complete": {
@@ -575,7 +575,13 @@
           "top": "0",
           "bottom": "0",
           "left": "0",
-          "transition": "width 0.4s"
+          "transition": "width 0.4s, min-width 0.4s"
+        },
+        "variants": {
+          "start": {
+            "variant": "funnelProgress.base.progress.base",
+            "minWidth": "0px"
+          }
         }
       }
     }


### PR DESCRIPTION
# Description

The 'no progress' case needs to be styled as a special variant, because we want the progress bar to have a minimum-width. This ensures it does not clash with the step icon, while still supporting 0% progress.

![image](https://user-images.githubusercontent.com/951457/74027889-032c0400-49a1-11ea-9261-9f3dc540fbf3.png)

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [X] Small non-breaking change: patch version
- [ ] Larger non-breaking change: minor version
- [ ] Breaking change: major version

Definition of done:

- [X] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [X] If new component, designer has approved screenshot
- [X] If the change will affect other teams, that team knows about this change
- [X] If introducing a new component behaviour, added a story to cover that case.
