### PR TITLE
Add hero-card compound

### DIFF
--- a/src/compounds/hero-card/.npmignore
+++ b/src/compounds/hero-card/.npmignore
@@ -1,0 +1,6 @@
+**/*
+
+!lib/*
+!package.json
+!README.md
+!LICENSE

--- a/src/compounds/hero-card/.npmrc
+++ b/src/compounds/hero-card/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/src/compounds/hero-card/package.json
+++ b/src/compounds/hero-card/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@uswitch/trustyle.hero-card",
+  "version": "0.0.0",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "ts:main": "src/index.tsx",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.0.27",
+    "react": "^16.7.0"
+  },
+  "dependencies": {
+    "@uswitch/trustyle-utils.get": "^1.0.5",
+    "@uswitch/trustyle.button-link": "^1.0.3"
+  }
+}

--- a/src/compounds/hero-card/src/index.tsx
+++ b/src/compounds/hero-card/src/index.tsx
@@ -17,16 +17,22 @@ const HeroCard: React.FC<Props> = ({ title, ctaText, children }) => {
   return (
     <div
       sx={{
-        display: 'grid',
-        alignItems: 'center',
+        display: 'flex',
         variant: styles()
       }}
     >
-      <Styled.h1>{title}</Styled.h1>
+      <div sx={{ variant: styles('flexContainer') }}>
+        <Styled.h1>{title}</Styled.h1>
+        <ButtonLink
+          variant="primary"
+          size="small"
+          sx={{ variant: styles('buttonLink'), display: ['none', 'initial'] }}
+        >
+          {ctaText}
+        </ButtonLink>
+      </div>
       <div
         sx={{
-          gridColumn: [1, 2],
-          gridRow: [null, '1/span 2'],
           variant: styles('links')
         }}
       >
@@ -35,7 +41,7 @@ const HeroCard: React.FC<Props> = ({ title, ctaText, children }) => {
       <ButtonLink
         variant="primary"
         size="small"
-        sx={{ variant: styles('buttonLink') }}
+        sx={{ variant: styles('buttonLink'), display: ['initial', 'none'] }}
       >
         {ctaText}
       </ButtonLink>

--- a/src/compounds/hero-card/src/index.tsx
+++ b/src/compounds/hero-card/src/index.tsx
@@ -1,0 +1,46 @@
+/** @jsx jsx */
+
+import * as React from 'react'
+import { jsx, Styled } from 'theme-ui'
+import { ButtonLink } from '@uswitch/trustyle.button-link'
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  title: string
+  ctaText: string
+  children: React.ReactNode
+}
+
+const styles = (element?: string) =>
+  `compounds.heroCard.variants${element ? `.${element}` : ''}`
+
+const HeroCard: React.FC<Props> = ({ title, ctaText, children }) => {
+  return (
+    <div
+      sx={{
+        display: 'grid',
+        alignItems: 'center',
+        variant: styles()
+      }}
+    >
+      <Styled.h1>{title}</Styled.h1>
+      <div
+        sx={{
+          gridColumn: [1, 2],
+          gridRow: [null, '1/span 2'],
+          variant: styles('links')
+        }}
+      >
+        {children}
+      </div>
+      <ButtonLink
+        variant="primary"
+        size="small"
+        sx={{ variant: styles('buttonLink') }}
+      >
+        {ctaText}
+      </ButtonLink>
+    </div>
+  )
+}
+
+export default HeroCard

--- a/src/compounds/hero-card/src/stories.tsx
+++ b/src/compounds/hero-card/src/stories.tsx
@@ -1,0 +1,53 @@
+/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+import { text } from '@storybook/addon-knobs'
+
+import AllThemes, { permutationsGenerator } from '../../../utils/all-themes'
+import { LinkList, LinkListItem } from '../../../elements/link-list/src'
+import { FilledArrow } from '../../../elements/icon/src/filled-arrow'
+
+import HeroCard from '.'
+
+export default {
+  title: 'Compounds|HeroCard'
+}
+
+const title: string = text(
+  'Headline',
+  'Use a travel credit card to avoid spending fees abroad.'
+)
+const ctaText: string = text('CTA', 'Compare Credit Cards')
+const arrow = <FilledArrow color="" />
+
+export const ExampleWithKnobs = () => {
+  return (
+    <HeroCard ctaText={ctaText} title={title}>
+      <LinkList variant="quickLinks">
+        <LinkListItem icon={arrow}>Car Insurance</LinkListItem>
+        <LinkListItem icon={arrow}>Home Insurance</LinkListItem>
+        <LinkListItem icon={arrow}>Income Protection Insurance</LinkListItem>
+      </LinkList>
+    </HeroCard>
+  )
+}
+
+ExampleWithKnobs.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+export const AutomatedTests = () => {
+  const permutations = permutationsGenerator({
+    variant: ['primary']
+  })
+
+  return (
+    <AllThemes>
+      {permutations.map((p, i) => (
+        <ExampleWithKnobs key={i} />
+      ))}
+    </AllThemes>
+  )
+}

--- a/src/elements/link-list/src/index.tsx
+++ b/src/elements/link-list/src/index.tsx
@@ -24,25 +24,29 @@ export const LinkList: React.FC<ListLinkProps> = ({
 }) => {
   return (
     <div className={className} sx={{ variant: styles(variant) }}>
-      <div
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          variant: styles(variant, 'header')
-        }}
-      >
-        {icon}
-        <Styled.h3
-          as="h2"
+      {(title || icon) && (
+        <div
           sx={{
-            paddingTop: 'xs',
-            paddingBottom: 'xs',
-            margin: 0
+            display: 'flex',
+            alignItems: 'center',
+            variant: styles(variant, 'header')
           }}
         >
-          {title}
-        </Styled.h3>
-      </div>
+          {icon}
+          {title && (
+            <Styled.h3
+              as="h2"
+              sx={{
+                paddingTop: 'xs',
+                paddingBottom: 'xs',
+                margin: 0
+              }}
+            >
+              {title}
+            </Styled.h3>
+          )}
+        </div>
+      )}
       <ul
         sx={{
           padding: 0,

--- a/src/elements/link-list/src/index.tsx
+++ b/src/elements/link-list/src/index.tsx
@@ -25,7 +25,7 @@ export const LinkList: React.FC<ListLinkProps> = ({
   return (
     <div className={className} sx={{ variant: styles(variant) }}>
       {(title || icon) && (
-        <div
+        <header
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -45,7 +45,7 @@ export const LinkList: React.FC<ListLinkProps> = ({
               {title}
             </Styled.h3>
           )}
-        </div>
+        </header>
       )}
       <ul
         sx={{

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -423,7 +423,7 @@
             "padding": 0
           },
           "ul": {
-            "mb": ["sm",40]
+            "mb": 0
           },
           "li": {
             "border": "none",
@@ -433,14 +433,18 @@
             "fontWeight": "bold",
             "paddingX": "md",
             "paddingY": "sm",
-            "mb": "xs",
 
             "svg": {
               "fill": "plum"
+            },
+
+            "& + li": {
+              "mt": "xs"
             }
           },
 
           "& + a": {
+            "mt": ["sm",40],
             "width": ["100%", "unset"]
           }
         }
@@ -817,6 +821,29 @@
       "button-with-checkbox-checked": {
         "variant": "compounds.cookie-banner.button-with-checkbox",
         "borderColor": "plum"
+      }
+    },
+
+    "heroCard": {
+      "variants": {
+        "background": "linear-gradient(161.42deg, #924A8B 22.95%, #AF4C83 77.05%)",
+        "box-shadow": "0px 9px 19px rgba(92, 36, 87, 0.2)",
+        "column-gap": 104,
+        "paddingX":["sm","xxxl"],
+        "pt": ["md", 85],
+        "pb": ["lg", 85],
+        "border-radius": ["4px", "8px"],
+        "grid-template-columns": ["1fr", "1fr 1fr"],
+        "h1": {
+          "color": "grey-0",
+          "align-self": [null, "flex-end"]
+        },
+
+        "buttonLink": {
+          "justify-self": "baseline",
+          "align-self": "flex-start",
+          "mt":["sm", 0]
+        }
       }
     }
   },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -826,23 +826,32 @@
 
     "heroCard": {
       "variants": {
+        "flex-direction": ["column", "row"],
         "background": "linear-gradient(161.42deg, #924A8B 22.95%, #AF4C83 77.05%)",
         "box-shadow": "0px 9px 19px rgba(92, 36, 87, 0.2)",
-        "column-gap": 104,
         "paddingX":["sm","xxxl"],
         "pt": ["md", 85],
         "pb": ["lg", 85],
         "border-radius": ["4px", "8px"],
-        "grid-template-columns": ["1fr", "1fr 1fr"],
         "h1": {
-          "color": "grey-0",
-          "align-self": [null, "flex-end"]
+          "color": "grey-0"
+        },
+
+        "links": {
+          "width": ["initial","50%"]
+        },
+
+        "flexContainer": {
+          "width": ["initial","50%"],
+          "mr": [0,104],
+          "display": ["flex"],
+          "flex-direction": "column",
+          "justify-content": "center",
+          "align-items": "flex-start"
         },
 
         "buttonLink": {
-          "justify-self": "baseline",
-          "align-self": "flex-start",
-          "mt":["sm", 0]
+          "mt":["sm","xs"]
         }
       }
     }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -56,7 +56,8 @@
     "lg": 32,
     "xl": 48,
     "xxl": 64,
-    "xxxl": 96
+    "xxxl": 96,
+    "4xl": 112
   },
 
   "sizes": {
@@ -829,9 +830,9 @@
         "flex-direction": ["column", "row"],
         "background": "linear-gradient(161.42deg, #924A8B 22.95%, #AF4C83 77.05%)",
         "box-shadow": "0px 9px 19px rgba(92, 36, 87, 0.2)",
-        "paddingX":["sm","xxxl"],
-        "pt": ["md", 85],
-        "pb": ["lg", 85],
+        "paddingX":["sm","4xl"],
+        "pt": ["md", "xxxl"],
+        "pb": ["lg", "xxxl"],
         "border-radius": ["4px", "8px"],
         "h1": {
           "color": "grey-0"
@@ -843,7 +844,7 @@
 
         "flexContainer": {
           "width": ["initial","50%"],
-          "mr": [0,104],
+          "mr": [0,"4xl"],
           "display": ["flex"],
           "flex-direction": "column",
           "justify-content": "center",


### PR DESCRIPTION
# Description

The hero-card is a component needed on the money website to call out seasonal products.

![Screenshot 2020-06-25 at 10 30 45](https://user-images.githubusercontent.com/14987594/85694382-fc432b00-b6ce-11ea-9a56-037126061a91.png)

![Screenshot 2020-06-25 at 10 19 27](https://user-images.githubusercontent.com/14987594/85694364-f9483a80-b6ce-11ea-8228-2e09fe449b47.png)

# Checklist

Pull request contains:

- [x] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
