### PR TITLE
Remove duplicate home links when used inside eevee

### DIFF
--- a/src/elements/breadcrumbs/src/index.tsx
+++ b/src/elements/breadcrumbs/src/index.tsx
@@ -156,6 +156,10 @@ const Breadcrumbs: React.FC<Props> = ({
   customBackIcon = '<',
   customHomeIcon
 }) => {
+  if (crumbs.length && crumbs[0].fields.path === '/') {
+    crumbs = crumbs.slice(1)
+  }
+
   return (
     <React.Fragment>
       <div sx={{ display: ['block', 'none'] }}>

--- a/src/elements/breadcrumbs/src/index.tsx
+++ b/src/elements/breadcrumbs/src/index.tsx
@@ -44,8 +44,8 @@ const MobileBreadcrumbs: React.FC<Props> = ({
 
   if (crumbs.length) {
     const lastCrumb = crumbs[crumbs.length - 1]
-    href = lastCrumb.fields.path
-    backTo = lastCrumb.fields.displayText
+    href = lastCrumb.fields?.path
+    backTo = lastCrumb.fields?.displayText
   } else {
     href = '/'
     backTo = customHomeIcon || <HomeIcon />
@@ -128,10 +128,10 @@ const DesktopBreadcrumbs: React.FC<Props> = ({
         )}
       </li>
 
-      {crumbs.map((crumb, i) => (
+      {crumbs.map(({ fields: fields = {} }, i) => (
         <li sx={liStyling} key={i}>
-          <Styled.a sx={anchorStyling} href={crumb.fields.path}>
-            {crumb.fields.displayText}
+          <Styled.a sx={anchorStyling} href={fields.path}>
+            {fields.displayText}
           </Styled.a>
 
           {(i !== crumbs.length - 1 || title) && (
@@ -156,7 +156,7 @@ const Breadcrumbs: React.FC<Props> = ({
   customBackIcon = '<',
   customHomeIcon
 }) => {
-  if (crumbs.length && crumbs[0].fields.path === '/') {
+  if (crumbs.length && crumbs[0].fields?.path === '/') {
     crumbs = crumbs.slice(1)
   }
 

--- a/src/elements/breadcrumbs/src/stories.tsx
+++ b/src/elements/breadcrumbs/src/stories.tsx
@@ -12,6 +12,12 @@ export default {
 const crumbs = [
   {
     fields: {
+      path: '/',
+      displayText: 'Home'
+    }
+  },
+  {
+    fields: {
       path: '/gas-electricity/',
       displayText: 'Gas & Electricity'
     }


### PR DESCRIPTION
# Description

The breadcrumbs in contentful were all linked to the home breadcrumb so it appeared twice. This change means that it only appears once, but can still be customised.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [x] Small non-breaking change: patch version
- [ ] Larger non-breaking change: minor version
- [ ] Breaking change: major version

Definition of done:

- [x] PR description includes description of change
