### PR TITLE
Add critical prop to Card (for imgix)

### DIFF
--- a/src/elements/card/src/index.tsx
+++ b/src/elements/card/src/index.tsx
@@ -6,7 +6,7 @@ import { ImgixImage } from '@uswitch/trustyle.imgix-image'
 
 interface Props {
   className?: string
-  superScript?: string
+  critical?: boolean
   description?: string
   horizontal?: boolean
   imageSize?: 'cover' | 'contain'
@@ -15,6 +15,7 @@ interface Props {
   imgSrc: string
   linkHref: string
   linkText?: string
+  superScript?: string
   tag?: string
   title: string
 }
@@ -24,7 +25,7 @@ const makeStyles = (variant: string) => (element?: string) =>
 
 const Card: React.FC<Props> = ({
   className = '',
-  superScript,
+  critical = true,
   description,
   horizontal = false,
   imageSize = 'cover',
@@ -33,6 +34,7 @@ const Card: React.FC<Props> = ({
   imgSrc,
   linkHref,
   linkText,
+  superScript,
   tag,
   title
 }) => {
@@ -56,7 +58,7 @@ const Card: React.FC<Props> = ({
             ar: '16:9',
             fill: 'solid'
           }}
-          critical
+          critical={critical}
         />
       </Styled.a>
       <div


### PR DESCRIPTION
# Description

Images in cards are not lazyloaded. This commit introduces a `critical`
prop that can be used to enable lazyloading.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated