### PR TITLE
Update README with warning about versioning early

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ To add a new element, copy the template to the src/elements directory, update th
 
 ## Publishing
 
+**Do not do this until you are ready to merge and your PR has been approved!** Justification below.
+
 To preview which packages have changed, you can run `npx lerna changed` without publishing.
 
 Once happy with the code changes, run `npx lerna version` and bump the versions accordingly.
 
 Lerna will generate a publish commit. Push that commit to your remote branch and once it gets merged to master, CI will publish the new versions to `npm`.
+
+Why you shouldn't publish until ready to merge:
+
+- You will block anyone else who wants to change that package or any dependents or dependencies until your PR is merged.
+- If changes are requested, you will have to update the version again after making the changes.
+- If you have to merge in master, you will have to update the version again.
 
 ## TODO:
 


### PR DESCRIPTION
# Description

Have seen a couple people get blocked by this recently, and a bunch of the bot warnings in #trustyle were from people versioning early and then having to merge in master.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
