### PR TITLE
Fix viewport plugin - was erroring because default didn't exist

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -73,7 +73,7 @@ const newViewports = {
 addParameters({
   viewport: {
     viewports: newViewports,
-    defaultViewport: 'iPhone'
+    defaultViewport: 'iPhone6'
   },
   options: {
     name: 'TruStyle Storybook',


### PR DESCRIPTION
# Description

The viewport addon was failing to load because the available viewports were changed yesterday but the default wasn't updated - am updating that to fix it :)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [x] PR description includes description of change
