### PR TITLE
Move sidenav variant theme to under compounds key for money, uswitch, ban…

### DIFF
--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/side-nav/src/index.tsx
+++ b/src/compounds/side-nav/src/index.tsx
@@ -27,7 +27,7 @@ const SideNav: React.FC<Props> = ({ internalLinks, additionalLinks = [] }) => {
         <Accordion title={internalLinks.title}>
           <ul
             sx={{
-              variant: 'compounds.sideNav.internalLinkList'
+              variant: 'compounds.side-nav.internalLinkList'
             }}
           >
             {internalLinks?.links?.map(({ text, url, isActive }) => {
@@ -35,7 +35,7 @@ const SideNav: React.FC<Props> = ({ internalLinks, additionalLinks = [] }) => {
                 <li
                   key={url}
                   sx={{
-                    variant: `compounds.sideNav.internalLinkListItem.${
+                    variant: `compounds.side-nav.internalLinkListItem.${
                       isActive ? 'isActive' : 'base'
                     }`
                   }}
@@ -55,7 +55,7 @@ const SideNav: React.FC<Props> = ({ internalLinks, additionalLinks = [] }) => {
                   sx={{
                     marginBottom: 0,
                     paddingBottom: 0,
-                    variant: 'compounds.sideNav.additionalLink'
+                    variant: 'compounds.side-nav.additionalLink'
                   }}
                 >
                   <Styled.a href={url}>{text}</Styled.a>

--- a/src/compounds/side-nav/src/index.tsx
+++ b/src/compounds/side-nav/src/index.tsx
@@ -27,7 +27,7 @@ const SideNav: React.FC<Props> = ({ internalLinks, additionalLinks = [] }) => {
         <Accordion title={internalLinks.title}>
           <ul
             sx={{
-              variant: 'sideNav.internalLinkList'
+              variant: 'compounds.sideNav.internalLinkList'
             }}
           >
             {internalLinks?.links?.map(({ text, url, isActive }) => {
@@ -35,7 +35,7 @@ const SideNav: React.FC<Props> = ({ internalLinks, additionalLinks = [] }) => {
                 <li
                   key={url}
                   sx={{
-                    variant: `sideNav.internalLinkListItem.${
+                    variant: `compounds.sideNav.internalLinkListItem.${
                       isActive ? 'isActive' : 'base'
                     }`
                   }}
@@ -55,7 +55,7 @@ const SideNav: React.FC<Props> = ({ internalLinks, additionalLinks = [] }) => {
                   sx={{
                     marginBottom: 0,
                     paddingBottom: 0,
-                    variant: 'sideNav.additionalLink'
+                    variant: 'compounds.sideNav.additionalLink'
                   }}
                 >
                   <Styled.a href={url}>{text}</Styled.a>

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -230,7 +230,7 @@
   },
 
   "compounds": {
-    "sideNav": {
+    "side-nav": {
       "internalLinkList": {
         "listStyle": "none",
         "paddingLeft": 0,
@@ -255,11 +255,11 @@
           }
         },
         "isActive": {
-          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "variant": "compounds.side-nav.internalLinkListItem.base",
           "color": "primary",
           "bg": "rgb(247, 247, 248)",
           "::after": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "variant": "compounds.side-nav.internalLinkListItem.base.::after",
             "content": "\"\"",
             "position": "absolute",
             "top": "0",
@@ -270,7 +270,7 @@
             "backgroundColor": "primary"
           },
           ">a": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "variant": "compounds.side-nav.internalLinkListItem.base.>a",
             "color": "primary",
             "fontWeight": "bold",
             "transform": "translateX(8px)",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -194,11 +194,11 @@
         }
       },
       "isActive": {
-        "variant": "compounds.sideNav.internalLinkListItem.base",
+        "variant": "sideNav.internalLinkListItem.base",
         "color": "primary",
         "bg": "rgb(247, 247, 248)",
         "::after": {
-          "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+          "variant": "sideNav.internalLinkListItem.base.::after",
           "content": "\"\"",
           "position": "absolute",
           "top": "0",
@@ -209,7 +209,7 @@
           "backgroundColor": "primary"
         },
         ">a": {
-          "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+          "variant": "sideNav.internalLinkListItem.base.>a",
           "color": "primary",
           "fontWeight": "bold",
           "transform": "translateX(8px)",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -169,7 +169,6 @@
       }
     }
   },
-
   "sideNav": {
     "internalLinkList": {
       "listStyle": "none",
@@ -195,11 +194,11 @@
         }
       },
       "isActive": {
-        "variant": "sideNav.internalLinkListItem.base",
+        "variant": "compounds.sideNav.internalLinkListItem.base",
         "color": "primary",
         "bg": "rgb(247, 247, 248)",
         "::after": {
-          "variant": "sideNav.internalLinkListItem.base.::after",
+          "variant": "compounds.sideNav.internalLinkListItem.base.::after",
           "content": "\"\"",
           "position": "absolute",
           "top": "0",
@@ -210,7 +209,7 @@
           "backgroundColor": "primary"
         },
         ">a": {
-          "variant": "sideNav.internalLinkListItem.base.>a",
+          "variant": "compounds.sideNav.internalLinkListItem.base.>a",
           "color": "primary",
           "fontWeight": "bold",
           "transform": "translateX(8px)",
@@ -231,6 +230,66 @@
   },
 
   "compounds": {
+    "sideNav": {
+      "internalLinkList": {
+        "listStyle": "none",
+        "paddingLeft": 0,
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "margin": 0
+      },
+      "internalLinkListItem": {
+        "base": {
+          "mb": 0,
+          "position": "relative",
+          ">a": {
+            "transition": "all 0.2s ease-in-out",
+            "display": "block",
+            "color": "grey-70",
+            "textDecoration": "none",
+            "fontSize": "sm",
+            "padding": "12px 16px",
+            ":visited": {
+              "color": "grey-70"
+            }
+          }
+        },
+        "isActive": {
+          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "color": "primary",
+          "bg": "rgb(247, 247, 248)",
+          "::after": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "content": "\"\"",
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "display": "block",
+            "width": 4,
+            "height": "100%",
+            "backgroundColor": "primary"
+          },
+          ">a": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "color": "primary",
+            "fontWeight": "bold",
+            "transform": "translateX(8px)",
+            ":visited": {
+              "color": "primary"
+            }
+          }
+        }
+      },
+      "additionalLink": {
+        "display": "block",
+        "marginBottom": "xxs",
+        "color": "grey-80",
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "textDecoration": "none"
+      }
+    },
+
     "breadcrumb": {
       "my": "sm",
       "mx": 0

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -279,6 +279,62 @@
   },
 
   "compounds": {
+    "sideNav": {
+      "internalLinkList": {
+        "listStyle": "none",
+        "paddingLeft": 0,
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "margin": 0
+      },
+      "internalLinkListItem": {
+        "base": {
+          "mb": 0,
+          "position": "relative",
+          ">a": {
+            "display": "block",
+            "color": "grey-70",
+            "textDecoration": "none",
+            "fontSize": "sm",
+            "padding": "12px 16px",
+            ":visited": {
+              "color": "grey-70"
+            }
+          }
+        },
+        "isActive": {
+          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "color": "uswitch-navy",
+          "::after": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "content": "\"\"",
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "display": "block",
+            "width": 4,
+            "height": "100%",
+            "backgroundColor": "uswitch-navy"
+          },
+          ">a": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "color": "uswitch-navy",
+            ":visited": {
+              "color": "uswitch-navy"
+            }
+          }
+        }
+      },
+      "additionalLink": {
+        "display": "block",
+        "marginBottom": "xxs",
+        "color": "grey-80",
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "textDecoration": "none"
+      }
+    },
+
     "card": {
       "display": "flex",
       "width": ["100%", "49%", "grid.lg.3"],

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -279,7 +279,7 @@
   },
 
   "compounds": {
-    "sideNav": {
+    "side-nav": {
       "internalLinkList": {
         "listStyle": "none",
         "paddingLeft": 0,
@@ -303,10 +303,10 @@
           }
         },
         "isActive": {
-          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "variant": "compounds.side-nav.internalLinkListItem.base",
           "color": "uswitch-navy",
           "::after": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "variant": "compounds.side-nav.internalLinkListItem.base.::after",
             "content": "\"\"",
             "position": "absolute",
             "top": "0",
@@ -317,7 +317,7 @@
             "backgroundColor": "uswitch-navy"
           },
           ">a": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "variant": "compounds.side-nav.internalLinkListItem.base.>a",
             "color": "uswitch-navy",
             ":visited": {
               "color": "uswitch-navy"

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -361,6 +361,97 @@
   },
 
   "compounds": {
+    "sideNav": {
+      "internalLinkList": {
+        "listStyle": "none",
+        "paddingLeft": 0,
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "margin": 0
+      },
+      "internalLinkListItem": {
+        "base": {
+          "padding": "8px 0 8px 35px",
+          "mb": 0,
+          "position": "relative",
+          "::after": {
+            "content": "\"\"",
+            "position": "absolute",
+            "top": "45%",
+            "transform": "translateY(-50%)",
+            "display": "block",
+            "width": 12,
+            "height": 12,
+            "left": 6,
+            "borderRadius": 12,
+            "backgroundColor": "white",
+            "borderWidth": 2,
+            "borderStyle": "solid",
+            "borderColor": "grey-30"
+          },
+          "::before": {
+            "content": "\"\"",
+            "position": "absolute",
+            "left": 13,
+            "width": 2,
+            "backgroundColor": "grey-30",
+            "top": "0",
+            "height": "100%"
+          },
+          ":first-child::before": {
+            "top": "50%",
+            "height": "50%"
+          },
+          ":last-child::before": {
+            "height": "50%"
+          },
+          ">a": {
+            "color": "grey-60",
+            "textDecoration": "none",
+            "fontSize": "xs",
+            "marginTop": "-4px",
+            "display": "block",
+            ":visited": {
+              "color": "grey-60"
+            }
+          }
+        },
+        "isActive": {
+          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "color": "experimental-text",
+          "::after": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "borderColor": "fuschia"
+          },
+          ">a": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "color": "experimental-text",
+            "fontWeight": "bold",
+            ":visited": {
+              "color": "experimental-text"
+            }
+          }
+        }
+      },
+      "additionalLink": {
+        "display": "block",
+        "color": "grey-80",
+        "paddingTop": "xs",
+        "paddingBottom": "xs",
+        "paddingLeft": "0",
+        "borderWidth": "1px 0 0 0",
+        "borderStyle": "solid",
+        "borderColor": "grey-20",
+        "fontSize": "xs",
+        "a": {
+          "textDecoration": "none"
+        },
+        ":last-child": {
+          "paddingBottom": "0"
+        }
+      }
+    },
+
     "card": {
       "itemsPerRow": [1, 2, 3],
       "width": "100%",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -361,7 +361,7 @@
   },
 
   "compounds": {
-    "sideNav": {
+    "side-nav": {
       "internalLinkList": {
         "listStyle": "none",
         "paddingLeft": 0,
@@ -417,14 +417,14 @@
           }
         },
         "isActive": {
-          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "variant": "compounds.side-nav.internalLinkListItem.base",
           "color": "experimental-text",
           "::after": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "variant": "compounds.side-nav.internalLinkListItem.base.::after",
             "borderColor": "fuschia"
           },
           ">a": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "variant": "compounds.side-nav.internalLinkListItem.base.>a",
             "color": "experimental-text",
             "fontWeight": "bold",
             ":visited": {

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -333,7 +333,7 @@
   },
 
   "compounds": {
-    "sideNav": {
+    "side-nav": {
       "internalLinkList": {
         "listStyle": "none",
         "paddingLeft": 0,
@@ -357,10 +357,10 @@
           }
         },
         "isActive": {
-          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "variant": "compounds.side-nav.internalLinkListItem.base",
           "color": "uswitch-navy",
           "::after": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "variant": "compounds.side-nav.internalLinkListItem.base.::after",
             "content": "\"\"",
             "position": "absolute",
             "top": "0",
@@ -371,7 +371,7 @@
             "backgroundColor": "uswitch-navy"
           },
           ">a": {
-            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "variant": "compounds.side-nav.internalLinkListItem.base.>a",
             "color": "uswitch-navy",
             ":visited": {
               "color": "uswitch-navy"

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -333,6 +333,62 @@
   },
 
   "compounds": {
+    "sideNav": {
+      "internalLinkList": {
+        "listStyle": "none",
+        "paddingLeft": 0,
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "margin": 0
+      },
+      "internalLinkListItem": {
+        "base": {
+          "mb": 0,
+          "position": "relative",
+          ">a": {
+            "display": "block",
+            "color": "grey-70",
+            "textDecoration": "none",
+            "fontSize": "sm",
+            "padding": "12px 16px",
+            ":visited": {
+              "color": "grey-70"
+            }
+          }
+        },
+        "isActive": {
+          "variant": "compounds.sideNav.internalLinkListItem.base",
+          "color": "uswitch-navy",
+          "::after": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.::after",
+            "content": "\"\"",
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "display": "block",
+            "width": 4,
+            "height": "100%",
+            "backgroundColor": "uswitch-navy"
+          },
+          ">a": {
+            "variant": "compounds.sideNav.internalLinkListItem.base.>a",
+            "color": "uswitch-navy",
+            ":visited": {
+              "color": "uswitch-navy"
+            }
+          }
+        }
+      },
+      "additionalLink": {
+        "display": "block",
+        "marginBottom": "xxs",
+        "color": "grey-80",
+        "paddingTop": "xxs",
+        "paddingBottom": "xxs",
+        "textDecoration": "none"
+      }
+    },
+    
     "card": {
       "itemsPerRow": [1, 2, 3],
       "width": "100%",


### PR DESCRIPTION
…krate and journey

# Description

Added sidenav component theme to live under compounds key in money, uswitch, bankrate and journey theme files.

# Checklist

Pull request contains:

- [ ] A new component
- [ x ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
