### PR TITLE
Custom size columns in product tables

### DIFF
--- a/src/compounds/product-table/src/components/cell-base.tsx
+++ b/src/compounds/product-table/src/components/cell-base.tsx
@@ -7,11 +7,13 @@ import { AddonContext, CellContext } from '../generics'
 export interface CellBaseProps extends React.HTMLAttributes<HTMLDivElement> {
   mobileOrder?: number
   extraRules?: object
+  customSize?: string
 }
 
 const ProductTableCellBase: React.FC<CellBaseProps> = ({
   mobileOrder = 2,
   extraRules: extraRulesProp = {},
+  customSize,
   children,
   className
 }) => {
@@ -25,12 +27,17 @@ const ProductTableCellBase: React.FC<CellBaseProps> = ({
     firstInSplit,
     inFlexbox,
     inSplit,
-    extraRules: extraRulesCellContext
+    extraRules: extraRulesCellContext,
+    setSize
   } = React.useContext(CellContext)
 
   const { order, extraRules: extraRulesAddonContext } = React.useContext(
     AddonContext
   )
+
+  if (setSize && customSize) {
+    setSize(customSize)
+  }
 
   const extraRules = {
     ...extraRulesCellContext,

--- a/src/compounds/product-table/src/components/cell-content.tsx
+++ b/src/compounds/product-table/src/components/cell-content.tsx
@@ -22,6 +22,7 @@ export interface CellPrimaryProps extends React.HTMLAttributes<HTMLDivElement> {
   label: string
   accent?: boolean
   mobileOrder?: number
+  customSize?: string
 }
 
 export interface ContentRowProps extends CellPrimaryProps {
@@ -33,10 +34,12 @@ const RowContent: React.FC<ContentRowProps> = ({
   children,
   inAddon,
   label,
-  mobileOrder
+  mobileOrder,
+  customSize
 }) => (
   <CellBase
     mobileOrder={mobileOrder || (accent ? 1 : 2)}
+    customSize={customSize}
     sx={{
       height: 'auto',
       display: 'grid',

--- a/src/compounds/product-table/src/components/cell-cta.tsx
+++ b/src/compounds/product-table/src/components/cell-cta.tsx
@@ -7,10 +7,12 @@ import CellBase from './cell-base'
 export interface CellCtaProps extends React.HTMLAttributes<HTMLDivElement> {
   primary: React.ReactNode
   secondary?: React.ReactNode
+  customSize?: string
 }
 const ProductTableCellCta: React.FC<CellCtaProps> = ({
   primary,
-  secondary
+  secondary,
+  customSize
 }) => {
   const buttonWrapperStyling = {
     flex: [1, undefined, 'initial'],
@@ -20,6 +22,7 @@ const ProductTableCellCta: React.FC<CellCtaProps> = ({
   }
   return (
     <CellBase
+      customSize={customSize}
       sx={{
         display: 'flex',
         alignItems: 'center',

--- a/src/compounds/product-table/src/components/cell-image.tsx
+++ b/src/compounds/product-table/src/components/cell-image.tsx
@@ -4,9 +4,17 @@ import { jsx } from 'theme-ui'
 
 import CellBase from './cell-base'
 
-export const ProductTableCellImage: React.FC = ({ children }) => (
+export interface ProductTableCellImageProps extends React.HTMLAttributes<any> {
+  customSize?: string
+}
+
+export const ProductTableCellImage: React.FC<ProductTableCellImageProps> = ({
+  customSize = '0.7fr',
+  children
+}) => (
   <CellBase
     mobileOrder={0}
+    customSize={customSize}
     sx={{
       display: 'flex',
       alignItems: 'center',

--- a/src/compounds/product-table/src/components/cell-placeholder.tsx
+++ b/src/compounds/product-table/src/components/cell-placeholder.tsx
@@ -6,14 +6,20 @@ import { AddonContext, CellContext } from '../generics'
 
 import CellBase from './cell-base'
 
-export const ProductTableCellPlaceholder: React.FC<React.HTMLAttributes<
-  HTMLDivElement
->> = () => {
+export interface ProductTableCellPlaceholderProps
+  extends React.HTMLAttributes<any> {
+  customSize?: string
+}
+
+export const ProductTableCellPlaceholder: React.FC<ProductTableCellPlaceholderProps> = ({
+  customSize
+}) => {
   const { inSplit } = React.useContext(CellContext)
   const { inAddon } = React.useContext(AddonContext)
 
   return (
     <CellBase
+      customSize={customSize}
       sx={{
         display: 'flex',
         alignItems: 'center',

--- a/src/compounds/product-table/src/components/cell-split.tsx
+++ b/src/compounds/product-table/src/components/cell-split.tsx
@@ -7,10 +7,21 @@ import { CellContext } from '../generics'
 // Needs to be the lowest common factor of all the split counts
 export const ROWS = 6
 
-const ProductTableCellSplit: React.FC<React.HTMLAttributes<any>> = ({
+export interface ProductTableCellSplitProps extends React.HTMLAttributes<any> {
+  customSize: string
+}
+
+const ProductTableCellSplit: React.FC<ProductTableCellSplitProps> = ({
+  customSize,
   children
 }) => {
-  const { gridColumnStart, gridColumnSpan } = React.useContext(CellContext)
+  const { gridColumnStart, gridColumnSpan, setSize } = React.useContext(
+    CellContext
+  )
+
+  if (setSize && customSize) {
+    setSize(customSize)
+  }
 
   const nonNullChildren = React.Children.toArray(children).filter(c => c)
   const rowsHeight = ROWS / nonNullChildren.length

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -43,7 +43,7 @@ const ProductTableRow: React.FC<RowProps> = ({
     })
 
   // @todo All addons go at the start - is there a better way to do this?
-  let nonNullChildren = addonsFor('grid')
+  const nonNullChildren = addonsFor('grid')
     .concat(React.Children.toArray(children))
     .filter(c => c) as React.ReactElement[]
 
@@ -71,14 +71,6 @@ const ProductTableRow: React.FC<RowProps> = ({
       setSizes([...sizes.slice(0, i), size, ...sizes.slice(i + 1)])
     }
   }
-
-  nonNullChildren = nonNullChildren.map((child, i) =>
-    React.cloneElement(child, {
-      setSize: (size: string) => {
-        setSize(i, size)
-      }
-    })
-  )
 
   /**
    * Row numbers explained:

--- a/src/compounds/product-table/src/generics.ts
+++ b/src/compounds/product-table/src/generics.ts
@@ -16,6 +16,7 @@ export interface CellContextProps {
   inSplit?: boolean
   inFlexbox?: boolean
   extraRules?: object
+  setSize?: (size: string) => void
 }
 
 export const CellContext = React.createContext<CellContextProps>({})

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -512,3 +512,35 @@ export const ExampleStacked = () => {
     </>
   )
 }
+
+export const CustomSizes = () => {
+  return (
+    <React.Fragment>
+      <ProductTable.Row preTitle="Sponsored" rowTitle="Super Saver April 2021">
+        <ProductTable.cells.Image customSize="0.5fr">
+          <img
+            src="https://placekitten.com/200/75?image=12"
+            alt="Salman"
+            sx={{ height: 75, width: '100%', objectFit: 'cover' }}
+          />
+        </ProductTable.cells.Image>
+        <ProductTable.cells.Split customSize="1.2fr">
+          <ProductTable.cells.Content label="Fixed rate contract">
+            14 months
+          </ProductTable.cells.Content>
+          <ProductTable.cells.Content label="Early exit fee">
+            £30 per fuel
+          </ProductTable.cells.Content>
+        </ProductTable.cells.Split>
+        <ProductTable.cells.Content label="Annual saving" accent>
+          <ProductTable.data.Range from={30} to={260} unit="pounds" />
+        </ProductTable.cells.Content>
+        <ProductTable.cells.Cta
+          primary={<ButtonLink variant="primary">Button</ButtonLink>}
+          secondary={<ButtonLink variant="link">Plan info</ButtonLink>}
+          customSize="0.7fr"
+        />
+      </ProductTable.Row>
+    </React.Fragment>
+  )
+}


### PR DESCRIPTION
# Description

Basically doing this to make the image smaller to improve the tablet layout when there's lots of info, but will be usable for other stuff too.

- [x] Implement for all cell types
- [x] Move `setSize` function to a provider instead of passing through props every time
- [ ] Address the `// @todo`

FS have other priorities this sprint - happy to talk anyone through it if they want to pick this up.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
