### PR TITLE
Fix product table tablet breakpoint in IE11

### DIFF
--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -115,7 +115,7 @@ const ProductTableRow: React.FC<RowProps> = ({
           variant: 'productTable.row.grid',
 
           // Flex in mobile IE11 (?!) as auto-layout for grid isn't supported
-          '@media all and (max-width: 768px) and (-ms-high-contrast: none), (-ms-high-contrast: active)': {
+          '@media all and (max-width: 990px) and (-ms-high-contrast: none), (-ms-high-contrast: active)': {
             display: 'flex',
             flexDirection: 'column'
           }


### PR DESCRIPTION
# Description

Was broken here when tablet product table tablet breakpoint was shown mobile layout instead of desktop, but IE11 breakpoint wasn't adjusted: https://github.com/uswitch/trustyle/pull/475/files#diff-4d553efec1d2b870ecca128c23369239

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
