### PR TITLE
Form and Rich Text Block panel styling to themes

### DIFF
--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -735,18 +735,20 @@
     "base": {
       "*:first-child": { "mt": 0 }
     },
-    "panel-primary": {
-      "py": "lg",
-      "px": ["sm", "xl"],
-      "bg": "grey-0",
-      "color": "grey-80",
-      "p": {
-        "textAlign": ["center", "left"],
-        "mb": 0
-      },
-      "boxShadow":
-        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "md"
+    "variants": {
+      "panel-primary": {
+        "py": "lg",
+        "px": ["sm", "xl"],
+        "bg": "grey-0",
+        "color": "grey-80",
+        "p": {
+          "textAlign": ["center", "left"],
+          "mb": 0
+        },
+        "boxShadow":
+          "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+        "borderRadius": "md"
+      }  
     }
   },
 

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -737,12 +737,16 @@
     },
     "panel-primary": {
       "py": "lg",
-      "px": ["sm", "52px"],
+      "px": ["sm", "xl"],
       "bg": "grey-0",
       "color": "grey-80",
+      "p": {
+        "textAlign": ["center", "left"],
+        "mb": 0
+      },
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "5px"
+      "borderRadius": "md"
     }
   },
 
@@ -750,13 +754,11 @@
     "label" :{
       "variant": "styles.h4",
       "color": "grey-80",
-      "mb": "sm",
       "display": "block",
-      "mt": "sm",
       ":not(:first-child)": { "mb": "sm" }
     },
     "button": {
-      "my": "16px"
+      "my": "sm"
     }
   },
 

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -712,6 +712,35 @@
     "contentSpan": 8
   },
 
+  "richTextBlock": {
+    "base": {
+      "*:first-child": { "mt": 0 }
+    },
+    "panel-primary": {
+      "py": "lg",
+      "px": ["sm", "52px"],
+      "bg": "grey-0",
+      "color": "grey-80",
+      "boxShadow":
+        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+      "borderRadius": "5px"
+    }
+  },
+
+  "form": {
+    "label" :{
+      "variant": "styles.h4",
+      "color": "grey-80",
+      "mb": "sm",
+      "display": "block",
+      "mt": "sm",
+      ":not(:first-child)": { "mb": "sm" }
+    },
+    "button": {
+      "my": "16px"
+    }
+  },
+
   "styles": {
     "heading": {
       "fontFamily": "heading",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -755,7 +755,7 @@
       "variant": "styles.h4",
       "color": "grey-80",
       "display": "block",
-      ":not(:first-child)": { "mb": "sm" }
+      ":not(:first-child)": { "mt": "sm" }
     },
     "button": {
       "my": "sm"

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -973,7 +973,7 @@
       "variant": "styles.h4",
       "color": "grey-80",
       "display": "block",
-      ":not(:first-child)": { "mb": "sm" }
+      ":not(:first-child)": { "mt": "sm" }
     },
     "button": {
       "my": "sm"

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -953,18 +953,20 @@
     "base": {
       "*:first-child": { "mt": 0 }
     },
-    "panel-primary": {
-      "py": "lg",
-      "px": ["sm", "xl"],
-      "bg": "grey-0",
-      "color": "grey-80",
-      "p": {
-        "textAlign": ["center", "left"],
-        "mb": 0
-      },
-      "boxShadow":
-        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "md"
+    "variants": {
+      "panel-primary": {
+        "py": "lg",
+        "px": ["sm", "xl"],
+        "bg": "grey-0",
+        "color": "grey-80",
+        "p": {
+          "textAlign": ["center", "left"],
+          "mb": 0
+        },
+        "boxShadow":
+          "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+        "borderRadius": "md"
+      }  
     }
   },
 

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -955,12 +955,16 @@
     },
     "panel-primary": {
       "py": "lg",
-      "px": ["sm", "52px"],
+      "px": ["sm", "xl"],
       "bg": "grey-0",
       "color": "grey-80",
+      "p": {
+        "textAlign": ["center", "left"],
+        "mb": 0
+      },
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "5px"
+      "borderRadius": "md"
     }
   },
 
@@ -968,13 +972,11 @@
     "label" :{
       "variant": "styles.h4",
       "color": "grey-80",
-      "mb": "sm",
       "display": "block",
-      "mt": "sm",
       ":not(:first-child)": { "mb": "sm" }
     },
     "button": {
-      "my": "16px"
+      "my": "sm"
     }
   },
 

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -948,6 +948,35 @@
     }
   },
 
+  "richTextBlock": {
+    "base": {
+      "*:first-child": { "mt": 0 }
+    },
+    "panel-primary": {
+      "py": "lg",
+      "px": ["sm", "52px"],
+      "bg": "grey-0",
+      "color": "grey-80",
+      "boxShadow":
+        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+      "borderRadius": "5px"
+    }
+  },
+
+  "form": {
+    "label" :{
+      "variant": "styles.h4",
+      "color": "grey-80",
+      "mb": "sm",
+      "display": "block",
+      "mt": "sm",
+      ":not(:first-child)": { "mb": "sm" }
+    },
+    "button": {
+      "my": "16px"
+    }
+  },
+
   "styles": {
     "root": {
       "fontFamily": "base",

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1626,6 +1626,21 @@
     }
   },
 
+  "richTextBlock": {
+    "base": {
+      "*:first-child": { "mt": 0 }
+    },
+    "panel-primary": {
+      "py": "lg",
+      "px": ["sm", "52px"],
+      "bg": "grey-0",
+      "color": "grey-80",
+      "boxShadow":
+        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+      "borderRadius": "5px"
+    }
+  },
+
   "styles": {
     "heading": {
       "fontFamily": "heading",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1635,6 +1635,9 @@
       "px": ["sm", "52px"],
       "bg": "grey-0",
       "color": "grey-60",
+      ":not(:label)": {
+        "textAlign": ["center", "left"]
+      },
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
       "borderRadius": "5px"
@@ -1643,7 +1646,8 @@
 
   "form": {
     "label" :{
-      "variant": "styles.h4",
+      "fontSize": ["18px", "20px"],
+      "fontWeight": "bold",
       "color": "grey-80",
       "mb": "sm",
       "display": "block",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1654,7 +1654,7 @@
       ":not(:first-child)": { "mb": "sm" }
     },
     "button": {
-      "my": "16px"
+      "my": "sm"
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1632,26 +1632,25 @@
     },
     "panel-primary": {
       "py": "lg",
-      "px": ["sm", "52px"],
+      "px": ["sm", "xl"],
       "bg": "grey-0",
       "color": "grey-60",
-      ":not(:label)": {
-        "textAlign": ["center", "left"]
+      "p": {
+        "textAlign": ["center", "left"],
+        "mb": 0
       },
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "5px"
+      "borderRadius": "md"
     }
   },
 
   "form": {
     "label" :{
-      "fontSize": ["18px", "20px"],
+      "variant": "styles.h4",
       "fontWeight": "bold",
       "color": "grey-80",
-      "mb": "sm",
       "display": "block",
-      "mt": "sm",
       ":not(:first-child)": { "mb": "sm" }
     },
     "button": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1630,18 +1630,20 @@
     "base": {
       "*:first-child": { "mt": 0 }
     },
-    "panel-primary": {
-      "py": "lg",
-      "px": ["sm", "xl"],
-      "bg": "grey-0",
-      "color": "grey-60",
-      "p": {
-        "textAlign": ["center", "left"],
-        "mb": 0
-      },
-      "boxShadow":
-        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "md"
+    "variants": {
+      "panel-primary": {
+        "py": "lg",
+        "px": ["sm", "xl"],
+        "bg": "grey-0",
+        "color": "grey-60",
+        "p": {
+          "textAlign": ["center", "left"],
+          "mb": 0
+        },
+        "boxShadow":
+          "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+        "borderRadius": "md"
+      }
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1641,6 +1641,20 @@
     }
   },
 
+  "form": {
+    "label" :{
+      "variant": "styles.h4",
+      "color": "grey-80",
+      "mb": "sm",
+      "display": "block",
+      "mt": "sm",
+      ":not(:first-child)": { "mb": "sm" }
+    },
+    "button": {
+      "my": "16px"
+    }
+  },
+
   "styles": {
     "heading": {
       "fontFamily": "heading",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1651,7 +1651,7 @@
       "fontWeight": "bold",
       "color": "grey-80",
       "display": "block",
-      ":not(:first-child)": { "mb": "sm" }
+      ":not(:first-child)": { "mt": "sm" }
     },
     "button": {
       "my": "sm"

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1634,7 +1634,7 @@
       "py": "lg",
       "px": ["sm", "52px"],
       "bg": "grey-0",
-      "color": "grey-80",
+      "color": "grey-60",
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
       "borderRadius": "5px"

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -344,12 +344,16 @@
     },
     "panel-primary": {
       "py": "lg",
-      "px": ["sm", "52px"],
+      "px": ["sm", "xl"],
       "bg": "grey-0",
       "color": "grey-80",
+      "p": {
+        "textAlign": ["center", "left"],
+        "mb": 0
+      },
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "5px"
+      "borderRadius": "md"
     }
   },
 
@@ -357,13 +361,11 @@
     "label" :{
       "variant": "styles.h4",
       "color": "grey-80",
-      "mb": "sm",
       "display": "block",
-      "mt": "sm",
       ":not(:first-child)": { "mb": "sm" }
     },
     "button": {
-      "my": "16px"
+      "my": "sm"
     }
   },
 

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -342,18 +342,20 @@
     "base": {
       "*:first-child": { "mt": 0 }
     },
-    "panel-primary": {
-      "py": "lg",
-      "px": ["sm", "xl"],
-      "bg": "grey-0",
-      "color": "grey-80",
-      "p": {
-        "textAlign": ["center", "left"],
-        "mb": 0
-      },
-      "boxShadow":
-        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "md"
+    "variants": {
+      "panel-primary": {
+        "py": "lg",
+        "px": ["sm", "xl"],
+        "bg": "grey-0",
+        "color": "grey-80",
+        "p": {
+          "textAlign": ["center", "left"],
+          "mb": 0
+        },
+        "boxShadow":
+          "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+        "borderRadius": "md"
+      }  
     }
   },
 

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -338,6 +338,35 @@
     }
   },
 
+  "richTextBlock": {
+    "base": {
+      "*:first-child": { "mt": 0 }
+    },
+    "panel-primary": {
+      "py": "lg",
+      "px": ["sm", "52px"],
+      "bg": "grey-0",
+      "color": "grey-80",
+      "boxShadow":
+        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+      "borderRadius": "5px"
+    }
+  },
+
+  "form": {
+    "label" :{
+      "variant": "styles.h4",
+      "color": "grey-80",
+      "mb": "sm",
+      "display": "block",
+      "mt": "sm",
+      ":not(:first-child)": { "mb": "sm" }
+    },
+    "button": {
+      "my": "16px"
+    }
+  },
+
   "linkWithChevron": {
     "marginLeft": 8,
     "textDecoration": "underline"

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -362,7 +362,7 @@
       "variant": "styles.h4",
       "color": "grey-80",
       "display": "block",
-      ":not(:first-child)": { "mb": "sm" }
+      ":not(:first-child)": { "mt": "sm" }
     },
     "button": {
       "my": "sm"

--- a/src/themes/uswitch-rebrand/package.json
+++ b/src/themes/uswitch-rebrand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-rebrand-theme",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch-rebrand/theme.json
+++ b/src/themes/uswitch-rebrand/theme.json
@@ -1256,18 +1256,20 @@
     "base": {
       "*:first-child": { "mt": 0 }
     },
-    "panel-primary": {
-      "py": "lg",
-      "px": ["sm", "xl"],
-      "bg": "grey-0",
-      "color": "grey-80",
-      "p": {
-        "textAlign": ["center", "left"],
-        "mb": 0
-      },
-      "boxShadow":
-        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "md"
+    "variants": {
+      "panel-primary": {
+        "py": "lg",
+        "px": ["sm", "xl"],
+        "bg": "grey-0",
+        "color": "grey-80",
+        "p": {
+          "textAlign": ["center", "left"],
+          "mb": 0
+        },
+        "boxShadow":
+          "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+        "borderRadius": "md"
+      }  
     }
   },
 

--- a/src/themes/uswitch-rebrand/theme.json
+++ b/src/themes/uswitch-rebrand/theme.json
@@ -1276,7 +1276,7 @@
       "variant": "styles.h4",
       "color": "grey-80",
       "display": "block",
-      ":not(:first-child)": { "mb": "sm" }
+      ":not(:first-child)": { "mt": "sm" }
     },
     "button": {
       "my": "sm"

--- a/src/themes/uswitch-rebrand/theme.json
+++ b/src/themes/uswitch-rebrand/theme.json
@@ -1252,6 +1252,37 @@
     }
   },
 
+  "richTextBlock": {
+    "base": {
+      "*:first-child": { "mt": 0 }
+    },
+    "panel-primary": {
+      "py": "lg",
+      "px": ["sm", "xl"],
+      "bg": "grey-0",
+      "color": "grey-80",
+      "p": {
+        "textAlign": ["center", "left"],
+        "mb": 0
+      },
+      "boxShadow":
+        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+      "borderRadius": "md"
+    }
+  },
+
+  "form": {
+    "label" :{
+      "variant": "styles.h4",
+      "color": "grey-80",
+      "display": "block",
+      ":not(:first-child)": { "mb": "sm" }
+    },
+    "button": {
+      "my": "sm"
+    }
+  },
+
   "styles": {
     "root": {
       "fontFamily": "base",

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1591,12 +1591,16 @@
     },
     "panel-primary": {
       "py": "lg",
-      "px": ["sm", "52px"],
+      "px": ["sm", "xl"],
       "bg": "grey-0",
       "color": "grey-80",
+      "p": {
+        "textAlign": ["center", "left"],
+        "mb": 0
+      },
       "boxShadow":
         "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "5px"
+      "borderRadius": "md"
     }
   },
 
@@ -1604,13 +1608,11 @@
     "label" :{
       "variant": "styles.h4",
       "color": "grey-80",
-      "mb": "sm",
       "display": "block",
-      "mt": "sm",
       ":not(:first-child)": { "mb": "sm" }
     },
     "button": {
-      "my": "16px"
+      "my": "sm"
     }
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1585,6 +1585,35 @@
     }
   },
 
+  "richTextBlock": {
+    "base": {
+      "*:first-child": { "mt": 0 }
+    },
+    "panel-primary": {
+      "py": "lg",
+      "px": ["sm", "52px"],
+      "bg": "grey-0",
+      "color": "grey-80",
+      "boxShadow":
+        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+      "borderRadius": "5px"
+    }
+  },
+
+  "form": {
+    "label" :{
+      "variant": "styles.h4",
+      "color": "grey-80",
+      "mb": "sm",
+      "display": "block",
+      "mt": "sm",
+      ":not(:first-child)": { "mb": "sm" }
+    },
+    "button": {
+      "my": "16px"
+    }
+  },
+
   "styles": {
     "h1": {
       "fontFamily": "heading",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1589,18 +1589,20 @@
     "base": {
       "*:first-child": { "mt": 0 }
     },
-    "panel-primary": {
-      "py": "lg",
-      "px": ["sm", "xl"],
-      "bg": "grey-0",
-      "color": "grey-80",
-      "p": {
-        "textAlign": ["center", "left"],
-        "mb": 0
-      },
-      "boxShadow":
-        "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
-      "borderRadius": "md"
+    "variants": {
+      "panel-primary": {
+        "py": "lg",
+        "px": ["sm", "xl"],
+        "bg": "grey-0",
+        "color": "grey-80",
+        "p": {
+          "textAlign": ["center", "left"],
+          "mb": 0
+        },
+        "boxShadow":
+          "0px 2px 3px rgba(24, 24, 61, 0.06), 0px 5px 5px rgba(24, 24, 61, 0.06), 0px 8px 7px rgba(24, 24, 61, 0.06)",
+        "borderRadius": "md"
+      }  
     }
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1609,7 +1609,7 @@
       "variant": "styles.h4",
       "color": "grey-80",
       "display": "block",
-      ":not(:first-child)": { "mb": "sm" }
+      ":not(:first-child)": { "mt": "sm" }
     },
     "button": {
       "my": "sm"


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/56200818/85873590-3f81c480-b7c9-11ea-8094-a0ea6c9a189f.png)

Add styling for the Form (label and button) and Rich Text Block (base and panel-primary variant) to the themes for all brands. Note: Input styling will be on another PR

# Checklist

Pull request contains:

- [x] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
