### PR TITLE
Remove lazyload from imgix

### DIFF
--- a/src/compounds/ad-banner/package.json
+++ b/src/compounds/ad-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.ad-banner",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -19,6 +19,6 @@
   "dependencies": {
     "@uswitch/trustyle.badge": "*",
     "@uswitch/trustyle.button-link": "*",
-    "@uswitch/trustyle.imgix-image": "^0.1.32"
+    "@uswitch/trustyle.imgix-image": "^0.1.33"
   }
 }

--- a/src/compounds/ad-banner/src/index.tsx
+++ b/src/compounds/ad-banner/src/index.tsx
@@ -21,6 +21,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   href: string
   badgeIcon?: React.ReactElement
   badgeVariant?: string
+  imageCritical?: boolean
 }
 
 const AdBanner: React.FC<Props> = ({
@@ -37,7 +38,8 @@ const AdBanner: React.FC<Props> = ({
   additionalImageTag = '',
   href,
   badgeIcon,
-  badgeVariant = 'inverse'
+  badgeVariant = 'inverse',
+  imageCritical = true
 }) => {
   return (
     <div
@@ -114,6 +116,7 @@ const AdBanner: React.FC<Props> = ({
               imgixParams={{
                 fit: 'fillmax'
               }}
+              critical={imageCritical}
             />
           </div>
           <div>
@@ -128,6 +131,7 @@ const AdBanner: React.FC<Props> = ({
               imgixParams={{
                 fit: 'fillmax'
               }}
+              critical={imageCritical}
             />
           </div>
         </div>

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/card/package.json
+++ b/src/elements/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.card",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle.flex-grid": "^0.2.0",
-    "@uswitch/trustyle.imgix-image": "^0.1.32"
+    "@uswitch/trustyle.imgix-image": "^0.1.33"
   }
 }

--- a/src/elements/imgix-image/package.json
+++ b/src/elements/imgix-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.imgix-image",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.27",
     "@types/react-imgix": "^9.0.2",
-    "react": "^16.7.0",
-    "lazysizes": "^4.1.5"
+    "lazysizes": "^4.1.5",
+    "react": "^16.7.0"
   }
 }

--- a/src/elements/imgix-image/package.json
+++ b/src/elements/imgix-image/package.json
@@ -13,7 +13,6 @@
     "build": "npm run clean && tsc"
   },
   "dependencies": {
-    "lazysizes": "^4.1.5",
     "react-imgix": "^8.6.1"
   },
   "devDependencies": {
@@ -22,6 +21,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.27",
     "@types/react-imgix": "^9.0.2",
-    "react": "^16.7.0"
+    "react": "^16.7.0",
+    "lazysizes": "^4.1.5"
   }
 }

--- a/src/elements/imgix-image/src/index.tsx
+++ b/src/elements/imgix-image/src/index.tsx
@@ -3,13 +3,14 @@
 import * as React from 'react'
 import Imgix, { SharedImigixAndSourceProps } from 'react-imgix'
 import { css, jsx } from '@emotion/core'
-import 'lazysizes'
 
 interface Props extends SharedImigixAndSourceProps {
   alt?: string
   critical?: boolean
   className?: string
 }
+
+// lazysizes needed if you require lazyloading
 
 const Image: React.FC<Props> = ({
   alt,


### PR DESCRIPTION
# Description
Lazyload shouldn't be a dependency on imgix component but instead on User. 

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [X] If component change, version updated
