### PR TITLE
Fix spacing issue in category header

### DIFF
--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/category/src/index.tsx
+++ b/src/elements/category/src/index.tsx
@@ -48,7 +48,7 @@ const Category: React.FC<ListProps> = ({
           </div>
         )}
         <Row>
-          <Col span={contentSpan} sx={{ marginBottom: 0 }}>
+          <Col span={contentSpan} sx={{ marginBottom: [0, 0] }}>
             <Styled.h1
               as={text ? 'h1' : 'p'}
               sx={{


### PR DESCRIPTION
# Description

The margin bottom was only being overridden on mobile as the margin bottom in a media query was more specific and overriding it.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
