### PR TITLE
Allow button to take full variant path

### DIFF
--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -72,7 +72,9 @@ export const Button: React.FC<Props> = ({
         height: theme.buttons.base.btnSize
           ? theme.buttons.base.btnSize[size].height
           : 'base',
-        variant: `buttons.variants.${variant}`,
+        variant: variant.includes('.')
+          ? variant
+          : `buttons.variants.${variant}`,
 
         justifyContent: 'center',
         alignItems: 'center',


### PR DESCRIPTION
# Description

Currently the variant prop can only be a child of the button in the theme. This allows it to also take an absolute theme path

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
