### PR TITLE
Move itemsPerRow to correct position

### DIFF
--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -216,6 +216,59 @@
   },
 
   "compounds": {
+    "card": {
+      "itemsPerRow": [1], 
+      "base": {
+        "width": "100%",
+        "height": "100%",
+        "borderStyle": "solid",
+        "borderColor": "grey-20",
+        "borderWidth": "1px 0 0 0",
+        "boxSizing": "border-box",
+        "mb": "sm",
+        "img": {
+          "width": "100%"
+        },
+        "p": { "fontSize": 16, "lineHeight": "130%", "color": "grey-80" },
+        "h3": {
+          "fontSize": 18,
+          "minHeight": 0,
+          "fontWeight": "bold",
+          "color": "experimental-text",
+          "marginBottom": "xs",
+          "marginTop": "0",
+          "a": {
+            "textDecoration": "none"
+          }
+        },
+        "content": {
+          "paddingY": "lg",
+          "marginRight": "lg"
+        },
+        "marginRight": "base"
+      },
+      "variants": {
+        "vertical": {
+          "variant": "compounds.card.base",
+          "display": "flex",
+          "flexDirection": "row-reverse", 
+          "alignItems": "start",
+          "image": {
+            "paddingTop": "lg", 
+            "width": 250
+          },
+
+          "content": {
+            "width": 670,
+            "variant": "compounds.card.base.content"
+          },
+          "link": {
+            "variant": "compounds.card.base.link"
+          }
+        }
+      }
+    },
+    
     "accordion": {
       "base": {
         "marginTop": "sm",
@@ -271,8 +324,8 @@
       
       "layout": {
         "flexDirection": ["column-reverse", "column-reverse", "column-reverse"], 
-        "text": [12],
-        "nav": [12]
+        "text": [12, 12, 12],
+        "nav": [12, 12, 12]
       },
       
       "internalLinkList": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -217,7 +217,7 @@
 
   "compounds": {
     "card": {
-      "itemsPerRow": [1], 
+      "itemsPerRow": [1, 2, 3],
       "base": {
         "width": "100%",
         "height": "100%",
@@ -412,10 +412,6 @@
         "borderColor": "primary",
         "color": "grey-100"
       }
-    },
-
-    "card": {
-      "itemsPerRow": [1, 2, 3]
     }
   },
 

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -359,6 +359,10 @@
         "borderColor": "primary",
         "color": "grey-100"
       }
+    },
+
+    "card": {
+      "itemsPerRow": [1, 2, 3]
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -548,8 +548,8 @@
     },
 
     "card": {
+      "itemsPerRow": [1, 2, 3],
       "base": {
-        "itemsPerRow": [1, 2, 3],
         "width": "100%",
         "height": "100%",
         "boxSizing": "border-box",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -587,6 +587,7 @@
     },
 
     "card": {
+      "itemsPerRow": [1, 2, 3],
       "base": {
         "*": {
           "fontFamily": "Helvetica"


### PR DESCRIPTION
# Description

Category guides model uses `itemsPerRow` to calculate how many columns. This was removed by accident. This PR adds it back to money, uswitch and bankrate

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
