### PR TITLE
Disable localStorage for theme-ui

### DIFF
--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -1,6 +1,8 @@
 {
   "name": "Bankrate",
 
+  "useLocalStorage": false,
+
   "breakpoints": ["768px", "990px"],
 
   "zIndices": {

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -1,6 +1,8 @@
 {
   "name": "Journey",
 
+  "useLocalStorage": false,
+
   "breakpoints": ["768px", "990px"],
 
   "zIndices": {

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1,6 +1,8 @@
 {
   "name": "Money",
 
+  "useLocalStorage": false,
+
   "breakpoints": ["768px", "990px"],
 
   "zIndices": {

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -1,5 +1,8 @@
 {
   "name": "saveOnEnergy",
+
+  "useLocalStorage": false,
+
   "breakpoints": [
     "768px",
     "1280px"

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1,6 +1,8 @@
 {
   "name": "uSwitch",
 
+  "useLocalStorage": false,
+
   "breakpoints": ["768px", "990px"],
 
   "zIndices": {


### PR DESCRIPTION
We don't use user-configurable colour modes and yet theme-ui still tries
to write to localStorage without handling failure cases. This is
impacting a significant number of our customers.

https://theme-ui.com/color-modes/#disable-persisting-color-mode-on-localstorage

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated