### PR TITLE
Update numberFormatter to accept null as a unit

### DIFF
--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "1.3.3-alpha.0",
+  "version": "1.3.3-alpha.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/data-value.tsx
+++ b/src/compounds/product-table/src/components/data-value.tsx
@@ -19,7 +19,7 @@ const ProductTableDataValue: React.FC<DataValueProps> = ({
     <span>
       {numberFormatter(value, unit)}
       {typeof value === 'number' && subscript ? (
-        <small>{' ' + subscript}</small>
+        <small>{` ${subscript}`}</small>
       ) : null}
     </span>
   )

--- a/src/compounds/product-table/src/generics.ts
+++ b/src/compounds/product-table/src/generics.ts
@@ -76,8 +76,9 @@ export function numberFormatter(value: number | string, unit: string): string {
     return value
   }
 
-  const formatter = unit.split(' ').join('-')
+  const unitValue = unit || ''
+  const formatter = unitValue.split(' ').join('-')
   return formatters[formatter]
     ? formatters[formatter](value)
-    : `${value} ${unit}`
+    : `${value} ${unitValue}`.trim()
 }

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -397,6 +397,9 @@ export const ExampleWithNumberFormatters = () => {
             subscript="setup cost"
           />
         </ProductTable.cells.Content>
+        <ProductTable.cells.Content label="No formatter" accent>
+          <ProductTable.data.Value value={1000} unit={null} subscript="" />
+        </ProductTable.cells.Content>
       </ProductTable.Row>
     </React.Fragment>
   )


### PR DESCRIPTION
# Description

Fix the `numberFormatter` generic function to accept `null` as a unit.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
