### PR TITLE
fix throwing error if theme is undefined

### DIFF
--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.frozen-input": "^2.0.0",
+    "@uswitch/trustyle.frozen-input": "^2.0.1",
     "@uswitch/trustyle.icon": "^1.8.4",
     "@uswitch/trustyle.styles": "^0.5.0"
   },

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -23,7 +23,7 @@ export const FrozenInput: React.FC<Props> = ({
 }) => {
   const [frozen, setFrozen] = useState(freezable && !!text)
   const { theme }: any = useThemeUI()
-  const iconGlyph = theme.name === 'Journey' ? 'edit-journey' : 'edit'
+  const iconGlyph = theme?.name === 'Journey' ? 'edit-journey' : 'edit'
 
   useEffect(() => {
     if (freezable && !frozen && !!text && inputRef && inputRef.current) {

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^2.0.0",
+    "@uswitch/trustyle.frozen-input": "^2.0.1",
     "@uswitch/trustyle.styles": "^0.5.0",
     "lodash.debounce": "^4.0.8",
     "react-input-mask": "^2.0.4"


### PR DESCRIPTION
# Description

For some reason this component is throwing an error `Cannot read property 'name' of null` when used in `Dropdown -> Eevee Components -> Eevee`.
I don't know why, because it works in just `Dropdown -> Eevee Components`, and there is definitely a theme in Eevee because other components use it in the exact same way, but this fixes it.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
