### PR TITLE
Journey: render ButtonLink with box-sizing: border-box

### DIFF
--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -372,6 +372,7 @@
 
   "buttons": {
     "base": {
+      "box-sizing": "border-box",
       "backgroundColor": "primary",
       "color": "light-1",
       "textAlign": "center",


### PR DESCRIPTION
# Description

The button uses `width: 100%`, but don't use `border-box` in Journey so it's width appears too large in Plan Info.

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [X] Small non-breaking change: patch version
- [ ] Larger non-breaking change: minor version
- [ ] Breaking change: major version

Definition of done:
