### PR TITLE
Update product table styling

### DIFF
--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "1.3.4-alpha.0",
+  "version": "1.3.4-alpha.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "1.3.3-alpha.1",
+  "version": "1.3.4-alpha.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/cell-base.tsx
+++ b/src/compounds/product-table/src/components/cell-base.tsx
@@ -81,7 +81,9 @@ const ProductTableCellBase: React.FC<CellBaseProps> = ({
     >
       <div
         sx={{
-          flex: 1,
+          flexGrow: 1,
+          flexShrink: 1,
+          flexBasis: 'auto',
           height: '100%',
           boxSizing: 'border-box'
         }}

--- a/src/compounds/product-table/src/components/cell-content.tsx
+++ b/src/compounds/product-table/src/components/cell-content.tsx
@@ -23,64 +23,130 @@ export interface CellPrimaryProps extends React.HTMLAttributes<HTMLDivElement> {
   accent?: boolean
   mobileOrder?: number
 }
-const ProductTableCellContent: React.FC<CellPrimaryProps> = ({
+
+export interface ContentRowProps extends CellPrimaryProps {
+  inAddon: string | boolean
+}
+
+const RowContent: React.FC<ContentRowProps> = ({
+  accent,
+  children,
+  inAddon,
   label,
-  accent = false,
+  mobileOrder
+}) => (
+  <CellBase
+    mobileOrder={mobileOrder || (accent ? 1 : 2)}
+    sx={{
+      height: 'auto',
+      display: 'grid',
+      alignItems: 'center',
+      gridGap: 'sm',
+      gridTemplateColumns: 'auto auto',
+      msGridColumns: 'auto auto',
+      gridTemplateRows: '100%',
+      msGridRows: '100%',
+      variant: `productTable.cellContent.variants.inSplit.${
+        accent ? 'accent' : 'main'
+      }`
+    }}
+    // @ts-ignore
+    css={{ display: '-ms-grid' }}
+  >
+    <div
+      sx={{
+        display: inAddon ? [undefined, 'none'] : undefined,
+        ...grid('column', 1, 1),
+        ...grid('row', 1, 1),
+        fontSize: 'xs',
+        marginTop: '',
+        variant: 'productTable.cellContent.variants.inSplit.label'
+      }}
+    >
+      {label}
+    </div>
+    <div
+      sx={{
+        ...grid('column', 2, 1),
+        ...grid('row', 1, 1),
+        fontSize: 'sm',
+        textAlign: 'right',
+        small: {
+          fontSize: 'sm'
+        },
+        variant: 'productTable.cellContent.variants.inSplit.content'
+      }}
+    >
+      {children}
+    </div>
+  </CellBase>
+)
+
+const BlockContent: React.FC<CellPrimaryProps> = ({
+  label,
+  accent,
   mobileOrder,
   children
+}) => (
+  <CellBase
+    mobileOrder={mobileOrder || (accent ? 1 : 2)}
+    sx={{
+      height: 'auto',
+      display: 'grid',
+      alignItems: 'center',
+      gridTemplateColumns: '100%',
+      msGridColumns: '100%',
+      gridTemplateRows: 'auto auto',
+      msGridRows: 'auto auto',
+      padding: accent ? 'sm' : '',
+      variant: `productTable.cellContent.${accent ? 'accent' : 'main'}`
+    }}
+    // @ts-ignore
+    css={{ display: '-ms-grid' }}
+  >
+    <div
+      sx={{
+        ...grid('column', 1, 1),
+        ...grid('row', 2, 1),
+        fontSize: 'xs',
+        marginTop: 'sm',
+        variant: 'productTable.cellContent.label'
+      }}
+    >
+      {label}
+    </div>
+    <div
+      sx={{
+        ...grid('column', 1, 1),
+        ...grid('row', 1, 1),
+        fontSize: 'xxxl',
+        small: {
+          fontSize: 'sm'
+        },
+        variant: 'productTable.cellContent.content'
+      }}
+    >
+      {children}
+    </div>
+  </CellBase>
+)
+
+const ProductTableCellContent: React.FC<CellPrimaryProps> = ({
+  children,
+  ...props
 }) => {
   const { inSplit } = React.useContext(CellContext)
   const { inAddon } = React.useContext(AddonContext)
 
-  const isRow = inSplit || inAddon
-
-  const rows =
-    inAddon && inAddon !== 'body-responsive' ? 'auto auto' : '1fr 1fr'
-
-  return (
-    <CellBase
-      mobileOrder={mobileOrder || (accent ? 1 : 2)}
-      sx={{
-        height: 'auto',
-        display: 'grid',
-        gridTemplateColumns: isRow ? rows : '100%',
-        '-ms-grid-columns': isRow ? rows : '100%',
-        gridTemplateRows: isRow ? '100%' : 'auto auto',
-        '-ms-grid-rows': isRow ? '100%' : 'auto auto',
-        padding: accent && !isRow ? 'sm' : '',
-        variant: accent
-          ? 'productTable.cellContent.main.variants.accent'
-          : 'productTable.cellContent.main.base'
-      }}
-      // @ts-ignore
-      css={{ display: '-ms-grid' }}
-    >
-      <div
-        sx={{
-          display: inAddon ? [undefined, 'none'] : undefined,
-          ...grid('column', 1, 1),
-          ...grid('row', isRow ? 1 : 2, 1),
-          fontSize: 'xs',
-          marginTop: isRow ? '' : 'sm',
-          variant: 'productTable.cellContent.label'
-        }}
-      >
-        {label}
-      </div>
-      <div
-        sx={{
-          ...grid('column', isRow ? 2 : 1, 1),
-          ...grid('row', 1, 1),
-          fontSize: isRow ? 'sm' : 'xxxl',
-          small: {
-            fontSize: 'sm'
-          }
-        }}
-      >
+  if (inSplit || inAddon) {
+    return (
+      <RowContent inAddon={inAddon} {...props}>
         {children}
-      </div>
-    </CellBase>
-  )
+      </RowContent>
+    )
+  }
+
+  return <BlockContent {...props}>{children}</BlockContent>
 }
 
 export default ProductTableCellContent

--- a/src/compounds/product-table/src/components/cell-image.tsx
+++ b/src/compounds/product-table/src/components/cell-image.tsx
@@ -11,6 +11,13 @@ export const ProductTableCellImage: React.FC = ({ children }) => (
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      img: {
+        maxHeight: 'icon.xxl',
+        height: '100%',
+        maxWidth: '100%',
+        width: 'auto',
+        objectFit: 'contain'
+      },
       variant: 'productTable.cellImage.main'
     }}
   >

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -73,6 +73,10 @@ const ProductTableRow: React.FC<RowProps> = ({
         paddingX: ['sm', 'md'],
         paddingY: 'md',
         marginTop: badges.length ? [10, 15] : 0,
+        marginBottom: 'md',
+        ':last-of-type': {
+          marginBottom: 0
+        },
         variant: 'productTable.row.main'
       }}
     >

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -85,17 +85,7 @@ export const ExampleWithKnobs = () => {
     if (col === 'Image') {
       return (
         <ProductTable.cells.Image>
-          <img
-            src="https://uswitch-cms.imgix.net/uswitch-assets-eu/broadband/images/providers/virgin-media.png"
-            alt="Salman"
-            sx={{
-              maxHeight: 75,
-              height: '100%',
-              maxWidth: '100%',
-              width: 'auto',
-              objectFit: 'contain'
-            }}
-          />
+          <img src="https://placekitten.com/42/75?image=9" alt="Salman" />
         </ProductTable.cells.Image>
       )
     }

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -432,3 +432,65 @@ export const ExampleWithMultipleAccents = () => {
     </ProductTable.Row>
   )
 }
+
+export const ExampleStacked = () => {
+  return (
+    <>
+      <ProductTable.Row preTitle="Sponsored" rowTitle="Super Saver April 2021">
+        <ProductTable.cells.Image>
+          <img
+            src="https://placekitten.com/200/75?image=1"
+            alt="Salman"
+            sx={{ height: 75, width: '100%', objectFit: 'cover' }}
+          />
+        </ProductTable.cells.Image>
+        <ProductTable.cells.Split>
+          <ProductTable.cells.Content label="Fixed rate contract">
+            14 months
+          </ProductTable.cells.Content>
+          <ProductTable.cells.Content label="Early exit fee">
+            £30 per fuel
+          </ProductTable.cells.Content>
+        </ProductTable.cells.Split>
+        <ProductTable.cells.Content label="Annual saving" accent>
+          <ProductTable.data.Range from={30} to={260} unit="pounds" />
+        </ProductTable.cells.Content>
+        <ProductTable.cells.Content label="Annual saving" accent>
+          <ProductTable.data.Range from={30} to={260} unit="pounds" />
+        </ProductTable.cells.Content>
+        <ProductTable.cells.Cta
+          primary={<ButtonLink variant="primary">Button</ButtonLink>}
+          secondary={<ButtonLink variant="link">Plan info</ButtonLink>}
+        />
+      </ProductTable.Row>
+
+      <ProductTable.Row preTitle="Sponsored" rowTitle="Super Saver April 2021">
+        <ProductTable.cells.Image>
+          <img
+            src="https://placekitten.com/200/75?image=1"
+            alt="Salman"
+            sx={{ height: 75, width: '100%', objectFit: 'cover' }}
+          />
+        </ProductTable.cells.Image>
+        <ProductTable.cells.Split>
+          <ProductTable.cells.Content label="Fixed rate contract">
+            14 months
+          </ProductTable.cells.Content>
+          <ProductTable.cells.Content label="Early exit fee">
+            £30 per fuel
+          </ProductTable.cells.Content>
+        </ProductTable.cells.Split>
+        <ProductTable.cells.Content label="Annual saving" accent>
+          <ProductTable.data.Range from={30} to={260} unit="pounds" />
+        </ProductTable.cells.Content>
+        <ProductTable.cells.Content label="Annual saving" accent>
+          <ProductTable.data.Range from={30} to={260} unit="pounds" />
+        </ProductTable.cells.Content>
+        <ProductTable.cells.Cta
+          primary={<ButtonLink variant="primary">Button</ButtonLink>}
+          secondary={<ButtonLink variant="link">Plan info</ButtonLink>}
+        />
+      </ProductTable.Row>
+    </>
+  )
+}

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -86,9 +86,15 @@ export const ExampleWithKnobs = () => {
       return (
         <ProductTable.cells.Image>
           <img
-            src="https://placekitten.com/200/75?image=9"
+            src="https://uswitch-cms.imgix.net/uswitch-assets-eu/broadband/images/providers/virgin-media.png"
             alt="Salman"
-            sx={{ height: 75, width: '100%', objectFit: 'cover' }}
+            sx={{
+              maxHeight: 75,
+              height: '100%',
+              maxWidth: '100%',
+              width: 'auto',
+              objectFit: 'contain'
+            }}
           />
         </ProductTable.cells.Image>
       )

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -979,11 +979,7 @@
   "productTable": {
     "row": {
       "main": {
-        "borderColor": "grey-20",
-        "marginBottom": "md",
-        ":last-of-type": {
-          "marginBottom": 0
-        }
+        "borderColor": "grey-20"
       },
       "header": {
         "borderBottomColor": "grey-20"

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -987,16 +987,25 @@
       }
     },
     "cellContent": {
-      "main": {
-        "base": {},
-        "variants": {
+      "main": {},
+      "label": {
+        "color": "grey-60"
+      },
+      "content": {},
+      "accent": {
+        "backgroundColor": "grey-05"
+      },
+      "variants": {
+        "inSplit": {
+          "main": {},
+          "label": {
+            "color": "grey-60"
+          },
+          "content": {},
           "accent": {
             "backgroundColor": "grey-05"
           }
         }
-      },
-      "label": {
-        "color": "grey-60"
       }
     },
     "cellCta": {
@@ -1080,8 +1089,8 @@
       "fontWeight": "base",
       "lineHeight": "base",
       "color": "grey-100",
-      "-webkit-font-smoothing": "antialiased",
-      "-moz-osx-font-smoothing": "grayscale"
+      "webkitFontSmoothing": "antialiased",
+      "mozOsxFontSmoothing": "grayscale"
     },
 
     "a": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -97,6 +97,14 @@
         "4": 280
       }
     },
+    "icon": {
+      "xs": 16,
+      "sm": 16,
+      "md": 32,
+      "lg": 64,
+      "xl": 72,
+      "xxl": 96
+    },
     "hero": { "width": 1024 },
     "label": { "width": 280 },
     "input": { "height": 58 },
@@ -984,6 +992,11 @@
         "inSplit": {
           "borderTopColor": "grey-20"
         }
+      }
+    },
+    "cellImage": {
+      "main": {
+        "padding": "sm"
       }
     },
     "cellContent": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -276,7 +276,7 @@
       }
     }
   },
-  
+
   "sideNav": {
     "internalLinkList": {
       "listStyle": "none",
@@ -368,7 +368,7 @@
     }
   },
 
-  
+
   "compounds": {
     "article-intro": {
       "base": {
@@ -487,7 +487,7 @@
       "h1, h2, h3, h4, h5, h6": {
         "color": "inherit"
       }
-    } 
+    }
   },
 
   "imageCalloutContent": {
@@ -979,7 +979,11 @@
   "productTable": {
     "row": {
       "main": {
-        "borderColor": "grey-20"
+        "borderColor": "grey-20",
+        "marginBottom": "md",
+        ":last-of-type": {
+          "marginBottom": 0
+        }
       },
       "header": {
         "borderBottomColor": "grey-20"

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -964,11 +964,7 @@
   "productTable": {
     "row": {
       "main": {
-        "borderColor": "grey-30",
-        "marginBottom": "md",
-        ":last-of-type": {
-          "marginBottom": 0
-        }
+        "borderColor": "grey-30"
       },
       "header": {
         "borderBottomColor": "grey-20"

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -964,7 +964,11 @@
   "productTable": {
     "row": {
       "main": {
-        "borderColor": "grey-30"
+        "borderColor": "grey-30",
+        "marginBottom": "md",
+        ":last-of-type": {
+          "marginBottom": 0
+        }
       },
       "header": {
         "borderBottomColor": "grey-20"

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -981,16 +981,25 @@
       }
     },
     "cellContent": {
-      "main": {
-        "base": {},
-        "variants": {
+      "main": {},
+      "label": {
+        "color": "grey-80"
+      },
+      "content": {},
+      "accent": {
+        "backgroundColor": "grey-05"
+      },
+      "variants": {
+        "inSplit": {
+          "main": {},
+          "label": {
+            "color": "grey-80"
+          },
+          "content": {},
           "accent": {
             "backgroundColor": "grey-05"
           }
         }
-      },
-      "label": {
-        "color": "grey-80"
       }
     },
     "cellCta": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -94,6 +94,14 @@
         "4": 280
       }
     },
+    "icon": {
+      "xs": 16,
+      "sm": 16,
+      "md": 32,
+      "lg": 64,
+      "xl": 72,
+      "xxl": 96
+    },
     "hero": { "width": 1280 },
     "label": { "width": 280 },
     "input": { "height": 58 },
@@ -978,6 +986,11 @@
     "addonFooter": {
       "main": {
         "borderTopColor": "grey-20"
+      }
+    },
+    "cellImage": {
+      "main": {
+        "padding": "sm"
       }
     },
     "cellContent": {


### PR DESCRIPTION
# Description

- [x] Break `cells.Content` into two distinct components; one for standalone content cells and one for "row" content.
- [x] Update `cells.Image` style to better present images/logos
    - [x] Set sensible defaults for logos
    - [x] Add `icon` sizes
- [x] Updated the structure of the `productTable` theme
- [x] Camel-case `-webkit-font-smoothing` and `-ms-grid-column` due to errors when rendering product tables

<img width="1064" alt="Screenshot 2020-04-27 at 16 10 11" src="https://user-images.githubusercontent.com/1562593/80388272-9b030500-88a1-11ea-80cc-5c219bbd0279.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
