### PR TITLE
Add quick links as variant to link list

### DIFF
--- a/src/compounds/interactive-tabs/package.json
+++ b/src/compounds/interactive-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.interactive-tabs",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -15,6 +15,6 @@
     "@uswitch/trustyle-utils.get": "^1.0.5",
     "@uswitch/trustyle.carousel": "^1.1.0",
     "@uswitch/trustyle.flex-grid": "^2.2.3",
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.5.1"
+    "@uswitch/trustyle.accordion": "^0.5.2"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,7 +16,7 @@
     "@uswitch/trustyle.awards-tag": "^0.0.5",
     "@uswitch/trustyle.button": "^0.11.10",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
-    "@uswitch/trustyle.icon": "^1.8.5",
+    "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.imgix-image": "^0.1.36",
     "@uswitch/trustyle.primary-info-block": "^0.2.11",
     "@uswitch/trustyle.sponsored-by-tag": "^0.0.5",

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -18,7 +18,7 @@
     "@uswitch/trustyle.button-link": "^1.0.3",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.8",
-    "@uswitch/trustyle.icon": "^1.8.5",
+    "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.imgix-image": "^0.1.36",
     "@uswitch/trustyle.primary-info-block": "^0.2.11",
     "@uswitch/trustyle.sponsored-by-tag": "^0.0.5",

--- a/src/compounds/testimonial-card/package.json
+++ b/src/compounds/testimonial-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.testimonial-card",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   },
   "devDependencies": {
     "@uswitch/trustyle.carousel": "^1.1.0"

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,6 +16,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/elements/author-profile/package.json
+++ b/src/elements/author-profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author-profile",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/elements/breadcrumbs/package.json
+++ b/src/elements/breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.breadcrumbs",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/elements/bullet-list-highlight/package.json
+++ b/src/elements/bullet-list-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bullet-list-highlight",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5",
+    "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.styles": "^0.5.1"
   },
   "devDependencies": {

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.palette": "^1.0.5",
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "devDependencies": {
-    "@uswitch/trustyle.breadcrumbs": "^1.3.1"
+    "@uswitch/trustyle.breadcrumbs": "^1.3.2"
   },
   "dependencies": {
     "@uswitch/trustyle.flex-grid": "^2.2.4"

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.frozen-input": "^2.0.4",
-    "@uswitch/trustyle.icon": "^1.8.5",
+    "@uswitch/trustyle.frozen-input": "^2.0.5",
+    "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.styles": "^0.5.1"
   },
   "devDependencies": {

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.5.1"
+    "@uswitch/trustyle.accordion": "^0.5.2"
   }
 }

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5",
+    "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.styles": "^0.5.1"
   },
   "devDependencies": {

--- a/src/elements/icon/package.json
+++ b/src/elements/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.icon",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/icon/src/filled-arrow.tsx
+++ b/src/elements/icon/src/filled-arrow.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+import * as st from './styles'
+
+interface Props {
+  color: string
+  size?: number
+}
+
+export const FilledArrow: React.FC<Props> = ({ color, size }) => (
+  <svg
+    sx={{
+      display: 'block',
+      ...st.size(size),
+      fill: color
+    }}
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M0 8.90015C0 8.07172 0.671573 7.40015 1.5 7.40015H10V10.4001H1.5C0.671573 10.4001 0 9.72857 0 8.90015Z" />
+    <path d="M17.1716 8.256C17.614 8.65334 17.614 9.34666 17.1716 9.744L10.9896 15.296C10.3459 15.8742 9.32143 15.4173 9.32143 14.552L9.32143 3.44796C9.32143 2.58269 10.3459 2.12581 10.9896 2.70397L17.1716 8.256Z" />
+  </svg>
+)

--- a/src/elements/icon/src/index.tsx
+++ b/src/elements/icon/src/index.tsx
@@ -14,6 +14,7 @@ import { Conversation } from './conversation'
 import { Cross } from './cross'
 import { Edit } from './edit'
 import { Email } from './email'
+import { FilledArrow } from './filled-arrow'
 import { Filters } from './filters'
 import { Four } from './four'
 import { Home } from './home'
@@ -48,6 +49,7 @@ export type Glyph =
   | 'cross'
   | 'edit'
   | 'email'
+  | 'filled-arrow'
   | 'filters'
   | 'four'
   | 'home'
@@ -113,6 +115,8 @@ export const Icon: React.FC<Props> = ({
       return <Edit color={color} size={size} />
     case 'email':
       return <Email color={color} size={size} />
+    case 'filled-arrow':
+      return <FilledArrow color={color} size={size} />
     case 'filters':
       return <Filters color={color} size={size} />
     case 'four':

--- a/src/elements/icon/src/stories.tsx
+++ b/src/elements/icon/src/stories.tsx
@@ -18,6 +18,7 @@ const glyphChoices: Glyph[] = [
   'cross',
   'edit',
   'email',
+  'filled-arrow',
   'filters',
   'four',
   'home',

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^2.0.4",
+    "@uswitch/trustyle.frozen-input": "^2.0.5",
     "@uswitch/trustyle.styles": "^0.5.1",
     "lodash.debounce": "^4.0.8",
     "react-input-mask": "^2.0.4"

--- a/src/elements/link-list/package.json
+++ b/src/elements/link-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.link-list",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/link-list/src/index.tsx
+++ b/src/elements/link-list/src/index.tsx
@@ -3,28 +3,46 @@
 import * as React from 'react'
 import { jsx, Styled } from 'theme-ui'
 
+export type Variant = 'base' | 'quickLinks'
+
 interface ListLinkProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string
+  icon?: React.ReactNode
+  variant?: Variant
   className?: string
 }
+
+const styles = (variant: Variant, element?: string) =>
+  `elements.linkList.variants.${variant}${element ? `.${element}` : ''}`
 
 export const LinkList: React.FC<ListLinkProps> = ({
   children,
   title,
+  icon,
+  variant = 'base',
   className
 }) => {
   return (
-    <div className={className}>
-      <Styled.h3
-        as="h2"
+    <div className={className} sx={{ variant: styles(variant) }}>
+      <div
         sx={{
-          paddingTop: 'xs',
-          paddingBottom: 'xs',
-          margin: 0
+          display: 'flex',
+          alignItems: 'center',
+          variant: styles(variant, 'header')
         }}
       >
-        {title}
-      </Styled.h3>
+        {icon}
+        <Styled.h3
+          as="h2"
+          sx={{
+            paddingTop: 'xs',
+            paddingBottom: 'xs',
+            margin: 0
+          }}
+        >
+          {title}
+        </Styled.h3>
+      </div>
       <ul
         sx={{
           padding: 0,
@@ -41,12 +59,14 @@ export const LinkList: React.FC<ListLinkProps> = ({
 interface ListLinkItemProps extends React.HTMLAttributes<HTMLDivElement> {
   href?: string
   className?: string
+  icon?: React.ReactNode
 }
 
 export const LinkListItem: React.FC<ListLinkItemProps> = ({
   children,
   href,
-  className
+  className,
+  icon
 }) => {
   return (
     <li
@@ -56,7 +76,10 @@ export const LinkListItem: React.FC<ListLinkItemProps> = ({
         borderTopColor: 'grey-20',
         paddingTop: 'xs',
         paddingBottom: 'xs',
-        marginBottom: '0'
+        marginBottom: '0',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center'
       }}
       className={className}
     >
@@ -71,6 +94,7 @@ export const LinkListItem: React.FC<ListLinkItemProps> = ({
       >
         {children}
       </Styled.a>
+      {icon}
     </li>
   )
 }

--- a/src/elements/link-list/src/stories.tsx
+++ b/src/elements/link-list/src/stories.tsx
@@ -1,9 +1,11 @@
 /** @jsx jsx */
 import * as React from 'react'
 import { css, jsx } from '@emotion/core'
-import { number } from '@storybook/addon-knobs'
+import { number, select } from '@storybook/addon-knobs'
 
 import AllThemes from '../../../utils/all-themes'
+import { FilledArrow } from '../../call-out/node_modules/@uswitch/trustyle.icon/src/filled-arrow'
+import { ButtonLink } from '../../button-link/src'
 
 import { LinkList, LinkListItem } from './'
 
@@ -33,10 +35,50 @@ PrimaryVariant.story = {
   }
 }
 
+export const QuickLinks = () => {
+  const icon = select('Icon', ['creditCards', 'loans'], 'creditCards')
+
+  const iconImg = (icon: string) => (
+    <img src={require(`../../../../static/money-icons/${icon}.svg`)} />
+  )
+
+  const arrow = <FilledArrow color="" size={18} />
+
+  return (
+    <div css={css({ padding: number('Padding', 10) })}>
+      <LinkList title="Quick Links" icon={iconImg(icon)} variant="quickLinks">
+        <LinkListItem href="https://www.jonathanfielding.com" icon={arrow}>
+          Jonathans Blog
+        </LinkListItem>
+        <LinkListItem href="https://www.performancebudget.io" icon={arrow}>
+          Performance Budget Tool
+        </LinkListItem>
+        <LinkListItem href="https://www.duckduckgo.com" icon={arrow}>
+          Ethical search engine
+        </LinkListItem>
+      </LinkList>
+      <ButtonLink
+        size="small"
+        variant="primary"
+        href="https://www.money.co.uk/savings-accounts/investment-isas.htm"
+      >
+        Compare ISAs
+      </ButtonLink>
+    </div>
+  )
+}
+
+QuickLinks.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 export const AutomatedTests = () => {
   return (
     <AllThemes>
       <PrimaryVariant />
+      <QuickLinks />
     </AllThemes>
   )
 }

--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/elements/read-more-card/package.json
+++ b/src/elements/read-more-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.read-more-card",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5"
+    "@uswitch/trustyle.icon": "^1.8.6"
   }
 }

--- a/src/elements/side-drawer/package.json
+++ b/src/elements/side-drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-drawer",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.8.5",
+    "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.styles": "^0.5.1",
     "focus-trap-react": "^6.0.0",
     "react-dom": "^16.7.0",

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -150,7 +150,8 @@
     "experimental-text": "#29335C",
     "button-secondary": "#34454E",
     "button-secondary--hover": "#5D6A72",
-    "button-hollow--hover": "#FFF6E2"
+    "button-hollow--hover": "#FFF6E2",
+    "quick-link-bg": "#F1F1F3"
   },
 
   "radii": {
@@ -398,6 +399,49 @@
           "focus": {
             "variant": "elements.drop-down.select.base",
             "outlineColor": "plum"
+          }
+        }
+      }
+    },
+
+    "linkList": {
+      "variants": {
+        "quickLinks": {
+          "display": "flex",
+          "flex-direction": "column",
+          "header": {
+            "paddingY":["sm","md"]
+          },
+          "img": {
+            "mr": "sm",
+            "width": [57,35]
+          },
+          "h2": {
+            "color": "grey-80",
+            "fontWeight": "bold",
+            "fontSize": 20,
+            "padding": 0
+          },
+          "ul": {
+            "mb": ["sm",40]
+          },
+          "li": {
+            "border": "none",
+            "borderRadius": 4,
+            "bg": "quick-link-bg",
+            "fontSize": "xs",
+            "fontWeight": "bold",
+            "paddingX": "md",
+            "paddingY": "sm",
+            "mb": "xs",
+
+            "svg": {
+              "fill": "plum"
+            }
+          },
+
+          "& + a": {
+            "width": ["100%", "unset"]
           }
         }
       }


### PR DESCRIPTION
# Description

Add quick links as a variant to link list. Affects Money theme.

## Desktop
![Screenshot 2020-06-19 at 15 52 47](https://user-images.githubusercontent.com/14987594/85146209-6d08c400-b245-11ea-9567-d9f0be42679a.png)

## Mobile
![Screenshot 2020-06-19 at 15 53 01](https://user-images.githubusercontent.com/14987594/85146274-72660e80-b245-11ea-8c75-0569b49c978b.png)

# Checklist

Pull request contains:

- [x] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
