### PR TITLE
# Input type again

### DIFF
--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "0.3.55",
+  "version": "0.3.56",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -9,6 +9,7 @@ import debounce from 'lodash.debounce'
 
 import * as st from './styles'
 
+export type InputType = 'text' | 'email' | 'tel' | 'password' | 'number'
 export type Width = 'half' | 'full'
 
 export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {


### PR DESCRIPTION
it seem in Energy Journey Props are only used for a Number input that's used for mpan, mprn, consumption and spend while the InputType is used for another text-input component-element.
In order not to break this dependency it's better to add the type back, even if it is lacking from the Props.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [x] If component change, version updated