### PR TITLE
Convert ButtonLink into a styled component

### DIFF
--- a/src/elements/button-link/src/index.tsx
+++ b/src/elements/button-link/src/index.tsx
@@ -1,36 +1,41 @@
 /** @jsx jsx */
 
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, Styled } from 'theme-ui'
 
-interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  variant: string
-  href?: string
-}
+type Overwrite<T, U> = Omit<T, keyof U> & U
+type Props<T extends React.ComponentType<any>> = Overwrite<
+  React.ComponentProps<T>,
+  {
+    as?: T
+    variant: string
+    children: React.ReactNode
+  }
+>
 
-export const ButtonLink: React.FC<Props> = ({
+export const ButtonLink = <
+  T extends React.ComponentType<any> = React.ComponentType<
+    JSX.IntrinsicElements['a']
+  >
+>({
   children,
   variant,
-  href,
   ...props
-}) => {
-  return (
-    <a
-      sx={{
-        cursor: 'pointer',
-        backgroundImage: 'none',
-        fontFamily: 'base',
-        fontSize: 'base',
-        paddingX: 'sm',
-        paddingY: 'base',
-        display: 'inline-block',
-        textDecoration: 'none',
-        variant: `buttons.variants.${variant}`
-      }}
-      href={href}
-      {...props}
-    >
-      {children}
-    </a>
-  )
-}
+}: Props<T>) => (
+  <Styled.a
+    sx={{
+      cursor: 'pointer',
+      backgroundImage: 'none',
+      fontFamily: 'base',
+      fontSize: 'base',
+      paddingX: 'sm',
+      paddingY: 'base',
+      display: 'inline-block',
+      textDecoration: 'none',
+      variant: `buttons.variants.${variant}`
+    }}
+    {...props}
+  >
+    {children}
+  </Styled.a>
+)

--- a/src/elements/button-link/src/stories.tsx
+++ b/src/elements/button-link/src/stories.tsx
@@ -38,3 +38,17 @@ export const PrimaryVariant = () => (
 export const SecondaryVariant = () => (
   <ButtonLink variant="secondary">Primary link button</ButtonLink>
 )
+
+const CustomLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  to: string
+}> = ({ to, children, ...rest }) => (
+  <a onClick={() => window.alert(`Custom link component: ${to}`)} {...rest}>
+    {children}
+  </a>
+)
+
+export const StyledComponentAsProp = () => (
+  <ButtonLink variant="primary" as={CustomLink} to="special-url">
+    Using <em>as</em> prop
+  </ButtonLink>
+)

--- a/src/elements/button-link/src/stories.tsx
+++ b/src/elements/button-link/src/stories.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { css, jsx } from '@emotion/core'
 import { number, text } from '@storybook/addon-knobs'
+import { action } from '@storybook/addon-actions'
 
 import theme from '../../../utils/theme-selector'
 
@@ -42,7 +43,7 @@ export const SecondaryVariant = () => (
 const CustomLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   to: string
 }> = ({ to, children, ...rest }) => (
-  <a onClick={() => window.alert(`Custom link component: ${to}`)} {...rest}>
+  <a onClick={action(`Custom link component: ${to}`)} {...rest}>
     {children}
   </a>
 )

--- a/src/elements/pagination/src/stories.tsx
+++ b/src/elements/pagination/src/stories.tsx
@@ -14,7 +14,7 @@ const PaginationStory = ({ type }: any) => {
   const [currentPage, setCurrentPage] = React.useState(currentPageKnob)
 
   const handlePageChange = (number: number) => {
-    action(`number clicked: ${number}`)
+    action(`number clicked: ${number}`)()
     setCurrentPage(number)
   }
 


### PR DESCRIPTION
# Description

In apps where we use react-router, we want a Trustyle button link that actually uses Link from react-router. We can use a styled component to achieve this, using it in this way:

```
<ButtonLink
      as={Link}
      to={href}
      onClick={onPlanInfoClick}
      variant="secondary"
    >
      Plan info
    </ButtonLink>
```

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [ ] Small non-breaking change: patch version
- [X] Larger non-breaking change: minor version
- [ ] Breaking change: major version

Definition of done:

- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] If introducing a new component behaviour, added a story to cover that case.
