### PR TITLE
fix: android keyboard focus

### DIFF
--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -29,24 +29,22 @@ export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
 // is fired when the keyboard opens and pushes up the viewport.
 //
 // Related: https://stackoverflow.com/questions/23757345/android-does-not-correctly-scroll-on-input-focus-if-not-body-element?noredirect=1&lq=1
-const useScrollIntoView = (
-  inputRef: React.RefObject<HTMLInputElement>,
-  hasFocus: boolean
-) => {
+const useScrollIntoView = (inputRef: React.RefObject<HTMLInputElement>) => {
   useEffect(() => {
-    if (!hasFocus) return
-
     const handleResize = debounce(() => {
+      if (
+        inputRef.current === null ||
+        inputRef.current !== document.activeElement
+      )
+        return
       try {
-        // eslint-disable-next-line no-unused-expressions
-        inputRef.current?.scrollIntoView({
+        inputRef.current.scrollIntoView({
           behavior: 'smooth',
           block: 'center'
         })
       } catch {
         // `block: 'center'` is unsupported in Firefox < 58
-        // eslint-disable-next-line no-unused-expressions
-        inputRef.current?.scrollIntoView({
+        inputRef.current.scrollIntoView({
           behavior: 'smooth'
         })
       }
@@ -79,7 +77,7 @@ export const Input: React.FC<Props> = ({
     null
   )
   const [hasFocus, setHasFocus] = useState(false)
-  useScrollIntoView(inputRef, hasFocus)
+  useScrollIntoView(inputRef)
   const [interiorValue, setInteriorValue] = useState(
     inputProps.value || defaultValue || ''
   )


### PR DESCRIPTION
# Description

Android doesn't always scroll focused elements into view so we manually
do it. The code to handle this was broken in a previous commit.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated