### PR TITLE
Bug/author profile

### DIFF
--- a/src/elements/author-profile/package.json
+++ b/src/elements/author-profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author-profile",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/author-profile/src/index.tsx
+++ b/src/elements/author-profile/src/index.tsx
@@ -49,7 +49,9 @@ const AuthorProfile: React.FC<Props> = ({
             sx={{
               maxHeight: '100%',
               maxWidth: '100%',
-              borderRadius: '50%'
+              borderRadius: '50%',
+              objectFit: 'cover',
+              height: '100%'
             }}
           />
         </Styled.a>


### PR DESCRIPTION
# Description

Depending on photo size image was sometimes rendered elliptically.
Branch contains fix, image is now always scaled and rounded.
