### PR TITLE
Fix previous/next pagination buttons

### DIFF
--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -121,12 +121,13 @@ const Pagination: React.FC<Props> = ({
           ...liStyling
         }}
       >
+        {console.log(currentPage)}
         {currentPage === 1 ? (
           <InlineIcon direction="left" />
         ) : (
           <a
-            onClick={e => onPageChange(1, e)}
-            href={numberToLink && numberToLink(1)}
+            onClick={e => onPageChange(currentPage--, e)}
+            href={numberToLink && numberToLink(currentPage--)}
             sx={anchorStyling}
           >
             <InlineIcon direction="left" />
@@ -166,8 +167,8 @@ const Pagination: React.FC<Props> = ({
           <InlineIcon direction="right" />
         ) : (
           <a
-            onClick={e => onPageChange(totalPages, e)}
-            href={numberToLink && numberToLink(totalPages)}
+            onClick={e => onPageChange(currentPage++, e)}
+            href={numberToLink && numberToLink(currentPage++)}
             sx={anchorStyling}
           >
             <InlineIcon direction="right" />

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -121,13 +121,12 @@ const Pagination: React.FC<Props> = ({
           ...liStyling
         }}
       >
-        {console.log(currentPage)}
         {currentPage === 1 ? (
           <InlineIcon direction="left" />
         ) : (
           <a
-            onClick={e => onPageChange(currentPage--, e)}
-            href={numberToLink && numberToLink(currentPage--)}
+            onClick={e => onPageChange(currentPage - 1, e)}
+            href={numberToLink && numberToLink(currentPage - 1)}
             sx={anchorStyling}
           >
             <InlineIcon direction="left" />
@@ -167,8 +166,8 @@ const Pagination: React.FC<Props> = ({
           <InlineIcon direction="right" />
         ) : (
           <a
-            onClick={e => onPageChange(currentPage++, e)}
-            href={numberToLink && numberToLink(currentPage++)}
+            onClick={e => onPageChange(currentPage + 1, e)}
+            href={numberToLink && numberToLink(currentPage + 1)}
             sx={anchorStyling}
           >
             <InlineIcon direction="right" />


### PR DESCRIPTION
# Description

Current Behaviour:
When you click on the arrow on the right you are taken to the last page
When you click on the arrow on the left you are taken to the first page

Expected Behaviour:
When you click on the arrow on the right you are taken to the next page
When you click on the arrow on the left you are taken to the previous page

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
