### PR TITLE
Theme updates to support top orientation in callout

### DIFF
--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -755,6 +755,9 @@
       "backgroundColor": "grey-10",
       "paddingX": ["sm", "md"]
     },
+    "icon-container": {
+      "width": 16
+    },
     "icon": {
       "backgroundColor": "plum"
     }


### PR DESCRIPTION
# Description

Money Theme updates to support top orientation in callout element

orientation left:
<img width="366" alt="Screenshot 2020-05-11 at 16 54 21" src="https://user-images.githubusercontent.com/47602619/81585992-d5de6000-93ac-11ea-8753-ce828858cc8c.png">

orientation top:
<img width="366" alt="Screenshot 2020-05-11 at 16 54 38" src="https://user-images.githubusercontent.com/47602619/81586093-f73f4c00-93ac-11ea-9590-2292d0b49c89.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
