### PR TITLE
Fix typings for ToggleSwitch

### DIFF
--- a/src/elements/toggle-switch/src/index.tsx
+++ b/src/elements/toggle-switch/src/index.tsx
@@ -1,11 +1,15 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { Palette } from '@uswitch/trustyle-utils.palette'
+import { DetailedHTMLProps, InputHTMLAttributes } from 'react'
 
-interface Props {
+interface Props
+  extends DetailedHTMLProps<
+    InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {
   checked: boolean
   onChange?: (e: React.SyntheticEvent) => void
-  'aria-label'?: string
   icons?: {
     checked: React.ReactNode
     unchecked: React.ReactNode


### PR DESCRIPTION
# Description

Remaining props are passed to input element but type definition didn't
extend input props.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated