### PR TITLE
Skip drone on lerna version commits to speed up time to merge

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -22,6 +22,9 @@
     },
     "publish": {
       "includeMergedTags": true
+    },
+    "version": {
+      "message": "Version [CI SKIP]"
     }
   }
 }


### PR DESCRIPTION
# Description

As you have to push before running `lerna version`, drone runs on that and so isn't needed on the version commit.

This will speed up the process of getting stuff approved and merged.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
