### PR TITLE
Remove hardcoded button height - was causing bugs

### DIFF
--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -70,7 +70,6 @@ export const Button: React.FC<Props> = ({
         fontSize: get(theme, `buttons.base.btnSize.${size}.fontSize`, 'base'),
         paddingX: get(theme, `buttons.base.btnSize.${size}.paddingX`, 'sm'),
         paddingY: get(theme, `buttons.base.btnSize.${size}.paddingY`, 'base'),
-        height: get(theme, `buttons.base.btnSize.${size}.height`, 'base'),
         variant: get(theme, `buttons.variants.${variant}`),
 
         justifyContent: 'center',

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -385,7 +385,6 @@
       "border": "none",
       "fontFamily": "heading",
       "borderRadius": "4px",
-      "lineHeight": 0,
       ":disabled": {
         "opacity": "0.3",
         "cursor": "not-allowed"
@@ -394,14 +393,12 @@
         "large": {
           "paddingX": "xl",
           "paddingY": "base",
-          "fontSize": "md",
-          "height": 56
+          "fontSize": "md"
         },
         "small": {
           "paddingX": 40,
           "paddingY": 13,
-          "fontSize": "sm",
-          "height": "xl"
+          "fontSize": "sm"
         }
       }
     },

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -732,14 +732,12 @@
         "large": {
           "paddingX": "xl",
           "paddingY": "base",
-          "fontSize": "md",
-          "height": 56
+          "fontSize": "md"
         },
         "small": {
           "paddingX": 40,
           "paddingY": 13,
-          "fontSize": "sm",
-          "height": "xl"
+          "fontSize": "sm"
         }
       }
     },


### PR DESCRIPTION
- With one line of text, the button height was slightly too small
- Buttons couldn't have more than one line of text

https://app.asana.com/0/1153286245702289/1175415548003665

![image](https://user-images.githubusercontent.com/472830/81712621-bad32500-946c-11ea-8754-f59cae115fb1.png)

![image](https://user-images.githubusercontent.com/472830/81712637-bf97d900-946c-11ea-83f5-52a3bd6e1517.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
