### PR TITLE
make product table images work on ie11

### DIFF
--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/cell-image.tsx
+++ b/src/compounds/product-table/src/components/cell-image.tsx
@@ -11,17 +11,28 @@ export const ProductTableCellImage: React.FC = ({ children }) => (
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      img: {
-        maxHeight: 'icon.xxl',
-        height: '100%',
-        maxWidth: '100%',
-        width: 'auto',
-        objectFit: 'contain'
-      },
       variant: 'productTable.cellImage.main'
     }}
   >
-    {children}
+    <div
+      sx={{
+        position: 'relative',
+        height: '100%',
+        width: '100%',
+        img: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          maxWidth: '100%',
+          maxHeight: '100%',
+          margin: 'auto'
+        }
+      }}
+    >
+      {children}
+    </div>
   </CellBase>
 )
 export default ProductTableCellImage


### PR DESCRIPTION
# Description

Replaces object-fit which doesn't have support on IE11

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated

Before:
<img width="1202" alt="Screen Shot 2020-05-21 at 16 25 16" src="https://user-images.githubusercontent.com/8939909/82574917-b3540000-9b7f-11ea-82f5-f842d6a207fe.png">

After:
<img width="1207" alt="Screen Shot 2020-05-21 at 16 21 29" src="https://user-images.githubusercontent.com/8939909/82574974-c535a300-9b7f-11ea-8b3f-41fdebcc81cd.png">

