### PR TITLE
Add imageModule size to money theme

### DIFF
--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1127,6 +1127,11 @@
     "contentSpan": 10
   },
 
+  "imageModule": {
+    "contentCols": 12,
+    "contentSpan": 10
+  },
+
   "productTable": {
     "row": {
       "main": {


### PR DESCRIPTION
# Description

Add `contentSpan` to `imageModule` in money's theme ahead of changes to
eevee.

https://github.com/uswitch/recharge-eevee/pull/315

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated