### PR TITLE
Add palette as a peer dependency due to shared contexts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7001,6 +7001,12 @@
         }
       }
     },
+    "@uswitch/trustyle-utils.palette": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uswitch/trustyle-utils.palette/-/trustyle-utils.palette-1.0.1.tgz",
+      "integrity": "sha512-zFOda1obm1MGrgfwW33lbNLCWdt9WgsSU5msuwXyW/nCTIBrRIcA1gKu9hCd4tTyE6errsMVm0xYKGbHl2MNuQ==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/theme-ui": "^0.2.7",
     "@typescript-eslint/eslint-plugin": "^1.10.2",
     "@typescript-eslint/parser": "^2.17.0",
+    "@uswitch/trustyle-utils.palette": "^1.0.1",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-require-context-hook": "^1.0.0",

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -14,10 +14,10 @@
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.27",
+    "@uswitch/trustyle-utils.palette": "^1.0.1",
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^1.0.1",
     "@uswitch/trustyle.icon": "^1.0.0"
   }
 }

--- a/src/elements/toggle-switch/package.json
+++ b/src/elements/toggle-switch/package.json
@@ -12,11 +12,9 @@
     "clean": "rm -rf lib",
     "build": "npm run clean && tsc"
   },
-  "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^1.0.1"
-  },
   "peerDependencies": {
     "@emotion/core": "^10.0.27",
+    "@uswitch/trustyle-utils.palette": "^1.0.1",
     "react": "^16.7.0"
   }
 }

--- a/src/elements/toggle-switch/src/index.tsx
+++ b/src/elements/toggle-switch/src/index.tsx
@@ -53,7 +53,8 @@ const ToggleSwitch: React.FC<Props> = ({
           borderColor: checked ? 'featureColor' : null
         }}
       >
-        <div
+        <Palette
+          as="div"
           sx={{
             width: 39,
             height: 38,
@@ -67,9 +68,12 @@ const ToggleSwitch: React.FC<Props> = ({
             alignItems: 'center',
             variant: `toggleSwitch.${state}.switch`
           }}
+          px={{
+            borderColor: checked ? 'featureColor' : null
+          }}
         >
           {checked ? icons?.checked : icons?.unchecked}
-        </div>
+        </Palette>
       </Palette>
     </div>
   )


### PR DESCRIPTION
# Description

Due to the palette provider and requiring a shared context, the palette needs to be a dev dependency of the entire project

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
