### PR TITLE
Add customRows prop to override how many rows cells in a split take up

### DIFF
--- a/src/compounds/product-table/README.md
+++ b/src/compounds/product-table/README.md
@@ -131,6 +131,18 @@ import { CellContext } from '@uswitch/trustyle.product-table'
 const { inSplit } = React.useContext(CellContext)
 ```
 
+You can also override how many rows the children in a split cell take up using
+the `customRows` prop - by default they take up an even number of rows:
+
+```js
+<ProductTable.cells.Split customRows={[2, 4]}>
+  <ProductTable.cells.Content label="Average speed">
+    30Mbps
+  </ProductTable.cells.Content>
+  <ProductTable.cells.Content label="Contract">18 months</ProductTable.cells.Content>
+</ProductTable.cells.Split>
+```
+
 ### Writing your own cell
 
 In addition to the cells available under `ProductTable.cells`, you can also

--- a/src/compounds/product-table/src/components/cell-split.tsx
+++ b/src/compounds/product-table/src/components/cell-split.tsx
@@ -7,12 +7,12 @@ import { CellContext } from '../generics'
 // Needs to be the lowest common factor of all the split counts
 export const ROWS = 6
 
-interface Props extends React.HTMLAttributes<any> {
+export interface CellSplitProps extends React.HTMLAttributes<any> {
   // customRows allows us to override the default row span of split components
   customRows?: number[]
 }
 
-const ProductTableCellSplit: React.FC<Props> = ({
+const ProductTableCellSplit: React.FC<CellSplitProps> = ({
   customRows = [],
   children
 }) => {

--- a/src/compounds/product-table/src/components/cell-split.tsx
+++ b/src/compounds/product-table/src/components/cell-split.tsx
@@ -7,30 +7,59 @@ import { CellContext } from '../generics'
 // Needs to be the lowest common factor of all the split counts
 export const ROWS = 6
 
-const ProductTableCellSplit: React.FC<React.HTMLAttributes<any>> = ({
+interface Props extends React.HTMLAttributes<any> {
+  // customRows allows us to override the default row span of split components
+  customRows?: number[]
+}
+
+const ProductTableCellSplit: React.FC<Props> = ({
+  customRows = [],
   children
 }) => {
   const { gridColumnStart, gridColumnSpan } = React.useContext(CellContext)
 
   const nonNullChildren = React.Children.toArray(children).filter(c => c)
   const rowsHeight = ROWS / nonNullChildren.length
+
+  // Ensure customRows is valid before using
+  const customRowsAvailable =
+    customRows.length === nonNullChildren.length &&
+    customRows.reduce((acc, curr) => acc + curr) === ROWS
+
   return (
     <React.Fragment>
-      {nonNullChildren.map((child, index) => (
-        <CellContext.Provider
-          value={{
-            gridColumnStart,
-            gridColumnSpan,
-            gridRowStart: 4 + index * rowsHeight,
-            gridRowSpan: rowsHeight,
-            firstInSplit: index === 0,
-            inSplit: true
-          }}
-          key={index}
-        >
-          {child}
-        </CellContext.Provider>
-      ))}
+      {
+        nonNullChildren.reduce<{
+          children: React.ReactElement[]
+          rowStart: number
+        }>(
+          ({ children, rowStart }, child, index) => {
+            const span = customRowsAvailable ? customRows[index] : rowsHeight
+            return {
+              children: children.concat(
+                <CellContext.Provider
+                  value={{
+                    gridColumnStart,
+                    gridColumnSpan,
+                    gridRowStart: rowStart,
+                    gridRowSpan: span,
+                    firstInSplit: index === 0,
+                    inSplit: true
+                  }}
+                  key={index}
+                >
+                  {child}
+                </CellContext.Provider>
+              ),
+              rowStart: rowStart + span
+            }
+          },
+          {
+            children: [],
+            rowStart: 4
+          }
+        ).children
+      }
     </React.Fragment>
   )
 }

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -195,19 +195,16 @@ export const Example1 = () => {
       rowTitle="Santander Standard Loan (Online)"
       subtitle="Personal Loan"
     >
-      <ProductTable.cells.Image>
-        <img
-          src="https://placekitten.com/200/75?image=9"
-          alt="Salman"
-          sx={{ height: 75, width: '100%', objectFit: 'cover' }}
-        />
-      </ProductTable.cells.Image>
       <ProductTable.cells.Split>
         <ProductTable.cells.Placeholder />
         <ProductTable.cells.Placeholder />
         <ProductTable.cells.Placeholder />
       </ProductTable.cells.Split>
       <ProductTable.cells.Split>
+        <ProductTable.cells.Placeholder />
+        <ProductTable.cells.Placeholder />
+      </ProductTable.cells.Split>
+      <ProductTable.cells.Split customRows={[4, 2]}>
         <ProductTable.cells.Placeholder />
         <ProductTable.cells.Placeholder />
       </ProductTable.cells.Split>


### PR DESCRIPTION
# Description

Required for layouts like this:

![image](https://user-images.githubusercontent.com/472830/78675763-6d97ec80-78dd-11ea-9d51-efbbb20524d3.png)

Please don't merge - it's not pointing at master :)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
