### PR TITLE
Revert breaking change to badge component

### DIFF
--- a/src/compounds/ad-banner/package.json
+++ b/src/compounds/ad-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.ad-banner",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -19,6 +19,6 @@
   "dependencies": {
     "@uswitch/trustyle.badge": "*",
     "@uswitch/trustyle.button-link": "*",
-    "@uswitch/trustyle.imgix-image": "^0.1.33"
+    "@uswitch/trustyle.imgix-image": "^0.1.34"
   }
 }

--- a/src/compounds/ad-banner/src/index.tsx
+++ b/src/compounds/ad-banner/src/index.tsx
@@ -92,8 +92,16 @@ const AdBanner: React.FC<Props> = ({
           }}
         >
           <Badge variant={badgeVariant}>
-            {badgeIcon}
-            {label}
+            <div
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center'
+              }}
+            >
+              {badgeIcon}
+              {label}
+            </div>
           </Badge>
         </div>
         <div

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/card/package.json
+++ b/src/elements/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.card",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle.flex-grid": "^0.2.0",
-    "@uswitch/trustyle.imgix-image": "^0.1.33"
+    "@uswitch/trustyle.imgix-image": "^0.1.34"
   }
 }

--- a/src/elements/imgix-image/package.json
+++ b/src/elements/imgix-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.imgix-image",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -554,9 +554,6 @@
 
   "badge" : {
     "base": {
-      "display": "flex",
-      "flexDirection": "row",
-      "alignItems": "center",
       "paddingX": [14, 23],
       "paddingY": [3, 7],
       "fontSize": "xs",


### PR DESCRIPTION
# Description

The display flex change wasn't applied in all themes and broke the current usages of the component as it changed the default width.

Better for this to be done where the component is used!

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
