### PR TITLE
Made header sizes smaller on mobile

### DIFF
--- a/src/elements/global-styles/src/stories.tsx
+++ b/src/elements/global-styles/src/stories.tsx
@@ -54,7 +54,12 @@ storiesOf('Global Styles|Typography', module).add('Types', () => {
       <blockquote>
         <p>{children}</p>
       </blockquote>
-    )
+    ),
+    heading: null,
+    table: null,
+    th: null,
+    td: null,
+    tr: null
   }
 
   return (
@@ -62,9 +67,9 @@ storiesOf('Global Styles|Typography', module).add('Types', () => {
       {Object.keys(theme().styles).map((key: string) => {
         const textValue = text(`Text ${key}`, typeNames[key] || key)
 
-        const Comp = overrides[key] ? overrides[key] : key
+        const Comp = overrides[key] !== undefined ? overrides[key] : key
         // @ts-ignore
-        return <Comp key={key}>{textValue}</Comp>
+        return Comp && <Comp key={key}>{textValue}</Comp>
       })}
     </React.Fragment>
   )

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -222,7 +222,7 @@
   "articleIntro": {
     "base": {
       "heading": {
-        "marginTop": ["sm", "sm", "xl"], 
+        "marginTop": ["sm", "sm", "xl"],
         "marginBottom": "sm"
       },
       "description": {
@@ -726,34 +726,34 @@
 
     "h1": {
       "variant": "styles.heading",
-      "fontSize": "xxxl",
+      "fontSize": ["xxl", "xxxl"],
       "marginTop": "xl",
       "marginBottom": "sm"
     },
 
     "h2": {
       "variant": "styles.heading",
-      "fontSize": "xxl",
+      "fontSize": ["xl", "xxl"],
       "marginTop": "md",
       "marginBottom": "sm"
     },
 
     "h3": {
       "variant": "styles.heading",
-      "fontSize": "xl",
+      "fontSize": ["lg", "xl"],
       "marginY": "sm"
     },
 
     "h4": {
       "variant": "styles.heading",
-      "fontSize": "lg",
+      "fontSize": ["md", "lg"],
       "marginTop": 0,
       "marginBottom": "sm"
     },
 
     "h5": {
       "variant": "styles.heading",
-      "fontSize": "md",
+      "fontSize": ["sm","md"],
       "marginTop": 0,
       "marginBottom": "sm"
     },


### PR DESCRIPTION
# Description

They were the same size on desktop and mobile - should have been a size smaller on mobile.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
