### PR TITLE
Add wildcard support to flex-grid's LayoutFromJson component

### DIFF
--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -23,7 +23,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.icon": "^1.0.2",
     "@uswitch/trustyle.imgix-image": "^0.1.34",
-    "@uswitch/trustyle.primary-info-block": "^0.2.7",
+    "@uswitch/trustyle.primary-info-block": "^0.2.8",
     "@uswitch/trustyle.sponsored-by-tag": "^0.0.3",
     "@uswitch/trustyle.usp-tag": "^0.0.3"
   }

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -25,7 +25,7 @@
     "@uswitch/trustyle.grid": "^2.0.2",
     "@uswitch/trustyle.icon": "^1.0.0",
     "@uswitch/trustyle.imgix-image": "^0.1.31",
-    "@uswitch/trustyle.primary-info-block": "^0.2.7",
+    "@uswitch/trustyle.primary-info-block": "^0.2.8",
     "@uswitch/trustyle.sponsored-by-tag": "^0.0.3",
     "@uswitch/trustyle.usp-tag": "^0.0.3"
   }

--- a/src/elements/card/package.json
+++ b/src/elements/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.card",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {
@@ -16,7 +16,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.flex-grid": "^2.1.1",
+    "@uswitch/trustyle.flex-grid": "^2.2.0",
     "@uswitch/trustyle.imgix-image": "^0.1.34"
   }
 }

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,6 +20,6 @@
     "@uswitch/trustyle.breadcrumbs": "^1.0.6"
   },
   "dependencies": {
-    "@uswitch/trustyle.flex-grid": "^2.1.1"
+    "@uswitch/trustyle.flex-grid": "^2.2.0"
   }
 }

--- a/src/elements/primary-info-block/package.json
+++ b/src/elements/primary-info-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.primary-info-block",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/layout/flex-grid/package.json
+++ b/src/layout/flex-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.flex-grid",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/layout/flex-grid/src/index.tsx
+++ b/src/layout/flex-grid/src/index.tsx
@@ -228,7 +228,9 @@ export const GridFromJson: React.FC<FromJsonProps> = ({
 
   // In the future, string key could be support for contentful block ID
   let autoKey = 0
-  const getChildFromKey = (key?: number): React.ReactNode => {
+  const getChildFromKey = (
+    key?: number
+  ): { id: any; component: React.ReactNode } => {
     // If no key, search for the next key that isn't already used
     if (typeof key === 'undefined') {
       while (usedKeys.includes(autoKey)) {

--- a/src/layout/flex-grid/src/stories.tsx
+++ b/src/layout/flex-grid/src/stories.tsx
@@ -296,41 +296,41 @@ storiesOf('Layout|Flex Grid', module).add(
   }
 )
 
-/* storiesOf('Layout|Flex Grid', module).add( */
-/*   'Grid layout from JSON with wildcard', */
-/*   () => { */
-/*     const gridJson = [ */
-/*       { layout: [{ key: 0, span: 12 }] }, */
-/*       { direction: 'row', layout: [{ key: '*', span: [12, 6, 4] }] }, */
-/*       { layout: [{ key: 1, span: 12 }] } */
-/*     ] */
+storiesOf('Layout|Flex Grid', module).add(
+  'Grid layout from JSON with wildcard',
+  () => {
+    const gridJson = [
+      { layout: [{ key: 0, span: 12 }] },
+      { direction: 'row', layout: [{ key: '*', span: [6, 3] }] },
+      { layout: [{ key: 1, span: 12 }] }
+    ]
 
-/*     return ( */
-/*       <Container> */
-/*         <GridFromJson */
-/*           json={gridJson} */
-/*           childrenArray={[ */
-/*             <span sx={colStyling} key={1}> */
-/*               Cell 1 */
-/*             </span>, */
-/*             <span sx={colStyling} key={2}> */
-/*               Cell 2 */
-/*             </span>, */
-/*             <span sx={colStyling} key={3}> */
-/*               Cell 3 */
-/*             </span>, */
-/*             <span sx={colStyling} key={4}> */
-/*               Cell 4 */
-/*             </span>, */
-/*             <span sx={colStyling} key={5}> */
-/*               Cell 5 */
-/*             </span>, */
-/*             <span sx={colStyling} key={6}> */
-/*               Cell 6 */
-/*             </span> */
-/*           ]} */
-/*         /> */
-/*       </Container> */
-/*     ) */
-/*   } */
-/* ) */
+    return (
+      <Container>
+        <GridFromJson
+          json={gridJson}
+          childrenArray={[
+            <span sx={colStyling} key={1}>
+              Header
+            </span>,
+            <span sx={colStyling} key={2}>
+              Footer
+            </span>,
+            <span sx={colStyling} key={3}>
+              Wildcard cell 1
+            </span>,
+            <span sx={colStyling} key={4}>
+              Wildcard cell 2
+            </span>,
+            <span sx={colStyling} key={5}>
+              Wildcard cell 3
+            </span>,
+            <span sx={colStyling} key={6}>
+              Wildcard cell 4
+            </span>
+          ]}
+        />
+      </Container>
+    )
+  }
+)

--- a/src/layout/flex-grid/src/stories.tsx
+++ b/src/layout/flex-grid/src/stories.tsx
@@ -227,25 +227,110 @@ storiesOf('Layout|Flex Grid', module).add('Grid layout from JSON', () => {
         json={gridJson}
         childrenArray={[
           <span sx={colStyling} key={1}>
-            Col 1
+            Cell 1
           </span>,
           <span sx={colStyling} key={2}>
-            Col 2
+            Cell 2
           </span>,
           <span sx={colStyling} key={3}>
-            Col 3
+            Cell 3
           </span>,
           <span sx={colStyling} key={4}>
-            Col 4
+            Cell 4
           </span>,
           <span sx={colStyling} key={5}>
-            Col 5
+            Cell 5
           </span>,
           <span sx={colStyling} key={6}>
-            Col 6
+            Cell 6
           </span>
         ]}
       />
     </Container>
   )
 })
+
+storiesOf('Layout|Flex Grid', module).add(
+  'Grid layout from JSON without keys',
+  () => {
+    const gridJson = [
+      {
+        direction: 'row',
+        layout: [{ span: [12, 4] }, { span: [6, 4] }, { span: [6, 4] }]
+      },
+      {
+        layout: [{ span: 12 }]
+      },
+      {
+        direction: 'row',
+        layout: [{ span: [12, 6] }, { span: [12, 6] }]
+      }
+    ]
+    return (
+      <Container>
+        <GridFromJson
+          json={gridJson}
+          childrenArray={[
+            <span sx={colStyling} key={1}>
+              Cell 1
+            </span>,
+            <span sx={colStyling} key={2}>
+              Cell 2
+            </span>,
+            <span sx={colStyling} key={3}>
+              Cell 3
+            </span>,
+            <span sx={colStyling} key={4}>
+              Cell 4
+            </span>,
+            <span sx={colStyling} key={5}>
+              Cell 5
+            </span>,
+            <span sx={colStyling} key={6}>
+              Cell 6
+            </span>
+          ]}
+        />
+      </Container>
+    )
+  }
+)
+
+/* storiesOf('Layout|Flex Grid', module).add( */
+/*   'Grid layout from JSON with wildcard', */
+/*   () => { */
+/*     const gridJson = [ */
+/*       { layout: [{ key: 0, span: 12 }] }, */
+/*       { direction: 'row', layout: [{ key: '*', span: [12, 6, 4] }] }, */
+/*       { layout: [{ key: 1, span: 12 }] } */
+/*     ] */
+
+/*     return ( */
+/*       <Container> */
+/*         <GridFromJson */
+/*           json={gridJson} */
+/*           childrenArray={[ */
+/*             <span sx={colStyling} key={1}> */
+/*               Cell 1 */
+/*             </span>, */
+/*             <span sx={colStyling} key={2}> */
+/*               Cell 2 */
+/*             </span>, */
+/*             <span sx={colStyling} key={3}> */
+/*               Cell 3 */
+/*             </span>, */
+/*             <span sx={colStyling} key={4}> */
+/*               Cell 4 */
+/*             </span>, */
+/*             <span sx={colStyling} key={5}> */
+/*               Cell 5 */
+/*             </span>, */
+/*             <span sx={colStyling} key={6}> */
+/*               Cell 6 */
+/*             </span> */
+/*           ]} */
+/*         /> */
+/*       </Container> */
+/*     ) */
+/*   } */
+/* ) */


### PR DESCRIPTION
# Description

This will come in handy in places like the collection component where the layout doesn't know how many children it is going to be receiving.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
