### PR TITLE
Revert fonts

### DIFF
--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -14,8 +14,8 @@
   },
 
   "fonts": {
-    "base": "'Helvetica Now Text', -apple-system, sans-serif",
-    "heading": "'Helvetica Now Display', -apple-system, sans-serif",
+    "base": "-apple-system, sans-serif",
+    "heading": "-apple-system, sans-serif",
     "monospace": "Menlo, monospace"
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -14,8 +14,8 @@
   },
 
   "fonts": {
-    "base": "-apple-system, sans-serif",
-    "heading": "-apple-system, sans-serif",
+    "base": "'Helvetica Now Text', -apple-system, sans-serif",
+    "heading": "'Helvetica Now Display', -apple-system, sans-serif",
     "monospace": "Menlo, monospace"
   },
 


### PR DESCRIPTION
# Description

Removed Helvetica Now fonts from uswitch theme as still waiting for sign off on webfont license. Incident to be raised.

# Checklist

Pull request contains:

- [ ] A new component
- [ x ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
