### PR TITLE
Visual changes for product table

### DIFF
--- a/src/compounds/product-table/src/components/cell-content.tsx
+++ b/src/compounds/product-table/src/components/cell-content.tsx
@@ -33,7 +33,8 @@ const RowContent: React.FC<ContentRowProps> = ({
   children,
   inAddon,
   label,
-  mobileOrder
+  mobileOrder,
+  className
 }) => (
   <CellBase
     mobileOrder={mobileOrder || (accent ? 1 : 2)}
@@ -52,6 +53,7 @@ const RowContent: React.FC<ContentRowProps> = ({
     }}
     // @ts-ignore
     css={{ display: '-ms-grid' }}
+    className={className}
   >
     <div
       sx={{
@@ -86,6 +88,7 @@ const BlockContent: React.FC<CellPrimaryProps> = ({
   label,
   accent,
   mobileOrder,
+  className,
   children
 }) => (
   <CellBase
@@ -103,6 +106,7 @@ const BlockContent: React.FC<CellPrimaryProps> = ({
     }}
     // @ts-ignore
     css={{ display: '-ms-grid' }}
+    className={className}
   >
     <div
       sx={{
@@ -147,7 +151,24 @@ const ProductTableCellContent: React.FC<CellPrimaryProps> = ({
     )
   }
 
-  return <BlockContent {...props}>{children}</BlockContent>
+  if (props.accent) {
+    return <BlockContent {...props}>{children}</BlockContent>
+  }
+
+  return (
+    <React.Fragment>
+      <RowContent
+        inAddon={inAddon}
+        {...props}
+        sx={{ display: [null, null, 'none'] }}
+      >
+        {children}
+      </RowContent>
+      <BlockContent {...props} sx={{ display: ['none', null, 'grid'] }}>
+        {children}
+      </BlockContent>
+    </React.Fragment>
+  )
 }
 
 export default ProductTableCellContent

--- a/src/compounds/product-table/src/components/data-auto.tsx
+++ b/src/compounds/product-table/src/components/data-auto.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, Styled } from 'theme-ui'
 
 interface FormattedText {
   size: 'big' | 'small'
@@ -35,6 +35,16 @@ function autoFormat(text?: string): FormattedText[] {
 
       return words.concat(word)
     }, [] as FormattedText[])
+    .map(word => {
+      if (word.size === 'big') {
+        return word
+      }
+
+      return {
+        size: word.size,
+        word: word.word.charAt(0) !== '/' ? ' ' + word.word : word.word
+      }
+    })
 }
 
 export interface DataAutoProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -44,7 +54,13 @@ const ProductTableDataAuto: React.FC<DataAutoProps> = ({ text }) => {
   return (
     <div>
       {autoFormat(text).map(({ word, size }) =>
-        size === 'small' ? <small>{word}</small> : word
+        size === 'small' ? (
+          <small>{word}</small>
+        ) : (
+          <Styled.h2 as="span" sx={{ color: 'inherit' }}>
+            {word}
+          </Styled.h2>
+        )
       )}
     </div>
   )

--- a/src/compounds/product-table/src/components/data-range.tsx
+++ b/src/compounds/product-table/src/components/data-range.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, Styled } from 'theme-ui'
 
 import { numberFormatter } from '../generics'
 
@@ -16,7 +16,9 @@ const ProductTableDataRange: React.FC<DataRangeProps> = ({
 }) => {
   return (
     <div>
-      {numberFormatter(from, unit)}
+      <Styled.h2 as="span" sx={{ color: 'inherit' }}>
+        {numberFormatter(from, unit)}
+      </Styled.h2>
       <small> to {numberFormatter(to, unit)}</small>
     </div>
   )

--- a/src/compounds/product-table/src/components/data-text-subscript.tsx
+++ b/src/compounds/product-table/src/components/data-text-subscript.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, Styled } from 'theme-ui'
 
 export interface DataTextSubscriptProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -13,7 +13,9 @@ const ProductTableDataTextSubscript: React.FC<DataTextSubscriptProps> = ({
 }) => {
   return (
     <div>
-      {text}
+      <Styled.h2 as="span" sx={{ color: 'inherit' }}>
+        {text}
+      </Styled.h2>
       <small>{' ' + subscript}</small>
     </div>
   )

--- a/src/compounds/product-table/src/components/data-value.tsx
+++ b/src/compounds/product-table/src/components/data-value.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, Styled } from 'theme-ui'
 
 import { numberFormatter } from '../generics'
 
@@ -17,7 +17,9 @@ const ProductTableDataValue: React.FC<DataValueProps> = ({
 }) => {
   return (
     <span>
-      {numberFormatter(value, unit)}
+      <Styled.h2 as="span" sx={{ color: 'inherit' }}>
+        {numberFormatter(value, unit)}
+      </Styled.h2>
       {typeof value === 'number' && subscript ? (
         <small>{` ${subscript}`}</small>
       ) : null}

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, Styled } from 'theme-ui'
 
 import { Addon, AddonArg, CellContext } from '../generics'
 
@@ -165,9 +165,11 @@ const ProductTableRow: React.FC<RowProps> = ({
                         {preTitle}
                       </span>
                     )}
-                    <h3 sx={{ margin: 0, variant: 'productTable.row.title' }}>
+                    <Styled.h3
+                      sx={{ margin: 0, variant: 'productTable.row.title' }}
+                    >
                       {rowTitle}
-                    </h3>
+                    </Styled.h3>
                     {subtitle && (
                       <span
                         sx={{


### PR DESCRIPTION
- Use Styled heading elements for table heading and formatted data
- Add spacing to auto formatter for stuff like "£10 a month" - was "£10a month" before
- Display un-accented cell content as row on smaller screens

This has changed it for all themes - didn't get a reply on whether it should only be done for money.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
