### PR TITLE
Usp color fixes

### DIFF
--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -25,6 +25,6 @@
     "@uswitch/trustyle.imgix-image": "^0.1.34",
     "@uswitch/trustyle.primary-info-block": "^0.2.8",
     "@uswitch/trustyle.sponsored-by-tag": "^0.0.3",
-    "@uswitch/trustyle.usp-tag": "^0.0.4"
+    "@uswitch/trustyle.usp-tag": "^0.0.5"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/src/index.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/index.tsx
@@ -131,7 +131,7 @@ const AwardBadge = ({ awardName }: { awardName: string }) => (
         letterSpacing: -0.5,
         fontSize: 9,
         marginLeft: 'xxs',
-        fontFamily: "'-apple-system', 'BlinkMacSystemFont'"
+        fontFamily: 'base'
       }}
     >
       {awardName}

--- a/src/compounds/sponsored-product-rate-table/src/index.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/index.tsx
@@ -154,7 +154,15 @@ const SponsoredRateTable: React.FC<Props> = ({
   campaignImgSrc,
   campaignImgHeight = '144px'
 }) => (
-  <a href={href} target={target} sx={{ textDecoration: 'none' }}>
+  <a
+    href={href}
+    target={target}
+    sx={{
+      textDecoration: 'none',
+      color: 'inherit',
+      '&:hover': { color: 'inherit' }
+    }}
+  >
     <div
       sx={{
         borderWidth: 1,

--- a/src/compounds/sponsored-product-rate-table/src/index.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/index.tsx
@@ -18,6 +18,8 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   productImgAlt: string
   informationDetails: Detail[]
   usps: string[]
+  uspBackgroundColor?: string
+  uspBeforeColor?: string
   href: string
   target: string
   sponsorLogoSrc: string
@@ -71,12 +73,19 @@ const ProductImage = ({ src, alt }: { src: string; alt: string }) => (
 
 interface UspTagsProps {
   usps: string[]
+  uspColor: string
+  beforeColor: string
 }
 
-const UspTags: React.FC<UspTagsProps> = ({ usps }) => (
+const UspTags: React.FC<UspTagsProps> = ({ usps, uspColor, beforeColor }) => (
   <React.Fragment>
     {usps.map((obj, index) => (
-      <UspTag usp={obj} key={`infoblock-${index}`} />
+      <UspTag
+        usp={obj}
+        backgroundColor={uspColor}
+        beforeColor={beforeColor}
+        key={`infoblock-${index}`}
+      />
     ))}
   </React.Fragment>
 )
@@ -136,6 +145,8 @@ const SponsoredRateTable: React.FC<Props> = ({
   productImgAlt,
   informationDetails,
   usps,
+  uspBackgroundColor = 'rgba(132,166,255,0.3)',
+  uspBeforeColor = '#84A6FF',
   href,
   target,
   sponsorLogoSrc,
@@ -255,7 +266,13 @@ const SponsoredRateTable: React.FC<Props> = ({
             <InformationBlocks details={informationDetails} />
           </div>
 
-          {usps && <UspTags usps={usps} />}
+          {usps && (
+            <UspTags
+              usps={usps}
+              uspColor={uspBackgroundColor}
+              beforeColor={uspBeforeColor}
+            />
+          )}
 
           <AwardsTag award={award} sx={{ display: [null, 'none'] }} />
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -27,6 +27,6 @@
     "@uswitch/trustyle.imgix-image": "^0.1.31",
     "@uswitch/trustyle.primary-info-block": "^0.2.8",
     "@uswitch/trustyle.sponsored-by-tag": "^0.0.3",
-    "@uswitch/trustyle.usp-tag": "^0.0.4"
+    "@uswitch/trustyle.usp-tag": "^0.0.5"
   }
 }

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -19,6 +19,8 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   imgAlt: string
   informationDetails?: Detail[]
   usps?: string[]
+  uspBackgroundColor?: string
+  uspBeforeColor?: string
   href: string
   target: string
   sponsorSrc: string
@@ -57,12 +59,19 @@ const InformationBlocks: React.FC<InformationBlocksProps> = ({ details }) => (
 
 interface UspTagsProps {
   usps: string[]
+  uspColor: string
+  beforeColor: string
 }
 
-const UspTags: React.FC<UspTagsProps> = ({ usps }) => (
+const UspTags: React.FC<UspTagsProps> = ({ usps, uspColor, beforeColor }) => (
   <React.Fragment>
     {usps.map((obj, index) => (
-      <UspTag usp={obj} key={`infoblock-${index}`} />
+      <UspTag
+        usp={obj}
+        backgroundColor={uspColor}
+        beforeColor={beforeColor}
+        key={`infoblock-${index}`}
+      />
     ))}
   </React.Fragment>
 )
@@ -135,6 +144,8 @@ const SponsoredProduct: React.FC<Props> = ({
   imgAlt,
   informationDetails,
   usps,
+  uspBackgroundColor = 'rgba(132,166,255,0.3)',
+  uspBeforeColor = '#84A6FF',
   href,
   target,
   sponsorSrc,
@@ -342,7 +353,13 @@ const SponsoredProduct: React.FC<Props> = ({
               </div>
             )}
 
-            {usps && <UspTags usps={usps} />}
+            {usps && (
+              <UspTags
+                usps={usps}
+                uspColor={uspBackgroundColor}
+                beforeColor={uspBeforeColor}
+              />
+            )}
           </Stack>
 
           <div sx={{ display: ['block', 'none'] }}>

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -70,7 +70,7 @@ const UspTags: React.FC<UspTagsProps> = ({ usps, uspColor, beforeColor }) => (
         usp={obj}
         backgroundColor={uspColor}
         beforeColor={beforeColor}
-        key={`infoblock-${index}`}
+        key={index}
       />
     ))}
   </React.Fragment>

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -50,7 +50,7 @@ const InformationBlocks: React.FC<InformationBlocksProps> = ({ details }) => (
         value={obj.value}
         suffix={obj.suffix}
         label={obj.label}
-        key={`infoblock-${index}`}
+        key={index}
         sx={{ padding: [null, 'xs'] }}
       />
     ))}
@@ -136,7 +136,7 @@ const EnhancedImage = ({ src, height }: { src: string; height: string }) => (
 )
 
 const topComponentMargin = (productSrc: string, enhancedSrc: string) =>
-  productSrc && !enhancedSrc ? '38px' : null
+  productSrc && !enhancedSrc ? ['38px', 0] : null
 
 const SponsoredProduct: React.FC<Props> = ({
   title,
@@ -158,7 +158,7 @@ const SponsoredProduct: React.FC<Props> = ({
   <a href={href} target={target} sx={{ textDecoration: 'none' }}>
     <div
       sx={{
-        borderWidth: [1, 'none'],
+        borderWidth: [1, 0],
         borderStyle: ['solid', 'none'],
         borderColor: ['grey-30', 'none'],
         marginTop: () => topComponentMargin(imgSrc, enhancedImgSrc)
@@ -180,9 +180,6 @@ const SponsoredProduct: React.FC<Props> = ({
           padding: [12, 'sm'],
           display: [null, 'flex'],
           justifyContent: [null, 'space-between'],
-          borderWidth: ['none', 1],
-          borderStyle: ['none', 'solid'],
-          borderColor: ['none', 'grey-30'],
           boxShadow: ['none', '12px 12px 0px rgba(20, 20, 36, 0.15)'],
           backgroundColor: backgroundColor
         }}

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -155,7 +155,15 @@ const SponsoredProduct: React.FC<Props> = ({
   backgroundColor = 'white',
   enhancedImgHeight = '144px'
 }) => (
-  <a href={href} target={target} sx={{ textDecoration: 'none' }}>
+  <a
+    href={href}
+    target={target}
+    sx={{
+      textDecoration: 'none',
+      color: 'inherit',
+      '&:hover': { color: 'inherit' }
+    }}
+  >
     <div
       sx={{
         borderWidth: [1, 0],

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -274,7 +274,7 @@ const SponsoredProduct: React.FC<Props> = ({
                   letterSpacing: -0.5,
                   fontSize: 9,
                   marginLeft: 'xxs',
-                  fontFamily: "'-apple-system', 'BlinkMacSystemFont'"
+                  fontFamily: 'base'
                 }}
               >
                 {award}

--- a/src/elements/usp-tag/package.json
+++ b/src/elements/usp-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.usp-tag",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/usp-tag/src/index.tsx
+++ b/src/elements/usp-tag/src/index.tsx
@@ -32,7 +32,7 @@ const UspTag: React.FC<Props> = ({
     >
       <span
         sx={{
-          fontFamily: "'-apple-system', 'BlinkMacSystemFont'",
+          fontFamily: 'base',
           fontWeight: 'bold',
           fontSize: 'xs',
           color: 'grey-80',

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -14,8 +14,8 @@
   },
 
   "fonts": {
-    "base": "-apple-system, sans-serif",
-    "heading": "-apple-system, sans-serif",
+    "base": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Arial, sans-serif",
+    "heading": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Arial, sans-serif",
     "monospace": "Menlo, monospace"
   },
 


### PR DESCRIPTION
# Description

Make usp color an optional prop on sponsored product so that can be changed within external projects. Added all system fonts to uswitch theme and made usp tag element use theme fonts. 

# Checklist

Pull request contains:

- [ ] A new component
- [ x ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
