### PR TITLE
Slim hero category tiles on desktop

### DIFF
--- a/src/elements/icon-tile/src/index.tsx
+++ b/src/elements/icon-tile/src/index.tsx
@@ -30,7 +30,7 @@ const IconTile: React.FC<Props> = ({ icon, children }) => {
     >
       <div
         sx={{
-          flex: 1,
+          flex: [1, null, 0],
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center'
@@ -38,7 +38,14 @@ const IconTile: React.FC<Props> = ({ icon, children }) => {
       >
         {icon}
       </div>
-      <Styled.p sx={{ fontSize: 'md', marginY: 0, variant: 'iconTile.text' }}>
+      <Styled.p
+        sx={{
+          flex: [null, null, 1],
+          fontSize: 'md',
+          marginY: 0,
+          variant: 'iconTile.text'
+        }}
+      >
         {children}
       </Styled.p>
     </div>

--- a/src/elements/icon-tile/src/index.tsx
+++ b/src/elements/icon-tile/src/index.tsx
@@ -12,10 +12,10 @@ const IconTile: React.FC<Props> = ({ icon, children }) => {
       sx={{
         boxSizing: 'border-box',
         display: 'flex',
-        flexDirection: 'column',
-        height: 136,
+        flexDirection: ['column', 'column', 'row'],
+        height: [136, 136, 95],
         backgroundColor: 'white',
-        padding: 'sm',
+        padding: ['sm', 'sm', 'lg'],
         paddingTop: 0,
         textAlign: 'center',
         borderRadius: 8,
@@ -24,7 +24,8 @@ const IconTile: React.FC<Props> = ({ icon, children }) => {
         variant: 'iconTile.main',
         ':hover': {
           opacity: 0.9
-        }
+        },
+        alignItems: 'center'
       }}
     >
       <div


### PR DESCRIPTION
# Description

In the hero on the homepage we have the category tiles however they are quite large, as part of the new homepage design we have decided to slim these down. This is a replacement of the old, larger design.

<img width="1343" alt="Screenshot 2020-06-11 at 15 26 36" src="https://user-images.githubusercontent.com/14987594/84398512-f2fa8e80-abf7-11ea-8ad6-2708939b7cd1.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
