### PR TITLE
Convert TileInput to use theming

### DIFF
--- a/src/elements/tile-input/src/index.tsx
+++ b/src/elements/tile-input/src/index.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import * as React from 'react'
-import { jsx } from '@emotion/core'
+import { jsx } from 'theme-ui'
 
 import * as st from './styles'
 
@@ -19,11 +19,11 @@ export const TileInput: React.FC<Props> = ({
   ...inputProps
 }) => (
   <label>
-    <input css={st.input(type)} type={type} {...inputProps} />
-    <span css={st.container(type)}>
-      <span css={st.content}>
+    <input sx={st.input(type)} type={type} {...inputProps} />
+    <span sx={st.container(type)}>
+      <span sx={st.content}>
         <span />
-        <span css={st.childrenWrapper}>{children}</span>
+        <span sx={st.childrenWrapper}>{children}</span>
         {label}
       </span>
     </span>

--- a/src/elements/tile-input/src/stories.tsx
+++ b/src/elements/tile-input/src/stories.tsx
@@ -69,8 +69,8 @@ export default {
   title: 'Elements|TileInput'
 }
 
-export const Radio = () => <Form type="radio" />
-export const Checkbox = () => <Form type="checkbox" />
+export const Radio = () => <Form type="radio" useHooks />
+export const Checkbox = () => <Form type="checkbox" useHooks />
 
-export const RadioSelected = () => <Form type="radio" useHooks={false} />
-export const CheckboxSelected = () => <Form type="checkbox" useHooks={false} />
+export const RadioSelected = () => <Form type="radio" />
+export const CheckboxSelected = () => <Form type="checkbox" />

--- a/src/elements/tile-input/src/styles.ts
+++ b/src/elements/tile-input/src/styles.ts
@@ -1,76 +1,86 @@
-import { css, SerializedStyles } from '@emotion/core'
-import {
-  colors,
-  helpers,
-  pxToRem,
-  spacers,
-  typography
-} from '@uswitch/trustyle.styles'
+import { SxStyleProp, Theme } from 'theme-ui'
 
-const svgSafeAzure = colors.azure.replace('#', '%23')
+const svgSafeColor = (color: string) => color.replace('#', '%23')
 
-export const input = (type: 'radio' | 'checkbox'): SerializedStyles =>
-  css({
+interface InputTile {
+  input: {
+    tile: {
+      inputColor: string
+    }
+  }
+}
+
+export const input = (type: 'radio' | 'checkbox') => (
+  theme: Theme & InputTile
+): SxStyleProp => {
+  let inputColor = 'black'
+
+  if (
+    theme.input &&
+    theme.input.tile &&
+    theme.input.tile.inputColor &&
+    typeof theme.input.tile.inputColor === 'string'
+  ) {
+    inputColor = theme.input.tile.inputColor
+  }
+
+  return {
     marginLeft: '-9000px',
     appearance: 'none',
     position: 'absolute',
     '&:checked + span': {
-      borderColor: colors.azure,
-      boxShadow: helpers.insetBorder(colors.azure),
-      color: colors.black,
+      borderColor: inputColor,
+      boxShadow: 'linkInset',
+      color: 'black',
       '&::before': {
-        backgroundImage:
-          type === 'radio'
-            ? undefined
-            : `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="${svgSafeAzure}" viewBox="-1 -2 14 12"><path d="M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z" /></svg>')`,
-        backgroundColor: type === 'radio' ? colors.azure : colors.white,
-        borderColor: colors.azure,
-        boxShadow:
-          type === 'radio' ? `inset 0 0 0 2px ${colors.white}` : undefined
+        borderColor: inputColor,
+        boxShadow: 'inset 0 0 0 2px white',
+        ...(type === 'radio'
+          ? {
+              backgroundColor: inputColor
+            }
+          : {
+              backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="${svgSafeColor(
+                inputColor
+              )}" viewBox="-1 -2 14 12"><path d="M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z" /></svg>')`
+            })
       }
     },
     '&:focus': {
       outline: 0
+    },
+    '&:focus + span': {
+      boxShadow: 'linkInset'
     }
-  })
+  }
+}
 
-export const container = (type: 'radio' | 'checkbox'): SerializedStyles =>
-  css([
-    typography.label,
-    {
-      borderColor: colors.lightGreyBlue,
-      borderRadius: '3px',
-      borderStyle: 'solid',
-      borderWidth: '1px',
-      boxSizing: 'border-box',
-      color: colors.slateGrey,
-      cursor: 'pointer',
-      display: 'block',
-      fontWeight: 'normal',
-      minHeight: '130px',
-      position: 'relative',
-      width: '100%',
-      '&:before': {
-        borderColor: colors.lightGreyBlue,
-        borderRadius: type === 'radio' ? '50%' : 4,
-        borderStyle: 'solid',
-        borderWidth: '2px',
-        content: '" "',
-        display: 'block',
-        height: '17px',
-        margin: pxToRem(11, 0, 0, 11),
-        width: '17px'
-      }
-    }
-  ])
+export const container = (type: 'radio' | 'checkbox') => (): SxStyleProp => ({
+  boxSizing: 'border-box',
+  cursor: 'pointer',
+  display: 'block',
+  minHeight: '130px',
+  position: 'relative',
+  width: '100%',
+  '&:before': {
+    borderRadius: type === 'radio' ? '50%' : 4,
+    content: '" "',
+    display: 'block',
+    height: '17px',
+    margin: '11px 0 0 11px',
+    width: '17px',
+    variant: 'input.tile.before'
+  },
+  variant: 'input.tile'
+})
 
-export const content: SerializedStyles = css({
+export const content: SxStyleProp = {
   position: 'absolute',
   top: 0,
   left: 0,
   right: 0,
   bottom: 0,
-  padding: pxToRem(spacers.pink),
+  padding: 'xs',
   display: 'flex',
   alignItems: 'center',
   textAlign: 'center',
@@ -79,14 +89,14 @@ export const content: SerializedStyles = css({
   '& > *': {
     width: '100%'
   }
-})
+}
 
 // Wrapper to prevent flexbox from stretching images with a percentage width
-export const childrenWrapper: SerializedStyles = css({
+export const childrenWrapper: SxStyleProp = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   '& > *': {
     maxWidth: '80%'
   }
-})
+}

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -632,6 +632,21 @@
           "borderWidth": "2px"
         }
       }
+    },
+    "tile": {
+      "inputColor": "#008fe9",
+      "borderColor": "light-grey-blue",
+      "borderRadius": "3px",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "color": "slate-grey",
+      "fontWeight": "normal",
+      "before": {
+        "content": "' '",
+        "borderColor": "light-grey-blue",
+        "borderStyle": "solid",
+        "borderWidth": "2px"
+      }
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -9,7 +9,8 @@
   },
 
   "shadows": {
-    "box": "2px 2px 25px #0004"
+    "box": "2px 2px 25px #0004",
+    "linkInset": "inset 0 0 0 1px #008fe9"
   },
 
   "fonts": {
@@ -629,6 +630,21 @@
           "borderStyle": "solid",
           "borderWidth": "2px"
         }
+      }
+    },
+    "tile": {
+      "inputColor": "#008fe9",
+      "borderColor": "#b0b8bf",
+      "borderRadius": "3px",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "color": "slate-grey",
+      "fontWeight": "normal",
+      "before": {
+        "content": "' '",
+        "borderColor": "#b0b8bf",
+        "borderStyle": "solid",
+        "borderWidth": "2px"
       }
     }
   },

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -10,7 +10,7 @@
 
   "shadows": {
     "box": "2px 2px 25px #0004",
-    "linkInset": "inset 0 0 0 1px #008fe9"
+    "linkInset": "inset 0 0 0 1px #141424"
   },
 
   "fonts": {
@@ -646,6 +646,20 @@
           "borderStyle": "solid",
           "borderWidth": "2px"
         }
+      }
+    },
+    "tile": {
+      "inputColor": "#141424",
+      "borderColor": "light-grey-blue",
+      "borderStyle": "solid",
+      "borderWidth": "2px",
+      "color": "slate-grey",
+      "fontWeight": "normal",
+      "before": {
+        "content": "' '",
+        "borderColor": "light-grey-blue",
+        "borderStyle": "solid",
+        "borderWidth": "2px"
       }
     }
   },


### PR DESCRIPTION
# Description

Converts TileInput to use theming

![tile-journey](https://user-images.githubusercontent.com/3267705/75174373-61d6d900-5728-11ea-8fca-8ce7fb7b3d70.png)
![tile-money](https://user-images.githubusercontent.com/3267705/75174547-abbfbf00-5728-11ea-913e-c76785c4edd2.png)
![tile-uswitch](https://user-images.githubusercontent.com/3267705/75174606-cd20ab00-5728-11ea-8b32-3cf1e590433d.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

This is a:

- [ ] A new component
- [ ] Small non-breaking change: patch version
- [ ] Larger non-breaking change: minor version
- [x] Breaking change: major version

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] ~If new component, designer has approved screenshot~
- [ ] ~If the change will affect other teams, that team knows about this change~
- [ ] ~If introducing a new component behaviour, added a story to cover that case.~
