### PR TITLE
Added number for input type

### DIFF
--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -9,7 +9,7 @@ import debounce from 'lodash.debounce'
 
 import * as st from './styles'
 
-export type InputType = 'text' | 'email' | 'tel' | 'password'
+export type InputType = 'text' | 'email' | 'tel' | 'password' | 'number'
 export type Width = 'half' | 'full'
 
 export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {


### PR DESCRIPTION
# Description

Right now Energy Journey is using `tel` as the input type for spend and energy consumption but `number` would be better suited.
For this I've added the `number` type to the possible input types.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated