### PR TITLE
added cookie-banner compound to themes

### DIFF
--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -396,6 +396,7 @@
       "mx": 0
     },
 
+
     "cookie-banner": {
       "heading": {
         "mt": [0, "md", "md"], 
@@ -421,6 +422,10 @@
         "borderColor": "grey-40",
         "backgroundColor": "white",
         "borderRadius": 3
+      },
+      "button-with-checkbox-checked": {
+        "variant": "compounds.cookie-banner.button-with-checkbox",
+        "borderColor": "plum"
       }
     }
   },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -394,6 +394,34 @@
     "breadcrumb": {
       "my": "sm",
       "mx": 0
+    },
+
+    "cookie-banner": {
+      "heading": {
+        "mt": [0, "md", "md"], 
+        "color": "grey-80"
+      },
+      "hr": {
+        "border": 0,
+        "height": 1,
+        "bg": "grey-20"
+      },
+      "copy": {
+        "mb": ["md", "sm", null],
+        "mt": "base"
+      },
+      "accept-all-button": {
+        "variant": "buttons.variants.primary"
+      },
+      "save-preferences-button": {
+        "variant": "buttons.variants.secondary"
+      },
+      "button-with-checkbox": {
+        "border": "1px solid",
+        "borderColor": "grey-40",
+        "backgroundColor": "white",
+        "borderRadius": 3
+      }
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -406,7 +406,6 @@
       "mx": 0
     },
 
-
     "cookie-banner": {
       "heading": {
         "mt": [0, "md", "md"], 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -385,12 +385,16 @@
         "variant": "buttons.variants.primary"
       },
       "save-preferences-button": {
-        "variant": "buttons.variants.secondary"
+        "variant": "buttons.variants.reversed"
       },
       "button-with-checkbox": {
         "border": "2px solid",
-        "borderColor": "borderColor",
+        "borderColor": "grey-40",
         "backgroundColor": "white"
+      },
+      "button-with-checkbox-checked": {
+        "variant": "compounds.cookie-banner.button-with-checkbox",
+        "borderColor": "uswitch-navy",
       }
     }
   },

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -366,6 +366,32 @@
     "breadcrumb": {
       "my": "sm",
       "mx": 0
+    },
+
+    "cookie-banner": {
+      "heading": {
+        "mt": [0, "md", "md"], 
+      },
+      "hr": {
+        "border": 0,
+        "height": 1,
+        "bg": "grey-20"
+      },
+      "copy": {
+        "mb": ["md", "sm", null],
+        "mt": "base"
+      },
+      "accept-all-button": {
+        "variant": "buttons.variants.primary"
+      },
+      "save-preferences-button": {
+        "variant": "buttons.variants.secondary"
+      },
+      "button-with-checkbox": {
+        "border": "2px solid",
+        "borderColor": "borderColor",
+        "backgroundColor": "white"
+      }
     }
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -369,7 +369,7 @@
 
     "cookie-banner": {
       "heading": {
-        "mt": [0, "md", "md"], 
+        "mt": [0, "md", "md"]
       },
       "hr": {
         "border": 0,
@@ -384,7 +384,7 @@
         "variant": "buttons.variants.primary"
       },
       "save-preferences-button": {
-        "variant": "buttons.variants.reversed"
+        "variant": "buttons.variants.inverse"
       },
       "button-with-checkbox": {
         "border": "2px solid",
@@ -393,7 +393,7 @@
       },
       "button-with-checkbox-checked": {
         "variant": "compounds.cookie-banner.button-with-checkbox",
-        "borderColor": "uswitch-navy",
+        "borderColor": "uswitch-navy"
       }
     }
   },

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -509,6 +509,24 @@
         ":visited": {
           "color": "white"
         }
+      },
+      "inverse": {
+        "variant": "buttons.base",
+        "color": "uswitch-navy",
+        "backgroundColor": "white",
+        "border": "2px solid",
+        "borderColor": "uswitch-navy",
+        ":hover": {
+          "backgroundColor": "grey-100"
+        },
+        ":disabled": {
+          "borderColor": "grey-60",
+          "color": "grey-60",
+          "cursor": "not-allowed"
+        },
+        ":visited": {
+          "color": "uswitch-navy"
+        }
       }
     }
   },


### PR DESCRIPTION
# Description

Add theming for the cookie banner (found in https://github.com/uswitch/recharge-mewtru)

# Checklist

Pull request contains:

- [x] A new component (theme only)
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
