### PR TITLE
Add overlay support to dropdown component (and minor visual changes)

### DIFF
--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -8,6 +8,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@uswitch/trustyle-utils.get": "^1.0.5",
     "@uswitch/trustyle.frozen-input": "^1.0.11",
     "@uswitch/trustyle.icon": "^1.5.3",
     "@uswitch/trustyle.styles": "^0.4.29"

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/drop-down/src/index.tsx
+++ b/src/elements/drop-down/src/index.tsx
@@ -2,11 +2,9 @@
 
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
-import { colors } from '@uswitch/trustyle.styles'
 import { Icon } from '@uswitch/trustyle.icon'
 import { FrozenInput } from '@uswitch/trustyle.frozen-input'
-
-const { blueGrey, tomato, UswitchNavy } = colors
+import get from '@uswitch/trustyle-utils.get'
 
 export interface DataProps {
   [key: string]: boolean | number | string | null
@@ -23,6 +21,7 @@ interface Props<V = any> {
   options: Option[]
   placeholder?: string
   value: V
+  overlay?: React.ReactNode
 }
 
 const prependDataProps = (dataProps: DataProps) =>
@@ -57,7 +56,8 @@ export const DropDown = forwardRef(
       name,
       options,
       placeholder,
-      value
+      value,
+      overlay
     }: Props,
     ref: React.Ref<DropDownElement>
   ) => {
@@ -75,11 +75,41 @@ export const DropDown = forwardRef(
         inputRef.current && inputRef.current.scrollIntoView(...args)
     }))
 
+    const variant = hasError
+      ? 'elements.drop-down.select.variants.error'
+      : hasFocus
+      ? 'elements.drop-down.select.variants.focus'
+      : 'elements.drop-down.select.base'
+
+    const iconColor =
+      get(theme, `${variant}.iconColor`) ||
+      get(theme, 'elements.drop-down.select.base.iconColor') ||
+      get(theme, `${variant}.borderColor`) ||
+      get(theme, 'elements.drop-down.select.base.borderColor')
+
     return (
       <FrozenInput text={frozenText} freezable={freezable} inputRef={inputRef}>
         <div
           sx={{ position: 'relative', variant: 'elements.drop-down.container' }}
         >
+          {overlay && (
+            <div
+              sx={{
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+                display: 'flex',
+                alignItems: 'center',
+                paddingX: 16,
+                borderRadius: 3,
+                variant
+              }}
+            >
+              {overlay}
+            </div>
+          )}
           <select
             ref={inputRef}
             onFocus={() => {
@@ -92,6 +122,7 @@ export const DropDown = forwardRef(
             }}
             onChange={e => onChange(e.currentTarget.value)}
             sx={{
+              opacity: overlay ? 0 : undefined,
               fontFamily: 'base',
               fontSize: 'base',
               lineHeight: '1.33',
@@ -106,11 +137,7 @@ export const DropDown = forwardRef(
               '&::-ms-expand': {
                 display: 'none'
               },
-              variant: hasError
-                ? 'elements.drop-down.select.variants.error'
-                : hasFocus
-                ? 'elements.drop-down.select.variants.focus'
-                : 'elements.drop-down.select.base'
+              variant
             }}
             id={name}
             name={name}
@@ -129,29 +156,21 @@ export const DropDown = forwardRef(
               </option>
             ))}
           </select>
-          <span
-            sx={{
-              height: 15,
-              width: 15,
-              pointerEvents: 'none',
-              position: 'absolute',
-              right: 16,
-              top: 'calc(50% - 15px / 2)',
-              variant: 'elements.drop-down.icon'
-            }}
-          >
-            <Icon
-              glyph="caret"
-              color={
-                hasError
-                  ? theme.elements?.['drop-down']?.errorColor ?? tomato
-                  : hasFocus
-                  ? theme.elements?.['drop-down']?.focusColor ?? UswitchNavy
-                  : theme.elements?.['drop-down']?.defaultColor ?? blueGrey
-              }
-              direction="down"
-            />
-          </span>
+          {!overlay && (
+            <span
+              sx={{
+                height: 15,
+                width: 15,
+                pointerEvents: 'none',
+                position: 'absolute',
+                right: 16,
+                top: 'calc(50% - 15px / 2)',
+                variant: 'elements.drop-down.icon'
+              }}
+            >
+              <Icon glyph="caret" color={iconColor} direction="down" />
+            </span>
+          )}
         </div>
       </FrozenInput>
     )

--- a/src/elements/drop-down/src/stories.tsx
+++ b/src/elements/drop-down/src/stories.tsx
@@ -1,8 +1,9 @@
 /** @jsx jsx */
 import { useState } from 'react'
-import { css, jsx } from '@emotion/core'
+import { jsx, useThemeUI } from 'theme-ui'
 
 import AllThemes from '../../../utils/all-themes'
+import ThemedIcon from '../../themed-icon/src'
 
 import { DropDown } from './'
 
@@ -16,7 +17,7 @@ const options = [
   { value: 'yellow', text: 'Yellow' }
 ]
 
-const Spacer = () => <div css={css({ minHeight: 20 })} />
+const Spacer = () => <div sx={{ minHeight: 20 }} />
 
 const ColourSelect = () => {
   const [val, setVal] = useState('red')
@@ -45,6 +46,32 @@ const FrozenColourSelect = () => {
   )
 }
 
+const SelectWithOverlay = () => {
+  const { theme }: any = useThemeUI()
+  const [val, setVal] = useState('red')
+
+  const icon = theme.name === 'Money' ? 'sort' : 'car'
+  const iconColor = theme.name === 'Money' ? 'fuschia' : 'red'
+  return (
+    <DropDown
+      name="overlay-example"
+      onBlur={() => {}}
+      onChange={setVal}
+      options={options}
+      value={val}
+      overlay={
+        <span>
+          <ThemedIcon
+            icon={icon}
+            sx={{ marginRight: 'xs', color: iconColor, borderColor: 'grey-20' }}
+          />
+          Sort by
+        </span>
+      }
+    />
+  )
+}
+
 export const Example = () => (
   <div>
     <ColourSelect />
@@ -63,6 +90,10 @@ export const Example = () => (
       options={[{ value: '', text: 'Incorrect' }]}
       value={''}
     />
+
+    <Spacer />
+
+    <SelectWithOverlay />
   </div>
 )
 

--- a/src/elements/themed-icon/package.json
+++ b/src/elements/themed-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.themed-icon",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/themed-icon/src/index.tsx
+++ b/src/elements/themed-icon/src/index.tsx
@@ -40,7 +40,7 @@ const ThemedIcon: React.FC<Props> & {
   if (!iconSymbol) {
     console.error(`Icon "${icon}" not found`)
     return (
-      <svg viewBox="0 0 50 50" sx={svgStyling}>
+      <svg viewBox="0 0 50 50" className={className} sx={svgStyling}>
         <circle
           r="23"
           cx="25"

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -378,7 +378,9 @@
       "select": {
         "base": {
           "border": "1px solid",
-          "borderColor": "grey-40"
+          "borderColor": "grey-40",
+          "borderRadius": 4,
+          "iconColor": "experimental-text"
         },
         "variants": {
           "error": {
@@ -1354,7 +1356,8 @@
   "productTable": {
     "row": {
       "main": {
-        "borderColor": "grey-20"
+        "borderColor": "grey-20",
+        "borderRadius": 4
       },
       "header": {
         "borderBottomColor": "grey-20"


### PR DESCRIPTION
# Description

- Add overlay support to dropdown component
- Make caret icon colour themeable
- Fix bug where themed-icon missing icon didn't have `className` passed through to it
- Couple border-radius changes in money theme

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
