### PR TITLE
Remove spacing from call out component

### DIFF
--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/call-out/src/index.tsx
+++ b/src/elements/call-out/src/index.tsx
@@ -55,8 +55,6 @@ const CallOut: React.FC<Props> = ({
         borderRadius: 4,
         paddingX: 'sm',
         paddingY: 'sm',
-        marginTop: 'xs',
-        marginBottom: 'md',
         variant: 'callOut.main'
       }}
       px={{


### PR DESCRIPTION
# Description

Can't be overridden as is - will re-add spacing in eevee when updating.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
