### PR TITLE
Extract button group component from eevee

### DIFF
--- a/src/elements/button-group/.npmignore
+++ b/src/elements/button-group/.npmignore
@@ -1,0 +1,6 @@
+**/*
+
+!lib/*
+!package.json
+!README.md
+!LICENSE

--- a/src/elements/button-group/.npmrc
+++ b/src/elements/button-group/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/src/elements/button-group/package.json
+++ b/src/elements/button-group/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@uswitch/trustyle.button-group",
+  "version": "0.0.0",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "ts:main": "src/index.tsx",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "--------------- BUILDING": "----------------------",
+    "clean": "rm -rf lib",
+    "build": "npm run clean && tsc"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.0.27",
+    "react": "^16.7.0"
+  }
+}

--- a/src/elements/button-group/src/index.tsx
+++ b/src/elements/button-group/src/index.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+const ButtonGroup: React.FC = ({ children }) => {
+  const spacedChildren = React.Children.map(children, child => {
+    if (!React.isValidElement(child)) {
+      return child
+    }
+
+    return <div sx={{ marginBottom: 'sm', marginLeft: 'sm' }}>{child}</div>
+  })
+
+  return (
+    <div
+      sx={(theme: any) => ({
+        display: ['block', 'inline-flex'],
+        flexDirection: 'row-reverse',
+        marginLeft: -theme.space.sm,
+        marginBottom: -theme.space.sm
+      })}
+    >
+      {spacedChildren}
+    </div>
+  )
+}
+
+export default ButtonGroup

--- a/src/elements/button-group/src/stories.tsx
+++ b/src/elements/button-group/src/stories.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+import { Button } from '../../button/src'
+import { ButtonLink } from '../../button-link/src'
+
+import ButtonGroup from './'
+
+export default {
+  title: 'Elements|Button Group'
+}
+
+export const Example = () => {
+  return (
+    <ButtonGroup>
+      <Button variant="primary">Primary button</Button>
+      <ButtonLink variant="secondary">Secondary button link</ButtonLink>
+    </ButtonGroup>
+  )
+}

--- a/src/elements/button-group/tsconfig.json
+++ b/src/elements/button-group/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "include": ["./src/index.tsx"]
+}


### PR DESCRIPTION
# Description

Exactly the same behaviour as in Eevee. The intention is that the collectable button component will use this - there won't be a new model in Contentful (for now, at least).

# Checklist

Pull request contains:

- [x] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
