### PR TITLE
Sponsored by tag - Money theme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To run storybook locally `npm start`.
 The packages are all built using the same build step. Run `npm run build` to build all the packages using `tsc`. All files matching `src/**/*.{ts,tsx}` are included and output is written to the `lib` directory within each package.
 
 To add a new element, copy the template to the src/elements directory, update the package.json with the name and add your source code.
-
+ 
 ## Publishing
 
 **Do not do this until you are ready to merge and your PR has been approved!** Justification below.

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@styled-system/css": "^5.1.5",
     "@types/styled-system__css": "^5.0.5",
     "@types/theme-ui": "file:types/theme-ui",
-    "styled-system": "^5.1.5"
+    "styled-system": "^5.1.5",
+    "tiny-debounce": "^0.1.1"
   }
 }

--- a/src/compounds/article-intro/package.json
+++ b/src/compounds/article-intro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.article-intro",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "devDependencies": {
-    "@uswitch/trustyle.author": "^0.4.0"
+    "@uswitch/trustyle.author": "^0.4.1"
   }
 }

--- a/src/elements/author/package.json
+++ b/src/elements/author/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/author/src/index.tsx
+++ b/src/elements/author/src/index.tsx
@@ -27,6 +27,9 @@ const Author: React.FC<Props> = ({
   editorUrl,
   className
 }) => {
+  const authorString = role
+    ? `Written by ${name}, ${role}`
+    : `Written by ${name}`
   return (
     <div
       sx={{
@@ -79,7 +82,7 @@ const Author: React.FC<Props> = ({
               variant: 'author.link'
             }}
           >
-            Written by {name}, {role}
+            {authorString}
           </a>
         </Styled.h6>
         <Styled.p

--- a/src/elements/checkbox-input/package.json
+++ b/src/elements/checkbox-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.checkbox-input",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/checkbox-input/src/index.tsx
+++ b/src/elements/checkbox-input/src/index.tsx
@@ -28,7 +28,7 @@ export const CheckboxInput: React.FC<Props> = ({
               transition: 'background-color 200ms, border-color 200ms'
             }
           },
-          variant: `input.checkbox.variants.${variant}`
+          variant: `elements.input.checkbox.variants.${variant}`
         }}
         type="checkbox"
         {...inputProps}
@@ -56,7 +56,7 @@ export const CheckboxInput: React.FC<Props> = ({
             flexGrow: 0,
             flexShrink: 0
           },
-          variant: 'input.checkbox.label'
+          variant: 'elements.input.checkbox.label'
         }}
       >
         {label}

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.frozen-input": "^2.0.5",
+    "@uswitch/trustyle.frozen-input": "^3.0.0",
     "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.styles": "^0.5.1"
   },

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useState } from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 import { Icon } from '@uswitch/trustyle.icon'
+import { colors } from '@uswitch/trustyle.styles'
 
 interface Props {
   text?: string
@@ -22,7 +23,7 @@ export const FrozenInput: React.FC<Props> = ({
   const { theme }: any = useThemeUI()
   const iconGlyph = theme.name === 'Journey' ? 'edit-journey' : 'edit'
   const iconColor =
-    theme.colors[theme.input?.frozen?.button?.color] || '#008fe9'
+    theme.colors[theme.input?.frozen?.button?.color] || colors.azure
 
   useEffect(() => {
     if (freezable && !frozen && !!text && inputRef && inputRef.current) {

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -3,7 +3,6 @@
 import { Fragment, useEffect, useState } from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 import { Icon } from '@uswitch/trustyle.icon'
-import { colors } from '@uswitch/trustyle.styles'
 
 interface Props {
   text?: string
@@ -21,7 +20,9 @@ export const FrozenInput: React.FC<Props> = ({
 }) => {
   const [frozen, setFrozen] = useState(freezable && !!text)
   const { theme }: any = useThemeUI()
-  const iconGlyph = theme?.name === 'Journey' ? 'edit-journey' : 'edit'
+  const iconGlyph = theme.name === 'Journey' ? 'edit-journey' : 'edit'
+  const iconColor =
+    theme.colors[theme.input?.frozen?.button?.color] || '#008fe9'
 
   useEffect(() => {
     if (freezable && !frozen && !!text && inputRef && inputRef.current) {
@@ -65,7 +66,7 @@ export const FrozenInput: React.FC<Props> = ({
           sx={{ variant: 'input.frozen.button' }}
           onClick={() => setFrozen(false)}
         >
-          <Icon color={colors.UswitchNavy} glyph={iconGlyph} />
+          <Icon color={iconColor} glyph={iconGlyph} />
         </button>
       </div>
 

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -23,7 +23,8 @@ export const FrozenInput: React.FC<Props> = ({
   const { theme }: any = useThemeUI()
   const iconGlyph = theme.name === 'Journey' ? 'edit-journey' : 'edit'
   const iconColor =
-    theme.colors[theme.input?.frozen?.button?.color] || colors.azure
+    theme.colors[theme.elements.input?.frozen?.button?.color] ||
+    colors.UswitchNavy
 
   useEffect(() => {
     if (freezable && !frozen && !!text && inputRef && inputRef.current) {
@@ -47,7 +48,7 @@ export const FrozenInput: React.FC<Props> = ({
           display: 'flex',
           height: '64px',
           justifyContent: 'space-between',
-          variant: 'input.frozen.base'
+          variant: 'elements.input.frozen.base'
         }}
       >
         <p
@@ -57,21 +58,21 @@ export const FrozenInput: React.FC<Props> = ({
             padding: '0 24px',
             textOverflow: 'ellipsis',
             width: `calc(100% - ${editIconWidth}px)`,
-            variant: 'input.frozen.text'
+            variant: 'elements.input.frozen.text'
           }}
         >
           {text}
         </p>
         <button
           aria-label="Edit Value"
-          sx={{ variant: 'input.frozen.button' }}
+          sx={{ variant: 'elements.input.frozen.button' }}
           onClick={() => setFrozen(false)}
         >
           <Icon color={iconColor} glyph={iconGlyph} />
         </button>
       </div>
 
-      <div sx={{ variant: 'input.frozen.hidden' }}>{children}</div>
+      <div sx={{ variant: 'elements.input.frozen.hidden' }}>{children}</div>
     </Fragment>
   )
 }

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -5,8 +5,6 @@ import { jsx, useThemeUI } from 'theme-ui'
 import { Icon } from '@uswitch/trustyle.icon'
 import { colors } from '@uswitch/trustyle.styles'
 
-import * as st from './styles'
-
 interface Props {
   text?: string
   freezable?: boolean
@@ -47,7 +45,7 @@ export const FrozenInput: React.FC<Props> = ({
           display: 'flex',
           height: '64px',
           justifyContent: 'space-between',
-          variant: 'input.frozen'
+          variant: 'input.frozen.base'
         }}
       >
         <p
@@ -64,14 +62,14 @@ export const FrozenInput: React.FC<Props> = ({
         </p>
         <button
           aria-label="Edit Value"
-          css={st.edit}
+          sx={{ variant: 'input.frozen.button' }}
           onClick={() => setFrozen(false)}
         >
           <Icon color={colors.UswitchNavy} glyph={iconGlyph} />
         </button>
       </div>
 
-      <div css={st.hidden}>{children}</div>
+      <div sx={{ variant: 'input.frozen.hidden' }}>{children}</div>
     </Fragment>
   )
 }

--- a/src/elements/frozen-input/src/styles.ts
+++ b/src/elements/frozen-input/src/styles.ts
@@ -21,20 +21,3 @@ export const value: SerializedStyles = css({
   textOverflow: 'ellipsis',
   width: `calc(100% - ${editIconWidth})`
 })
-
-export const edit: SerializedStyles = css({
-  background: 'none',
-  border: 'none',
-  cursor: 'pointer',
-  height: pxToRem(28),
-  padding: pxToRem(0, spacers.teal),
-  width: editIconWidth,
-  ':focus': {
-    outline: `2px solid ${colors.azure}`
-  },
-  '&::-moz-focus-inner': { border: 0 }
-})
-
-export const hidden: SerializedStyles = css({
-  display: 'none'
-})

--- a/src/elements/input-alert/package.json
+++ b/src/elements/input-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input-alert",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/input-alert/src/index.tsx
+++ b/src/elements/input-alert/src/index.tsx
@@ -17,19 +17,19 @@ const ARROW_SIZE = 8
 export const InputAlert: React.FC<Props> = ({ type, children, ...props }) => {
   const { theme }: any = useThemeUI()
 
-  const padding = get(theme, 'input-alert.padding')
-  const notificationColor = get(theme, 'input-alert.notificationColor')
-  const alertColor = get(theme, 'input-alert.alertColor')
+  const padding = get(theme, 'elements.input-alert.padding')
+  const notificationColor = get(theme, 'elements.input-alert.notificationColor')
+  const alertColor = get(theme, 'elements.input-alert.alertColor')
 
   return (
     <div
       {...props}
       sx={{
-        variant: 'input-alert',
+        variant: 'elements.input-alert',
         marginTop: `calc(${ARROW_SIZE}px + ${padding}px)`,
         backgroundColor: type === 'alert' ? alertColor : notificationColor,
         '&:before': {
-          variant: 'input-alert.before',
+          variant: 'elements.input-alert.before',
           top: -ARROW_SIZE,
           borderLeft: `${ARROW_SIZE}px solid transparent`,
           borderRight: `${ARROW_SIZE}px solid transparent`,

--- a/src/elements/input-alert/src/index.tsx
+++ b/src/elements/input-alert/src/index.tsx
@@ -17,37 +17,23 @@ const ARROW_SIZE = 8
 export const InputAlert: React.FC<Props> = ({ type, children, ...props }) => {
   const { theme }: any = useThemeUI()
 
-  const padding = get(theme, 'elements.input-alert.padding', theme.space.xs)
-  const notificationColor = get(
-    theme,
-    'elements.input-alert.notificationColor',
-    '#65717b'
-  )
-  const alertColor = get(theme, 'elements.input-alert.alertColor', '#db1818')
+  const padding = get(theme, 'input-alert.padding')
+  const notificationColor = get(theme, 'input-alert.notificationColor')
+  const alertColor = get(theme, 'input-alert.alertColor')
 
   return (
     <div
       {...props}
       sx={{
-        fontFamily: 'base',
-        fontSize: 'base',
-        lineHeight: 1.38,
-        color: get(theme, 'elements.input-alert.color', 'white'),
-        padding: padding,
+        variant: 'input-alert',
         marginTop: `calc(${ARROW_SIZE}px + ${padding}px)`,
-        position: 'relative',
-        borderRadius: get(theme, 'elements.input-alert.radii', theme.radii.sm),
         backgroundColor: type === 'alert' ? alertColor : notificationColor,
         '&:before': {
-          position: 'absolute',
-          content: "''",
+          variant: 'input-alert.before',
           top: -ARROW_SIZE,
-          width: 0,
-          height: 0,
           borderLeft: `${ARROW_SIZE}px solid transparent`,
           borderRight: `${ARROW_SIZE}px solid transparent`,
           borderBottomWidth: ARROW_SIZE,
-          borderBottomStyle: 'solid',
           borderBottomColor: type === 'alert' ? alertColor : notificationColor
         }
       }}

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,11 +8,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^2.0.5",
-    "@uswitch/trustyle.styles": "^0.5.1",
+    "@uswitch/trustyle.frozen-input": "^3.0.0",
     "@uswitch/trustyle.icon": "^1.8.4",
-    "lodash.debounce": "^4.0.8",
-    "react-input-mask": "^2.0.4"
+    "@uswitch/trustyle.styles": "^0.5.1",
+    "react-input-mask": "^2.0.4",
+    "tiny-debounce": "^0.1.1"
   },
   "devDependencies": {
     "typescript": "^3.6.2"

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@uswitch/trustyle.frozen-input": "^2.0.5",
     "@uswitch/trustyle.styles": "^0.5.1",
+    "@uswitch/trustyle.icon": "^1.8.4",
     "lodash.debounce": "^4.0.8",
     "react-input-mask": "^2.0.4"
   },

--- a/src/elements/input/src/debounce.d.ts
+++ b/src/elements/input/src/debounce.d.ts
@@ -1,0 +1,1 @@
+declare module 'tiny-debounce'

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -5,7 +5,7 @@ import { jsx } from 'theme-ui'
 import { FrozenInput } from '@uswitch/trustyle.frozen-input'
 import { pxToRem } from '@uswitch/trustyle.styles'
 import InputMask from 'react-input-mask'
-import debounce from 'lodash.debounce'
+import debounce from 'tiny-debounce'
 
 import * as st from './styles'
 

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -134,12 +134,12 @@ export const Input = forwardRef<HTMLInputElement, Props>(
         freezable={freezable}
         inputRef={inputRef}
       >
-        <div
-          sx={{
-            ...st.wrapper(hasError, hasFocus, width),
-            variant: (theme: any) => theme?.input?.base?.borderRadius
-          }}
-        >
+      <div
+        sx={{
+          ...st.wrapper(hasError, hasFocus, width),
+          variant: 'input.wrapper'
+        }}
+      >
         {prefix && (
           <span
             sx={{

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -121,7 +121,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     const childProps = {
       ...inputProps,
       sx: {
-        variant: 'input.base',
+        variant: 'elements.input.base',
         padding: (theme: any) => pxToRem(theme.space.base)
       },
       onBlur: blurHandler,
@@ -140,26 +140,26 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       freezable={freezable} 
       inputRef={inputRef}
     >
-      <div
-        sx={{
-          ...st.wrapper(hasError, hasFocus, width),
-          variant: 'input.wrapper'
-        }}
-      >
-        {(prefix || prefixIcon) && (
-          <span
-            sx={{
-              ...st.prefix(hasError, hasFocus),
-              variant: 'input.affix.prefix'
-            }}
-          >
-            {prefixIcon ? (
-              <Icon glyph={prefixIcon} size={16} color={iconColor} />
-            ) : (
-              prefix
-            )}
-          </span>
-        )}
+        <div
+          sx={{
+            ...st.wrapper(hasError, hasFocus, width),
+            variant: 'elements.input.wrapper'
+          }}
+        >
+          {(prefix || prefixIcon) && (
+            <span
+              sx={{
+                ...st.prefix(hasError, hasFocus),
+                variant: 'elements.input.affix.prefix'
+              }}
+            >
+              {prefixIcon ? (
+                <Icon glyph={prefixIcon} size={16} color={iconColor} />
+              ) : (
+                prefix
+              )}
+            </span>
+          )}
 
           {mask ? (
             <InputMask
@@ -176,7 +176,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
             <span 
               sx={{
                 ...st.suffix(hasError, hasFocus),
-                variant: 'input.affix.suffix'
+                variant: 'elements.input.affix.suffix'
               }}
             >
             {suffix}

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -1,9 +1,10 @@
 /** @jsx jsx */
 
 import { forwardRef, useEffect, useRef, useState } from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, useThemeUI } from 'theme-ui'
 import { FrozenInput } from '@uswitch/trustyle.frozen-input'
 import { pxToRem } from '@uswitch/trustyle.styles'
+import { Glyph, Icon } from '@uswitch/trustyle.icon'
 import InputMask from 'react-input-mask'
 import debounce from 'tiny-debounce'
 
@@ -20,6 +21,7 @@ export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   name: string
   postprocess?: (x: string) => string
   prefix?: string
+  prefixIcon?: Glyph
   suffix?: string
   value?: string | undefined
   width?: Width
@@ -71,6 +73,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       onFocus,
       postprocess = x => x,
       prefix,
+      prefixIcon,
       suffix,
       type,
       width = 'full',
@@ -128,26 +131,33 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       value
     }
 
-    return (
-      <FrozenInput
-        text={interiorValue}
-        freezable={freezable}
-        inputRef={inputRef}
-      >
+  const { theme }: any = useThemeUI()
+  const iconColor = theme.colors[theme.input?.affix?.prefix?.iconColor]
+
+  return (
+    <FrozenInput 
+      text={interiorValue} 
+      freezable={freezable} 
+      inputRef={inputRef}
+    >
       <div
         sx={{
           ...st.wrapper(hasError, hasFocus, width),
           variant: 'input.wrapper'
         }}
       >
-        {prefix && (
+        {(prefix || prefixIcon) && (
           <span
             sx={{
               ...st.prefix(hasError, hasFocus),
               variant: 'input.affix.prefix'
             }}
           >
-            {prefix}
+            {prefixIcon ? (
+              <Icon glyph={prefixIcon} size={16} color={iconColor} />
+            ) : (
+              prefix
+            )}
           </span>
         )}
 

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -140,7 +140,16 @@ export const Input = forwardRef<HTMLInputElement, Props>(
             variant: (theme: any) => theme?.input?.base?.borderRadius
           }}
         >
-          {prefix && <span sx={st.prefix(hasError, hasFocus)}>{prefix}</span>}
+        {prefix && (
+          <span
+            sx={{
+              ...st.prefix(hasError, hasFocus),
+              variant: 'input.affix.prefix'
+            }}
+          >
+            {prefix}
+          </span>
+        )}
 
           {mask ? (
             <InputMask
@@ -150,17 +159,19 @@ export const Input = forwardRef<HTMLInputElement, Props>(
               {...childProps}
             />
           ) : (
-            <input
-              ref={inputRef}
-              {...childProps}
-              sx={{
-                variant: 'input.base',
-                padding: (theme: any) => pxToRem(theme.space.base)
-              }}
-            />
+            <input ref={inputRef} {...childProps} />
           )}
 
-          {suffix && <span sx={st.suffix(hasError, hasFocus)}>{suffix}</span>}
+          {suffix && (
+            <span 
+              sx={{
+                ...st.suffix(hasError, hasFocus),
+                variant: 'input.affix.suffix'
+              }}
+            >
+            {suffix}
+            </span>
+          )}
         </div>
       </FrozenInput>
     )

--- a/src/elements/input/src/index.tsx
+++ b/src/elements/input/src/index.tsx
@@ -3,6 +3,7 @@
 import { forwardRef, useEffect, useRef, useState } from 'react'
 import { jsx } from 'theme-ui'
 import { FrozenInput } from '@uswitch/trustyle.frozen-input'
+import { pxToRem } from '@uswitch/trustyle.styles'
 import InputMask from 'react-input-mask'
 import debounce from 'lodash.debounce'
 
@@ -116,7 +117,10 @@ export const Input = forwardRef<HTMLInputElement, Props>(
 
     const childProps = {
       ...inputProps,
-      sx: st.input,
+      sx: {
+        variant: 'input.base',
+        padding: (theme: any) => pxToRem(theme.space.base)
+      },
       onBlur: blurHandler,
       onChange: changeHandler,
       onFocus: focusHandler,
@@ -133,7 +137,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
         <div
           sx={{
             ...st.wrapper(hasError, hasFocus, width),
-            variant: 'input.textInput.wrapper'
+            variant: (theme: any) => theme?.input?.base?.borderRadius
           }}
         >
           {prefix && <span sx={st.prefix(hasError, hasFocus)}>{prefix}</span>}
@@ -149,7 +153,10 @@ export const Input = forwardRef<HTMLInputElement, Props>(
             <input
               ref={inputRef}
               {...childProps}
-              sx={{ ...st.input, variant: 'input.textInput' }}
+              sx={{
+                variant: 'input.base',
+                padding: (theme: any) => pxToRem(theme.space.base)
+              }}
             />
           )}
 

--- a/src/elements/input/src/stories.tsx
+++ b/src/elements/input/src/stories.tsx
@@ -80,6 +80,8 @@ export const Example = () => {
       <Spacer height={spaceBetween} />
       <Input name="example" prefix="£" type="tel" />
       <Spacer height={spaceBetween} />
+      <Input name="example" prefixIcon="email" type="tel" />
+      <Spacer height={spaceBetween} />
       <Input name="example" suffix=".00" type="tel" />
       <Spacer height={spaceBetween} />
       <Input name="password" type="password" defaultValue="swordfish" />

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -2,7 +2,7 @@ import { colors, pxToRem } from '@uswitch/trustyle.styles'
 
 import { SxStyleProp } from '../../../../types/theme-ui'
 
-const { tomato, UswitchNavy, white } = colors
+const { tomato, UswitchNavy } = colors
 
 export const wrapper = (
   hasError: boolean,
@@ -16,17 +16,12 @@ export const wrapper = (
       ? `inset 0 0 0 1px ${theme.colors[theme.input?.focus?.color] ??
           UswitchNavy}`
       : 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)',
-  backgroundColor: white,
-  border: `solid 1px`,
   borderColor: (theme: any) =>
     hasError
       ? theme.colors[theme.input?.error?.color] ?? tomato
       : hasFocus
       ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
       : theme.colors[theme.input?.default?.color] ?? UswitchNavy,
-  boxSizing: 'border-box',
-  display: 'flex',
-  position: 'relative',
   width: width === 'half' ? '50%' : '100%'
 })
 

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -9,6 +9,7 @@ export const wrapper = (
   hasFocus: boolean,
   width: 'half' | 'full'
 ): SxStyleProp => ({
+  border: 'solid 1px',
   boxShadow: (theme: any) =>
     hasError
       ? `inset 0 0 0 1px ${theme.colors[theme.input?.error?.color] ?? tomato}`
@@ -17,7 +18,7 @@ export const wrapper = (
           UswitchNavy}`
       : 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)',
   borderColor: (theme: any) =>
-    hasError
+    console.log(theme) || hasError
       ? theme.colors[theme.input?.error?.color] ?? tomato
       : hasFocus
       ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
@@ -26,15 +27,8 @@ export const wrapper = (
 })
 
 const affix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
-  alignItems: 'center',
-  display: 'flex',
-  fontFamily: 'base',
-  fontSize: 'base',
-  lineHeight: 'base',
   margin: pxToRem(8, 0),
-  padding: pxToRem(0, 12),
-  textAlign: 'center',
-  boxSizing: 'border-box',
+  padding: pxToRem(8, spacers.green),
   borderColor: (theme: any) =>
     hasError
       ? theme.colors[theme.input?.error?.color] ?? tomato

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -12,17 +12,18 @@ export const wrapper = (
   border: 'solid 1px',
   boxShadow: (theme: any) =>
     hasError
-      ? `inset 0 0 0 1px ${theme.colors[theme.input?.error?.color] ?? tomato}`
+      ? `inset 0 0 0 1px ${theme.colors[theme.elements.input?.error?.color] ??
+          tomato}`
       : hasFocus
-      ? `inset 0 0 0 1px ${theme.colors[theme.input?.focus?.color] ??
+      ? `inset 0 0 0 1px ${theme.colors[theme.elements.input?.focus?.color] ??
           UswitchNavy}`
       : 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)',
   borderColor: (theme: any) =>
     hasError
-      ? theme.colors[theme.input?.error?.color] ?? tomato
+      ? theme.colors[theme.elements.input?.error?.color] ?? tomato
       : hasFocus
-      ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
-      : theme.colors[theme.input?.default?.color] ?? UswitchNavy,
+      ? theme.colors[theme.elements.input?.focus?.color] ?? UswitchNavy
+      : theme.colors[theme.elements.input?.default?.color] ?? UswitchNavy,
   width: width === 'half' ? '50%' : '100%'
 })
 
@@ -31,16 +32,16 @@ const affix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
   padding: pxToRem(8, spacers.green),
   borderColor: (theme: any) =>
     hasError
-      ? theme.colors[theme.input?.error?.color] ?? tomato
+      ? theme.colors[theme.elements.input?.error?.color] ?? tomato
       : hasFocus
-      ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
-      : theme.colors[theme.input?.default?.color] ?? UswitchNavy,
+      ? theme.colors[theme.elements.input?.focus?.color] ?? UswitchNavy
+      : theme.colors[theme.elements.input?.default?.color] ?? UswitchNavy,
   color: (theme: any) =>
     hasError
-      ? theme.colors[theme.input?.error?.color] ?? tomato
+      ? theme.colors[theme.elements.input?.error?.color] ?? tomato
       : hasFocus
-      ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
-      : theme.colors[theme.input?.default?.color] ?? 'text'
+      ? theme.colors[theme.elements.input?.focus?.color] ?? UswitchNavy
+      : theme.colors[theme.elements.input?.default?.color] ?? 'text'
 })
 
 export const prefix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -18,7 +18,7 @@ export const wrapper = (
           UswitchNavy}`
       : 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)',
   borderColor: (theme: any) =>
-    console.log(theme) || hasError
+    hasError
       ? theme.colors[theme.input?.error?.color] ?? tomato
       : hasFocus
       ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -55,13 +55,9 @@ const affix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
 })
 
 export const prefix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
-  ...affix(hasError, hasFocus),
-  borderRightStyle: 'solid',
-  borderRightWidth: 1
+  ...affix(hasError, hasFocus)
 })
 
 export const suffix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
-  ...affix(hasError, hasFocus),
-  borderLeftStyle: 'solid',
-  borderLeftWidth: 1
+  ...affix(hasError, hasFocus)
 })

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -2,7 +2,7 @@ import { colors, pxToRem } from '@uswitch/trustyle.styles'
 
 import { SxStyleProp } from '../../../../types/theme-ui'
 
-const { battleshipGrey, tomato, UswitchNavy, veryLightGrey, white } = colors
+const { tomato, UswitchNavy, white } = colors
 
 export const wrapper = (
   hasError: boolean,
@@ -10,7 +10,7 @@ export const wrapper = (
   width: 'half' | 'full'
 ): SxStyleProp => ({
   boxShadow: (theme: any) =>
-    console.log(theme) || hasError
+    hasError
       ? `inset 0 0 0 1px ${theme.colors[theme.input?.error?.color] ?? tomato}`
       : hasFocus
       ? `inset 0 0 0 1px ${theme.colors[theme.input?.focus?.color] ??
@@ -29,33 +29,6 @@ export const wrapper = (
   position: 'relative',
   width: width === 'half' ? '50%' : '100%'
 })
-
-export const input: SxStyleProp = {
-  fontFamily: 'base',
-  fontSize: 'base',
-  lineHeight: '1.33',
-  color: 'text',
-
-  appearance: 'none',
-  border: 'none',
-  background: 'none',
-  boxSizing: 'border-box',
-  display: 'flex',
-  flex: 1,
-  padding: (theme: any) => pxToRem(theme.space.base),
-  position: 'relative',
-  verticalAlign: 'middle',
-  width: '100%',
-  '&:focus': {
-    outline: 'none'
-  },
-  '&:disabled': {
-    outline: 'none',
-    border: 'none',
-    color: battleshipGrey,
-    background: veryLightGrey
-  }
-}
 
 const affix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
   alignItems: 'center',

--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -10,19 +10,20 @@ export const wrapper = (
   width: 'half' | 'full'
 ): SxStyleProp => ({
   boxShadow: (theme: any) =>
-    hasError
-      ? `inset 0 0 0 1px ${theme.elements?.input?.errorColor ?? tomato}`
+    console.log(theme) || hasError
+      ? `inset 0 0 0 1px ${theme.colors[theme.input?.error?.color] ?? tomato}`
       : hasFocus
-      ? `inset 0 0 0 1px ${theme.elements?.input?.focusColor ?? UswitchNavy}`
+      ? `inset 0 0 0 1px ${theme.colors[theme.input?.focus?.color] ??
+          UswitchNavy}`
       : 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)',
   backgroundColor: white,
   border: `solid 1px`,
   borderColor: (theme: any) =>
     hasError
-      ? theme.elements?.input?.errorColor ?? tomato
+      ? theme.colors[theme.input?.error?.color] ?? tomato
       : hasFocus
-      ? theme.elements?.input?.focusColor ?? UswitchNavy
-      : theme.elements?.input?.defaultColor ?? UswitchNavy,
+      ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
+      : theme.colors[theme.input?.default?.color] ?? UswitchNavy,
   boxSizing: 'border-box',
   display: 'flex',
   position: 'relative',
@@ -68,16 +69,16 @@ const affix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({
   boxSizing: 'border-box',
   borderColor: (theme: any) =>
     hasError
-      ? theme.elements?.input?.errorColor ?? tomato
+      ? theme.colors[theme.input?.error?.color] ?? tomato
       : hasFocus
-      ? theme.elements?.input?.focusColor ?? UswitchNavy
-      : theme.elements?.input?.defaultColor ?? UswitchNavy,
+      ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
+      : theme.colors[theme.input?.default?.color] ?? UswitchNavy,
   color: (theme: any) =>
     hasError
-      ? theme.elements?.input?.errorColor ?? tomato
+      ? theme.colors[theme.input?.error?.color] ?? tomato
       : hasFocus
-      ? theme.elements?.input?.focusColor ?? UswitchNavy
-      : theme.elements?.input?.defaultColor ?? 'text'
+      ? theme.colors[theme.input?.focus?.color] ?? UswitchNavy
+      : theme.colors[theme.input?.default?.color] ?? 'text'
 })
 
 export const prefix = (hasError: boolean, hasFocus: boolean): SxStyleProp => ({

--- a/src/elements/radio-input/package.json
+++ b/src/elements/radio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.radio-input",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/radio-input/src/index.tsx
+++ b/src/elements/radio-input/src/index.tsx
@@ -20,7 +20,7 @@ export const RadioInput: React.FC<Props> = ({ label, ...inputProps }) => (
             transition: 'background-color 200ms, border-color 200ms'
           }
         },
-        variant: 'input.radio.base'
+        variant: 'elements.input.radio.base'
       }}
       type="radio"
       {...inputProps}
@@ -48,7 +48,7 @@ export const RadioInput: React.FC<Props> = ({ label, ...inputProps }) => (
           flexGrow: 0,
           flexShrink: 0
         },
-        variant: 'input.radio.label'
+        variant: 'elements.input.radio.label'
       }}
     >
       {label}

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -7,31 +7,26 @@ import { ImgixImage } from '@uswitch/trustyle.imgix-image'
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   providerLogoSrc: string
   className?: string
+  providerText?: string
 }
 
 const SponsoredByTag: React.FC<Props> = ({
   providerLogoSrc,
-  className = ''
+  className = '',
+  providerText = 'Sponsored by'
 }) => (
   <div
     className={className}
     sx={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingY: 4
+      variant: 'elements.sponsoredByTag.base.wrapper'
     }}
   >
     <span
       sx={{
-        color: 'grey-60',
-        fontSize: 'xs',
-        fontFamily: 'base',
-        fontWeight: 'base',
-        fontStyle: 'normal'
+        variant: 'elements.sponsoredByTag.base.text'
       }}
     >
-      Sponsored by
+      {providerText}
     </span>
 
     <ImgixImage
@@ -39,7 +34,7 @@ const SponsoredByTag: React.FC<Props> = ({
       imgixParams={{ fit: 'clip' }}
       critical
       sx={{
-        height: [40, 56]
+        variant: 'elements.sponsoredByTag.base.image'
       }}
     />
   </div>

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -11,15 +11,39 @@ export default {
   title: 'Elements|Sponsored by tag'
 }
 
-export const ExampleWithKnobs = () => {
+export const ExampleWithDefaultText = () => {
   const providerLogo: string = text(
     'Provider logo url',
     'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
   )
+
   return <SponsoredByTag providerLogoSrc={providerLogo} />
 }
 
-ExampleWithKnobs.story = {
+export const ExampleWithTextProp = () => {
+  const providerLogo: string = text(
+    'Provider logo url',
+    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+  )
+
+  const providerText: string = text('Text to display', 'This is example text')
+  return (
+    <React.Fragment>
+      <SponsoredByTag
+        providerLogoSrc={providerLogo}
+        providerText={providerText}
+      />
+    </React.Fragment>
+  )
+}
+
+ExampleWithDefaultText.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+ExampleWithTextProp.story = {
   parameters: {
     percy: { skip: true }
   }
@@ -28,7 +52,8 @@ ExampleWithKnobs.story = {
 export const AutomatedTests = () => {
   return (
     <AllThemes>
-      <ExampleWithKnobs />
+      <ExampleWithDefaultText />
+      <ExampleWithTextProp />
     </AllThemes>
   )
 }

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -498,6 +498,14 @@
         "background": "veryLightGrey"
       }
     },
+    "wrapper": {
+      "backgroundColor": "white",
+      "border": "solid 1px",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "position": "relative",
+      "borderRadius": "3px"
+    },
     "affix": {
       "prefix": {
         "borderRightStyle": "solid",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -557,7 +557,7 @@
     "fontSize": "base",
     "lineHeight": 1.38,
     "color": "white",
-    "padding": "xs",
+    "padding": 12,
     "position": "relative",
     "borderRadius": "sm",
     "notificationColor": "#65717B",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -91,6 +91,8 @@
     "grey-100": "#050505",
 
     "frozen-bg": "#F6F6F6",
+    "battleshipGrey": "#65717B",
+    "veryLightGrey": "#E9EBED",
 
     "primary": "#0157FF",
     "primary--dark": "rgb(0, 70, 212);",
@@ -496,8 +498,8 @@
       "&:disabled": {
         "outline": "none",
         "border": "none",
-        "color": "primary",
-        "background": "veryLightGrey"
+        "color": "battleshipGrey",
+        "backgroundColor": "veryLightGrey"
       }
     },
     "frozen": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -335,6 +335,27 @@
         "height": 0,
         "borderBottomStyle": "solid"
       }
+    },
+    
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -316,7 +316,26 @@
           "borderLeftWidth": 1
         }
       }
-    }  
+    },
+    
+    "input-alert": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.38,
+      "color": "white",
+      "padding": 8,
+      "position": "relative",
+      "borderRadius": "sm",
+      "notificationColor": "#65717B",
+      "alertColor": "#DB1818",
+      "before": {
+        "position": "absolute",
+        "content": "''",
+        "width": 0,
+        "height": 0,
+        "borderBottomStyle": "solid"
+      }
+    }
   },
 
   "compounds": {
@@ -559,25 +578,6 @@
       "wrapper": {
         "borderRadius": "3px"
       }
-    }
-  },
-
-  "input-alert": {
-    "fontFamily": "base",
-    "fontSize": "base",
-    "lineHeight": 1.38,
-    "color": "white",
-    "padding": 8,
-    "position": "relative",
-    "borderRadius": "sm",
-    "notificationColor": "#65717B",
-    "alertColor": "#DB1818",
-    "before": {
-      "position": "absolute",
-      "content": "''",
-      "width": 0,
-      "height": 0,
-      "borderBottomStyle": "solid"
     }
   },
 

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -238,7 +238,85 @@
           "width": "2.5em"
         }
       }
-    }
+    },
+
+    "input": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": 1.33,
+        "color": "text",
+        "borderRadius": "4px",
+        "appearance": "none",
+        "border": "none",
+        "background": "none",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flex": 1,
+        "position": "relative",
+        "verticalAlign": "middle",
+        "width": "100%",
+        "&:focus": {
+          "outline": "none"
+        },
+        "&:disabled": {
+          "outline": "none",
+          "border": "none",
+          "color": "battleshipGrey",
+          "backgroundColor": "veryLightGrey"
+        }
+      },
+      "frozen": {
+        "base": {
+          "backgroundColor": "frozen-bg",
+          "borderRadius": "3px"
+        },
+        "button": {
+          "background": "none",
+          "border": "none",
+          "height": "28px",
+          "padding": "0 24px",
+          "width": "69px",
+          "cursor": "pointer",
+          ":focus": {
+            "outline": "2px solid",
+            "outlineColor": "#008fe9"
+          },
+          "&::-moz-focus-inner": { "border": 0 }
+        },
+        "hidden": {
+          "display": "none"
+        }
+      },
+      "wrapper": {
+        "backgroundColor": "white",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "position": "relative",
+        "borderRadius": "3px"
+      },
+      "affix": {
+        "base": {
+          "fontFamily": "base",
+          "fontSize": "base",
+          "lineHeight": "base",
+          "textAlign": "center",
+          "boxSizing": "border-box",
+          "alignItems": "center",
+          "display": "flex"
+        },
+        "prefix": {
+          "variant": "elements.input.affix.base",
+          "borderRightStyle": "solid",
+          "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
+        }
+      }
+    }  
   },
 
   "compounds": {
@@ -477,77 +555,9 @@
   },
 
   "input": {
-    "base": {
-      "fontFamily": "base",
-      "fontSize": "base",
-      "lineHeight": 1.33,
-      "color": "text",
-      "borderRadius": "4px",
-      "appearance": "none",
-      "border": "none",
-      "background": "none",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flex": 1,
-      "position": "relative",
-      "verticalAlign": "middle",
-      "width": "100%",
-      "&:focus": {
-        "outline": "none"
-      },
-      "&:disabled": {
-        "outline": "none",
-        "border": "none",
-        "color": "battleshipGrey",
-        "backgroundColor": "veryLightGrey"
-      }
-    },
-    "frozen": {
-      "base": {
-        "backgroundColor": "frozen-bg",
+    "textInput": {
+      "wrapper": {
         "borderRadius": "3px"
-      },
-      "button": {
-        "background": "none",
-        "border": "none",
-        "height": "28px",
-        "padding": "0 24px",
-        "width": "69px",
-        "cursor": "pointer",
-        ":focus": {
-          "outline": "2px solid",
-          "outlineColor": "#008fe9"
-        },
-        "&::-moz-focus-inner": { "border": 0 }
-      },
-      "hidden": {
-        "display": "none"
-      }
-    },
-    "wrapper": {
-      "backgroundColor": "white",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "position": "relative",
-      "borderRadius": "3px"
-    },
-    "affix": {
-      "base": {
-        "fontFamily": "base",
-        "fontSize": "base",
-        "lineHeight": "base",
-        "textAlign": "center",
-        "boxSizing": "border-box"      
-      },
-      "prefix": {
-        "variant": "input.affix.base",
-        "borderRightStyle": "solid",
-        "borderRightWidth": 1
-      },
-      "suffix": {
-        "variant": "input.affix.base",
-        "borderLeftStyle": "solid",
-        "borderLeftWidth": 1
       }
     }
   },

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -552,6 +552,25 @@
     }
   },
 
+  "input-alert": {
+    "fontFamily": "base",
+    "fontSize": "base",
+    "lineHeight": 1.38,
+    "color": "white",
+    "padding": "xs",
+    "position": "relative",
+    "borderRadius": "sm",
+    "notificationColor": "#65717B",
+    "alertColor": "#DB1818",
+    "before": {
+      "position": "absolute",
+      "content": "''",
+      "width": 0,
+      "height": 0,
+      "borderBottomStyle": "solid"
+    }
+  },
+
   "buttons": {
     "base": {
       "fontWeight": "bold",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -557,7 +557,7 @@
     "fontSize": "base",
     "lineHeight": 1.38,
     "color": "white",
-    "padding": 12,
+    "padding": 8,
     "position": "relative",
     "borderRadius": "sm",
     "notificationColor": "#65717B",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -508,8 +508,6 @@
       "button": {
         "background": "none",
         "border": "none",
-        "borderLeft": "1px solid",
-        "borderLeftColor": "#59646d",
         "height": "28px",
         "padding": "0 24px",
         "width": "69px",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -90,6 +90,8 @@
     "grey-90": "#141424",
     "grey-100": "#050505",
 
+    "frozen-bg": "#F6F6F6",
+
     "primary": "#0157FF",
     "primary--dark": "rgb(0, 70, 212);",
     "secondary": "#924A8B",
@@ -496,6 +498,30 @@
         "border": "none",
         "color": "primary",
         "background": "veryLightGrey"
+      }
+    },
+    "frozen": {
+      "base": {
+        "backgroundColor": "frozen-bg",
+        "borderRadius": "3px"
+      },
+      "button": {
+        "background": "none",
+        "border": "none",
+        "borderLeft": "1px solid",
+        "borderLeftColor": "#59646d",
+        "height": "28px",
+        "padding": "0 24px",
+        "width": "69px",
+        "cursor": "pointer",
+        ":focus": {
+          "outline": "2px solid",
+          "outlineColor": "#008fe9"
+        },
+        "&::-moz-focus-inner": { "border": 0 }
+      },
+      "hidden": {
+        "display": "none"
       }
     },
     "wrapper": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -500,18 +500,26 @@
     },
     "wrapper": {
       "backgroundColor": "white",
-      "border": "solid 1px",
       "boxSizing": "border-box",
       "display": "flex",
       "position": "relative",
       "borderRadius": "3px"
     },
     "affix": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": "base",
+        "textAlign": "center",
+        "boxSizing": "border-box"      
+      },
       "prefix": {
+        "variant": "input.affix.base",
         "borderRightStyle": "solid",
         "borderRightWidth": 1
       },
       "suffix": {
+        "variant": "input.affix.base",
         "borderLeftStyle": "solid",
         "borderLeftWidth": 1
       }

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -497,6 +497,16 @@
         "color": "primary",
         "background": "veryLightGrey"
       }
+    },
+    "affix": {
+      "prefix": {
+        "borderRightStyle": "solid",
+        "borderRightWidth": 1
+      },
+      "suffix": {
+        "borderLeftStyle": "solid",
+        "borderLeftWidth": 1
+      }
     }
   },
 

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -473,9 +473,29 @@
   },
 
   "input": {
-    "textInput": {
-      "wrapper": {
-        "borderRadius": "3px"
+    "base": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.33,
+      "color": "text",
+      "borderRadius": "4px",
+      "appearance": "none",
+      "border": "none",
+      "background": "none",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flex": 1,
+      "position": "relative",
+      "verticalAlign": "middle",
+      "width": "100%",
+      "&:focus": {
+        "outline": "none"
+      },
+      "&:disabled": {
+        "outline": "none",
+        "border": "none",
+        "color": "primary",
+        "background": "veryLightGrey"
       }
     }
   },

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -331,7 +331,6 @@
       }
     }
   },
-
   "compounds": {
     "accordion": {
       "base": {
@@ -748,6 +747,30 @@
   },
 
   "input": {
+    "base": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.33,
+      "color": "text",
+      "appearance": "none",
+      "border": "none",
+      "background": "none",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flex": 1,
+      "position": "relative",
+      "verticalAlign": "middle",
+      "width": "100%",
+      "&:focus": {
+        "outline": "none"
+      },
+      "&:disabled": {
+        "outline": "none",
+        "border": "none",
+        "color": "battleshipGrey",
+        "background": "veryLightGrey"
+      }
+    },
     "frozen": {
       "backgroundColor": "frozen-bg",
       "borderRadius": "0",
@@ -758,6 +781,15 @@
     "focus": {
       "outline": "2px solid",
       "outline-color": "orange"
+    },
+    "default": {
+      "color": "light-grey-blue"
+    },
+    "error": {
+      "color": "error-red"
+    },
+    "focus": {
+      "color": "p#008fe9lum"
     },
     "radioish": {
       "base": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -552,6 +552,27 @@
         "height": 0,
         "borderBottomStyle": "solid"
       }
+    },
+    
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -957,7 +957,7 @@
     "fontSize": "base",
     "lineHeight": 1.38,
     "color": "white",
-    "padding": "xs",
+    "padding": 12,
     "position": "relative",
     "borderRadius": "sm",
     "notificationColor": "battleship-grey",

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -791,6 +791,16 @@
     "focus": {
       "color": "p#008fe9lum"
     },
+    "affix": {
+      "prefix": {
+        "borderRightStyle": "solid",
+        "borderRightWidth": 1
+      },
+      "suffix": {
+        "borderLeftStyle": "solid",
+        "borderLeftWidth": 1
+      }
+    },
     "radioish": {
       "base": {
         "&:checked + span": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -786,8 +786,6 @@
       "button": {
         "background": "none",
         "border": "none",
-        "borderLeft": "1px solid",
-        "borderLeftColor": "#59646d",
         "height": "28px",
         "padding": "0 24px",
         "width": "69px",

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -857,6 +857,10 @@
           "borderWidth": "2px"
         }
       },
+      "error": {
+        "variant": "input.radioish.label",
+        "color": "error-red"
+      },
       "variants": {
         "normal": {
           "variant": "input.radioish.base"

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -779,15 +779,28 @@
       "borderRadius": "3px"
     },
     "frozen": {
-      "backgroundColor": "frozen-bg",
-      "borderRadius": "0",
-      "text": {
-        "color": "grey-80"
+      "base": {
+        "backgroundColor": "frozen-bg",
+        "borderRadius": "3px"
+      },
+      "button": {
+        "background": "none",
+        "border": "none",
+        "borderLeft": "1px solid",
+        "borderLeftColor": "#59646d",
+        "height": "28px",
+        "padding": "0 24px",
+        "width": "69px",
+        "cursor": "pointer",
+        ":focus": {
+          "outline": "2px solid",
+          "outlineColor": "#008fe9"
+        },
+        "&::-moz-focus-inner": { "border": 0 }
+      },
+      "hidden": {
+        "display": "none"
       }
-    },
-    "focus": {
-      "outline": "2px solid",
-      "outline-color": "orange"
     },
     "default": {
       "color": "light-grey-blue"
@@ -796,7 +809,7 @@
       "color": "error-red"
     },
     "focus": {
-      "color": "p#008fe9lum"
+      "color": "#008fe9"
     },
     "affix": {
       "base": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -329,8 +329,213 @@
           }
         }
       }
+    },
+
+    "input": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": 1.33,
+        "color": "text",
+        "appearance": "none",
+        "border": "none",
+        "background": "none",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flex": 1,
+        "position": "relative",
+        "verticalAlign": "middle",
+        "width": "100%",
+        "&:focus": {
+          "outline": "none"
+        },
+        "&:disabled": {
+          "outline": "none",
+          "border": "none",
+          "color": "battleship-grey",
+          "backgroundColor": "veryLightGrey"
+        }
+      },
+      "wrapper": {
+        "backgroundColor": "white",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "position": "relative",
+        "borderRadius": "0px"
+      },
+      "frozen": {
+        "base": {
+          "backgroundColor": "frozen-bg",
+          "borderRadius": "0px"
+        },
+        "text": {
+          "color": "grey-80"
+        },
+        "button": {
+          "background": "none",
+          "border": "none",
+          "height": "28px",
+          "padding": "0 24px",
+          "width": "69px",
+          "cursor": "pointer",
+          ":focus": {
+            "outline": "2px solid",
+            "outlineColor": "#008fe9"
+          },
+          "&::-moz-focus-inner": { "border": 0 }
+        },
+        "hidden": {
+          "display": "none"
+        }
+      },
+      "focus": {
+        "outline": "2px solid",
+        "outline-color": "orange"
+      },
+      "affix": {
+        "base": {
+          "fontFamily": "base",
+          "fontSize": "base",
+          "lineHeight": "base",
+          "textAlign": "center",
+          "boxSizing": "border-box" ,
+          "alignItems": "center",
+          "display": "flex"     
+        },
+        "prefix": {
+          "variant": "elements.input.affix.base",
+          "borderRightStyle": "solid",
+          "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
+        }
+      },
+      "radioish": {
+        "base": {
+          "&:checked + span": {
+            "borderColor": "black",
+            "boxShadow": "linkInset",
+            "color": "black",
+            "&::before": {
+              "borderColor": "black"
+            }
+          },
+          "&:focus + span": {
+            "variant": "elements.input.focus"
+          }
+        },
+        "label": {
+          "borderColor": "grey-40",
+          "borderStyle": "solid",
+          "borderWidth": "1px",
+          "color": "grey-80",
+          "fontWeight": "normal",
+          "padding": "11px 12px 11px 0",
+          "&:before": {
+            "borderColor": "grey-30",
+            "borderStyle": "solid",
+            "borderWidth": "2px"
+          }
+        },
+        "error": {
+          "variant": "elements.input.radioish.label",
+          "color": "error-red"
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.radioish.base"
+          },
+          "slim": {
+            "variant": "elements.input.radioish.base"
+          }
+        }
+      },
+      "radio": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "background": "black",
+              "boxShadow": "inset 0 0 0 2px #fff"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "minHeight": "54px",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "50%"
+          }
+        }
+      },
+      "checkbox": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "backgroundImage": "url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='-1 -2 14 12'%3E%3Cpath d='M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z' /%3E%3C/svg%3E\")",
+              "backgroundSize": "16px 16px",
+              "backgroundColor": "black",
+              "borderColor": "black"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "4px"
+          }
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.checkbox.base"
+          },
+          "slim": {
+            "variant": "elements.input.checkbox.base",
+            "& + span": {
+              "padding": "0px",
+              "border": "none"
+            },
+            "&:checked + span": {
+              "variant": "elements.input.checkbox.base.&:checked + span",
+              "boxShadow": "none",
+              "&::before": {
+                "variant": "elements.input.checkbox.base.&:checked + span.&::before"
+              }
+            },
+            "&:focus + span": {},
+            "&:focus + span::before": {
+              "variant": "elements.input.focus"
+            }
+          }
+        }
+      },
+      "tile": {
+        "inputColor": "#141424",
+        "borderColor": "light-grey-blue",
+        "borderStyle": "solid",
+        "borderWidth": "1px",
+        "color": "slate-grey",
+        "fontWeight": "normal",
+        "before": {
+          "content": "' '",
+          "borderColor": "light-grey-blue",
+          "borderStyle": "solid",
+          "borderWidth": "2px"
+        }
+      }
     }
   },
+
   "compounds": {
     "accordion": {
       "base": {
@@ -747,57 +952,11 @@
   },
 
   "input": {
-    "base": {
-      "fontFamily": "base",
-      "fontSize": "base",
-      "lineHeight": 1.33,
-      "color": "text",
-      "appearance": "none",
-      "border": "none",
-      "background": "none",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flex": 1,
-      "position": "relative",
-      "verticalAlign": "middle",
-      "width": "100%",
-      "&:focus": {
-        "outline": "none"
-      },
-      "&:disabled": {
-        "outline": "none",
-        "border": "none",
-        "color": "battleshipGrey",
-        "background": "veryLightGrey"
-      }
-    },
-    "wrapper": {
-      "backgroundColor": "white",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "position": "relative",
-      "borderRadius": "3px"
-    },
     "frozen": {
-      "base": {
-        "backgroundColor": "frozen-bg",
-        "borderRadius": "3px"
-      },
-      "button": {
-        "background": "none",
-        "border": "none",
-        "height": "28px",
-        "padding": "0 24px",
-        "width": "69px",
-        "cursor": "pointer",
-        ":focus": {
-          "outline": "2px solid",
-          "outlineColor": "#008fe9"
-        },
-        "&::-moz-focus-inner": { "border": 0 }
-      },
-      "hidden": {
-        "display": "none"
+      "backgroundColor": "frozen-bg",
+      "borderRadius": "0",
+      "text": {
+        "color": "grey-80"
       }
     },
     "default": {
@@ -808,25 +967,6 @@
     },
     "focus": {
       "color": "#008fe9"
-    },
-    "affix": {
-      "base": {
-        "fontFamily": "base",
-        "fontSize": "base",
-        "lineHeight": "base",
-        "textAlign": "center",
-        "boxSizing": "border-box"      
-      },
-      "prefix": {
-        "variant": "input.affix.base",
-        "borderRightStyle": "solid",
-        "borderRightWidth": 1
-      },
-      "suffix": {
-        "variant": "input.affix.base",
-        "borderLeftStyle": "solid",
-        "borderLeftWidth": 1
-      }
     },
     "radioish": {
       "base": {
@@ -854,10 +994,6 @@
           "borderStyle": "solid",
           "borderWidth": "2px"
         }
-      },
-      "error": {
-        "variant": "input.radioish.label",
-        "color": "error-red"
       },
       "variants": {
         "normal": {
@@ -968,7 +1104,6 @@
       "borderBottomStyle": "solid"
     }
   },
-
 
   "pagination": {
     "arrow": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -771,6 +771,14 @@
         "background": "veryLightGrey"
       }
     },
+    "wrapper": {
+      "backgroundColor": "white",
+      "border": "solid 1px",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "position": "relative",
+      "borderRadius": "3px"
+    },
     "frozen": {
       "backgroundColor": "frozen-bg",
       "borderRadius": "0",

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -773,7 +773,6 @@
     },
     "wrapper": {
       "backgroundColor": "white",
-      "border": "solid 1px",
       "boxSizing": "border-box",
       "display": "flex",
       "position": "relative",
@@ -800,11 +799,20 @@
       "color": "p#008fe9lum"
     },
     "affix": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": "base",
+        "textAlign": "center",
+        "boxSizing": "border-box"      
+      },
       "prefix": {
+        "variant": "input.affix.base",
         "borderRightStyle": "solid",
         "borderRightWidth": 1
       },
       "suffix": {
+        "variant": "input.affix.base",
         "borderLeftStyle": "solid",
         "borderLeftWidth": 1
       }

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -952,6 +952,26 @@
     }
   },
 
+  "input-alert": {
+    "fontFamily": "base",
+    "fontSize": "base",
+    "lineHeight": 1.38,
+    "color": "white",
+    "padding": "xs",
+    "position": "relative",
+    "borderRadius": "sm",
+    "notificationColor": "battleship-grey",
+    "alertColor": "error-red",
+    "before": {
+      "position": "absolute",
+      "content": "''",
+      "width": 0,
+      "height": 0,
+      "borderBottomStyle": "solid"
+    }
+  },
+
+
   "pagination": {
     "arrow": {
       "color": "#84A6FF"

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -533,6 +533,25 @@
           "borderWidth": "2px"
         }
       }
+    },
+
+    "input-alert": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.38,
+      "color": "white",
+      "padding": 12,
+      "position": "relative",
+      "borderRadius": "sm",
+      "notificationColor": "battleship-grey",
+      "alertColor": "error-red",
+      "before": {
+        "position": "absolute",
+        "content": "''",
+        "width": 0,
+        "height": 0,
+        "borderBottomStyle": "solid"
+      }
     }
   },
 
@@ -1083,25 +1102,6 @@
         "borderStyle": "solid",
         "borderWidth": "2px"
       }
-    }
-  },
-
-  "input-alert": {
-    "fontFamily": "base",
-    "fontSize": "base",
-    "lineHeight": 1.38,
-    "color": "white",
-    "padding": 12,
-    "position": "relative",
-    "borderRadius": "sm",
-    "notificationColor": "battleship-grey",
-    "alertColor": "error-red",
-    "before": {
-      "position": "absolute",
-      "content": "''",
-      "width": 0,
-      "height": 0,
-      "borderBottomStyle": "solid"
     }
   },
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1364,7 +1364,8 @@
           "variant": "input.radioish.base.&:checked + span",
           "&::before": {
             "variant": "input.radioish.base.&:checked + span.&::before",
-            "background": "black",
+            "borderColor": "plum",
+            "backgroundColor": "plum",
             "boxShadow": "inset 0 0 0 2px #fff"
           }
         }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1314,22 +1314,23 @@
     "radioish": {
       "base": {
         "&:checked + span": {
-          "borderColor": "black",
-          "boxShadow": "linkInset",
-          "color": "black",
+          "borderColor": "grey-40",
+          "color": "grey-80",
           "&::before": {
             "borderColor": "black"
           }
         },
         "&:focus + span": {
-          "variant": "input.focus"
+          "border": "2px solid",
+          "borderColor": "plum"
         }
       },
       "label": {
         "borderColor": "grey-40",
         "borderStyle": "solid",
+        "borderRadius": "4px",
         "borderWidth": "1px",
-        "color": "grey-80",
+        "color": "grey-60",
         "fontWeight": "normal",
         "padding": "11px 12px 11px 0",
         "&:before": {
@@ -1376,8 +1377,8 @@
             "variant": "input.radioish.base.&:checked + span.&::before",
             "backgroundImage": "url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='-1 -2 14 12'%3E%3Cpath d='M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z' /%3E%3C/svg%3E\")",
             "backgroundSize": "16px 16px",
-            "backgroundColor": "black",
-            "borderColor": "black"
+            "backgroundColor": "plum",
+            "borderColor": "plum"
           }
         }
       },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -681,7 +681,6 @@
     }  
   },
 
-
   "compounds": {
     "accordion": {
       "base": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1258,6 +1258,31 @@
   },
 
   "input": {
+    "base": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.33,
+      "color": "text",
+      "borderRadius": "4px",
+      "appearance": "none",
+      "border": "none",
+      "background": "none",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flex": 1,
+      "position": "relative",
+      "verticalAlign": "middle",
+      "width": "100%",
+      "&:focus": {
+        "outline": "none"
+      },
+      "&:disabled": {
+        "outline": "none",
+        "border": "none",
+        "color": "primary",
+        "background": "veryLightGrey"
+      }
+    },
     "default": {
       "color": "grey-40"
     },
@@ -1272,11 +1297,6 @@
       "color": "plum",
       "outline": "2px solid",
       "outline-color": "orange"
-    },
-    "textInput": {
-      "wrapper": {
-        "borderRadius": "4px"
-      }
     },
     "radioish": {
       "base": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -678,7 +678,31 @@
       "before": {
         "content": "none"
       }
-    }  
+    },
+
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "flex-end",
+          "paddingY": "xxs"
+        },
+        "text": {
+          "color": "white",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "maxHeight": "32px",
+          "maxWidth": "76px",
+          "pb": [0,"sm"],
+          "ml": "xs"
+        }
+      }
+    }
   },
 
   "compounds": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -663,6 +663,21 @@
           "borderWidth": "2px"
         }
       }
+    },
+
+    "input-alert": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.38,
+      "color": "error",
+      "padding": 8,
+      "position": "relative",
+      "borderRadius": "sm",
+      "notificationColor": "none",
+      "alertColor": "none",
+      "before": {
+        "content": "none"
+      }
     }  
   },
 
@@ -1599,21 +1614,6 @@
         "borderStyle": "solid",
         "borderWidth": "2px"
       }
-    }
-  },
-
-  "input-alert": {
-    "fontFamily": "base",
-    "fontSize": "base",
-    "lineHeight": 1.38,
-    "color": "error",
-    "padding": 8,
-    "position": "relative",
-    "borderRadius": "sm",
-    "notificationColor": "none",
-    "alertColor": "none",
-    "before": {
-      "content": "none"
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1258,17 +1258,24 @@
   },
 
   "input": {
+    "default": {
+      "color": "grey-40"
+    },
+    "error": {
+      "color": "error"
+    },
     "frozen": {
       "backgroundColor": "grey-10",
       "borderRadius": "3px"
     },
     "focus": {
+      "color": "plum",
       "outline": "2px solid",
       "outline-color": "orange"
     },
     "textInput": {
       "wrapper": {
-        "borderRadius": "3px"
+        "borderRadius": "4px"
       }
     },
     "radioish": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1468,6 +1468,25 @@
     }
   },
 
+  "input-alert": {
+    "fontFamily": "base",
+    "fontSize": "base",
+    "lineHeight": 1.38,
+    "color": "white",
+    "padding": "xs",
+    "position": "relative",
+    "borderRadius": "sm",
+    "notificationColor": "#65717B",
+    "alertColor": "error",
+    "before": {
+      "position": "absolute",
+      "content": "''",
+      "width": 0,
+      "height": 0,
+      "borderBottomStyle": "solid"
+    }
+  },
+
   "pagination": {
     "arrow": {
       "color": "grey-100"

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1284,7 +1284,6 @@
     },
     "wrapper": {
       "backgroundColor": "white",
-      "border": "solid 1px",
       "boxSizing": "border-box",
       "display": "flex",
       "position": "relative",
@@ -1304,10 +1303,19 @@
       "color": "plum"
     },
     "affix": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": "base",
+        "textAlign": "center",
+        "boxSizing": "border-box"      
+      },
       "prefix": {
+        "variant": "input.affix.base",
         "borderRightStyle": "none"
       },
       "suffix": {
+        "variant": "input.affix.base",
         "borderLeftStyle": "none"
       }
     },
@@ -1315,14 +1323,11 @@
       "base": {
         "&:checked + span": {
           "borderColor": "grey-40",
+          "boxShadow": "green",
           "color": "grey-80",
           "&::before": {
             "borderColor": "black"
           }
-        },
-        "&:focus + span": {
-          "border": "2px solid",
-          "borderColor": "plum"
         }
       },
       "label": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1280,7 +1280,7 @@
         "outline": "none",
         "border": "none",
         "color": "primary",
-        "background": "veryLightGrey"
+        "background": "grey-05"
       }
     },
     "default": {
@@ -1294,9 +1294,15 @@
       "borderRadius": "3px"
     },
     "focus": {
-      "color": "plum",
-      "outline": "2px solid",
-      "outline-color": "orange"
+      "color": "plum"
+    },
+    "affix": {
+      "prefix": {
+        "borderRightStyle": "none"
+      },
+      "suffix": {
+        "borderLeftStyle": "none"
+      }
     },
     "radioish": {
       "base": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -12,7 +12,8 @@
 
   "shadows": {
     "box": "2px 2px 25px #0004",
-    "linkInset": "inset 0 0 0 1px #008fe9"
+    "linkInset": "inset 0 0 0 1px #008fe9",
+    "plumInset": "inset 0 0 0 1px #924A8B"
   },
 
   "fonts": {
@@ -1323,11 +1324,14 @@
       "base": {
         "&:checked + span": {
           "borderColor": "grey-40",
-          "boxShadow": "green",
           "color": "grey-80",
           "&::before": {
             "borderColor": "black"
           }
+        },
+        "&:focus + span": {
+          "borderColor": "plum",
+          "boxShadow": "plumInset"
         }
       },
       "label": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -451,7 +451,219 @@
           }
         }
       }
-    }
+    },
+
+    "input": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": 1.33,
+        "color": "text",
+        "appearance": "none",
+        "border": "none",
+        "background": "none",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flex": 1,
+        "position": "relative",
+        "verticalAlign": "middle",
+        "width": "100%",
+        "&:focus": {
+          "outline": "none"
+        },
+        "&:disabled": {
+          "outline": "none",
+          "border": "none",
+          "color": "primary",
+          "backgroundColor": "grey-05"
+        }
+      },
+      "wrapper": {
+        "backgroundColor": "white",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "position": "relative",
+        "borderRadius": "4px"
+      },
+      "default": {
+        "color": "grey-40"
+      },
+      "error": {
+        "color": "error"
+      },
+      "frozen": {
+        "base": {
+          "backgroundColor": "grey-10",
+          "borderRadius": "4px",
+          "p": {
+            "margin": 0
+          }
+        },
+        "button": {
+          "background": "none",
+          "border": "none",
+          "borderLeft": "none",
+          "height": "28px",
+          "padding": "0 24px",
+          "width": "69px",
+          "cursor": "pointer",
+          "color": "grey-80",
+          ":focus": {
+            "outline": "2px solid",
+            "outlineColor": "plum"
+          },
+          "&::-moz-focus-inner": { "border": 0 }
+        },
+        "hidden": {
+          "display": "none"
+        }
+      },
+      "focus": {
+        "color": "plum"
+      },
+      "affix": {
+        "base": {
+          "fontFamily": "base",
+          "fontSize": "base",
+          "lineHeight": "base",
+          "textAlign": "center",
+          "boxSizing": "border-box",
+          "alignItems": "center",
+          "display": "flex"  
+        },
+        "prefix": {
+          "variant": "elements.input.affix.base",
+          "borderRightStyle": "none",
+          "iconColor": "grey-80"
+        },
+        "suffix": {
+          "variant": "elements.input.affix.base",
+          "borderLeftStyle": "none"
+        }
+      },
+      "radioish": {
+        "base": {
+          "&:checked + span": {
+            "borderColor": "grey-40",
+            "color": "grey-80",
+            "&::before": {
+              "borderColor": "black"
+            }
+          },
+          "&:focus + span": {
+            "borderColor": "plum",
+            "boxShadow": "plumInset"
+          }
+        },
+        "label": {
+          "borderColor": "grey-40",
+          "borderStyle": "solid",
+          "borderRadius": "4px",
+          "borderWidth": "1px",
+          "color": "grey-60",
+          "fontWeight": "normal",
+          "padding": "11px 12px 11px 0",
+          "&:before": {
+            "borderColor": "grey-30",
+            "borderStyle": "solid",
+            "borderWidth": "2px"
+          }
+        },
+        "error": {
+          "variant": "elements.input.radioish.label",
+          "color": "error"
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.radioish.base"
+          },
+          "slim": {
+            "variant": "elements.input.radioish.base"
+          }
+        }
+      },
+      "radio": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "borderColor": "plum",
+              "backgroundColor": "plum",
+              "boxShadow": "inset 0 0 0 2px #fff"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "50%"
+          }
+        }
+      },
+      "checkbox": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "backgroundImage": "url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='-1 -2 14 12'%3E%3Cpath d='M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z' /%3E%3C/svg%3E\")",
+              "backgroundSize": "16px 16px",
+              "backgroundColor": "plum",
+              "borderColor": "plum"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "4px"
+          }
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.checkbox.base"
+          },
+          "slim": {
+            "variant": "elements.input.checkbox.base",
+            "& + span": {
+              "padding": "0px",
+              "border": "none"
+            },
+            "&:checked + span": {
+              "variant": "elements.input.checkbox.base.&:checked + span",
+              "boxShadow": "none",
+              "&::before": {
+                "variant": "elements.input.checkbox.base.&:checked + span.&::before"
+              }
+            },
+            "&:focus + span": {},
+            "&:focus + span::before": {
+              "variant": "elements.input.focus"
+            }
+          }
+        }
+      },
+      "tile": {
+        "inputColor": "#008fe9",
+        "borderColor": "#b0b8bf",
+        "borderRadius": "3px",
+        "borderStyle": "solid",
+        "borderWidth": "1px",
+        "color": "slate-grey",
+        "fontWeight": "normal",
+        "before": {
+          "content": "' '",
+          "borderColor": "#b0b8bf",
+          "borderStyle": "solid",
+          "borderWidth": "2px"
+        }
+      }
+    }  
   },
 
 
@@ -1259,111 +1471,38 @@
   },
 
   "input": {
-    "base": {
-      "fontFamily": "base",
-      "fontSize": "base",
-      "lineHeight": 1.33,
-      "color": "text",
-      "appearance": "none",
-      "border": "none",
-      "background": "none",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flex": 1,
-      "position": "relative",
-      "verticalAlign": "middle",
-      "width": "100%",
-      "&:focus": {
-        "outline": "none"
-      },
-      "&:disabled": {
-        "outline": "none",
-        "border": "none",
-        "color": "primary",
-        "background": "grey-05"
-      }
-    },
-    "wrapper": {
-      "backgroundColor": "white",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "position": "relative",
-      "borderRadius": "4px"
-    },
-    "default": {
-      "color": "grey-40"
-    },
-    "error": {
-      "color": "error"
-    },
     "frozen": {
-      "base": {
-        "backgroundColor": "grey-10",
-        "borderRadius": "4px",
-        "p": {
-          "margin": 0
-        }
-      },
-      "button": {
-        "background": "none",
-        "border": "none",
-        "borderLeft": "none",
-        "height": "28px",
-        "padding": "0 24px",
-        "width": "69px",
-        "cursor": "pointer",
-        "color": "grey-80",
-        ":focus": {
-          "outline": "2px solid",
-          "outlineColor": "plum"
-        },
-        "&::-moz-focus-inner": { "border": 0 }
-      },
-      "hidden": {
-        "display": "none"
-      }
+      "backgroundColor": "grey-10",
+      "borderRadius": "3px"
     },
     "focus": {
-      "color": "plum"
+      "outline": "2px solid",
+      "outline-color": "orange"
     },
-    "affix": {
-      "base": {
-        "fontFamily": "base",
-        "fontSize": "base",
-        "lineHeight": "base",
-        "textAlign": "center",
-        "boxSizing": "border-box"      
-      },
-      "prefix": {
-        "variant": "input.affix.base",
-        "borderRightStyle": "none",
-        "iconColor": "grey-80"
-      },
-      "suffix": {
-        "variant": "input.affix.base",
-        "borderLeftStyle": "none"
+    "textInput": {
+      "wrapper": {
+        "borderRadius": "3px"
       }
     },
     "radioish": {
       "base": {
         "&:checked + span": {
-          "borderColor": "grey-40",
-          "color": "grey-80",
+          "borderColor": "black",
+          "boxShadow": "linkInset",
+          "color": "black",
           "&::before": {
             "borderColor": "black"
           }
         },
         "&:focus + span": {
-          "borderColor": "plum",
-          "boxShadow": "plumInset"
+          "variant": "input.focus"
         }
       },
       "label": {
         "borderColor": "grey-40",
         "borderStyle": "solid",
-        "borderRadius": "4px",
         "borderWidth": "1px",
-        "color": "grey-60",
+        "color": "grey-80",
         "fontWeight": "normal",
         "padding": "11px 12px 11px 0",
         "&:before": {
@@ -1371,10 +1510,6 @@
           "borderStyle": "solid",
           "borderWidth": "2px"
         }
-      },
-      "error": {
-        "variant": "input.radioish.label",
-        "color": "error"
       },
       "variants": {
         "normal": {
@@ -1392,8 +1527,7 @@
           "variant": "input.radioish.base.&:checked + span",
           "&::before": {
             "variant": "input.radioish.base.&:checked + span.&::before",
-            "borderColor": "plum",
-            "backgroundColor": "plum",
+            "background": "black",
             "boxShadow": "inset 0 0 0 2px #fff"
           }
         }
@@ -1415,8 +1549,8 @@
             "variant": "input.radioish.base.&:checked + span.&::before",
             "backgroundImage": "url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='-1 -2 14 12'%3E%3Cpath d='M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z' /%3E%3C/svg%3E\")",
             "backgroundSize": "16px 16px",
-            "backgroundColor": "plum",
-            "borderColor": "plum"
+            "backgroundColor": "black",
+            "borderColor": "black"
           }
         }
       },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -474,8 +474,8 @@
         "&:disabled": {
           "outline": "none",
           "border": "none",
-          "color": "primary",
-          "backgroundColor": "grey-05"
+          "color": "grey-60",
+          "backgroundColor": "grey-20"
         }
       },
       "wrapper": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1473,7 +1473,7 @@
     "fontSize": "base",
     "lineHeight": 1.38,
     "color": "error",
-    "padding": "xs",
+    "padding": 12,
     "position": "relative",
     "borderRadius": "sm",
     "notificationColor": "none",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1263,7 +1263,6 @@
       "fontSize": "base",
       "lineHeight": 1.33,
       "color": "text",
-      "borderRadius": "4px",
       "appearance": "none",
       "border": "none",
       "background": "none",
@@ -1282,6 +1281,14 @@
         "color": "primary",
         "background": "grey-05"
       }
+    },
+    "wrapper": {
+      "backgroundColor": "white",
+      "border": "solid 1px",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "position": "relative",
+      "borderRadius": "4px"
     },
     "default": {
       "color": "grey-40"

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1299,7 +1299,10 @@
     "frozen": {
       "base": {
         "backgroundColor": "grey-10",
-        "borderRadius": "4px"
+        "borderRadius": "4px",
+        "p": {
+          "margin": 0
+        }
       },
       "button": {
         "background": "none",
@@ -1309,6 +1312,7 @@
         "padding": "0 24px",
         "width": "69px",
         "cursor": "pointer",
+        "color": "grey-80",
         ":focus": {
           "outline": "2px solid",
           "outlineColor": "plum"
@@ -1332,7 +1336,8 @@
       },
       "prefix": {
         "variant": "input.affix.base",
-        "borderRightStyle": "none"
+        "borderRightStyle": "none",
+        "iconColor": "grey-80"
       },
       "suffix": {
         "variant": "input.affix.base",
@@ -1366,6 +1371,10 @@
           "borderStyle": "solid",
           "borderWidth": "2px"
         }
+      },
+      "error": {
+        "variant": "input.radioish.label",
+        "color": "error"
       },
       "variants": {
         "normal": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1473,7 +1473,7 @@
     "fontSize": "base",
     "lineHeight": 1.38,
     "color": "error",
-    "padding": 12,
+    "padding": 8,
     "position": "relative",
     "borderRadius": "sm",
     "notificationColor": "none",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1472,18 +1472,14 @@
     "fontFamily": "base",
     "fontSize": "base",
     "lineHeight": 1.38,
-    "color": "white",
+    "color": "error",
     "padding": "xs",
     "position": "relative",
     "borderRadius": "sm",
-    "notificationColor": "#65717B",
-    "alertColor": "error",
+    "notificationColor": "none",
+    "alertColor": "none",
     "before": {
-      "position": "absolute",
-      "content": "''",
-      "width": 0,
-      "height": 0,
-      "borderBottomStyle": "solid"
+      "content": "none"
     }
   },
 

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1297,8 +1297,27 @@
       "color": "error"
     },
     "frozen": {
-      "backgroundColor": "grey-10",
-      "borderRadius": "3px"
+      "base": {
+        "backgroundColor": "grey-10",
+        "borderRadius": "4px"
+      },
+      "button": {
+        "background": "none",
+        "border": "none",
+        "borderLeft": "none",
+        "height": "28px",
+        "padding": "0 24px",
+        "width": "69px",
+        "cursor": "pointer",
+        ":focus": {
+          "outline": "2px solid",
+          "outlineColor": "plum"
+        },
+        "&::-moz-focus-inner": { "border": 0 }
+      },
+      "hidden": {
+        "display": "none"
+      }
     },
     "focus": {
       "color": "plum"

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -311,6 +311,29 @@
     }
   },
 
+  "elements": {
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
+    }
+  },
+
   "imageCallout": {
     "imageSize": { "height": 337, "width": 477 },
     "sm": { "display": "flex", "width": 320, "mx": "auto" },

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -268,6 +268,16 @@
         "color": "primary",
         "background": "veryLightGrey"
       }
+    },
+    "affix": {
+      "prefix": {
+        "borderRightStyle": "solid",
+        "borderRightWidth": 1
+      },
+      "suffix": {
+        "borderLeftStyle": "solid",
+        "borderLeftWidth": 1
+      }
     }
   },
 

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -269,6 +269,14 @@
         "background": "veryLightGrey"
       }
     },
+    "wrapper": {
+      "backgroundColor": "white",
+      "border": "solid 1px",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "position": "relative",
+      "borderRadius": "3px"
+    },
     "affix": {
       "prefix": {
         "borderRightStyle": "solid",

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -271,18 +271,26 @@
     },
     "wrapper": {
       "backgroundColor": "white",
-      "border": "solid 1px",
       "boxSizing": "border-box",
       "display": "flex",
       "position": "relative",
       "borderRadius": "3px"
     },
     "affix": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": "base",
+        "textAlign": "center",
+        "boxSizing": "border-box"      
+      },
       "prefix": {
+        "variant": "input.affix.base",
         "borderRightStyle": "solid",
         "borderRightWidth": 1
       },
       "suffix": {
+        "variant": "input.affix.base",
         "borderLeftStyle": "solid",
         "borderLeftWidth": 1
       }

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -327,7 +327,7 @@
     "fontSize": "base",
     "lineHeight": 1.38,
     "color": "white",
-    "padding": "xs",
+    "padding": 12,
     "position": "relative",
     "borderRadius": "sm",
     "notificationColor": "#65717B",

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -163,6 +163,86 @@
   },
 
   "----------------------------- Variants": "-----------------------------",
+  "elements": {
+    "input": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": 1.33,
+        "color": "text",
+        "borderRadius": "4px",
+        "appearance": "none",
+        "border": "none",
+        "background": "none",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flex": 1,
+        "position": "relative",
+        "verticalAlign": "middle",
+        "width": "100%",
+        "&:focus": {
+          "outline": "none"
+        },
+        "&:disabled": {
+          "outline": "none",
+          "border": "none",
+          "color": "battleshipGrey",
+          "backgroundColor": "veryLightGrey"
+        }
+      },
+      "wrapper": {
+        "backgroundColor": "white",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "position": "relative",
+        "borderRadius": "3px"
+      },
+      "frozen": {
+        "base": {
+          "backgroundColor": "frozen-bg",
+          "borderRadius": "3px"
+        },
+        "button": {
+          "background": "none",
+          "border": "none",
+          "height": "28px",
+          "padding": "0 24px",
+          "width": "69px",
+          "cursor": "pointer",
+          ":focus": {
+            "outline": "2px solid",
+            "outlineColor": "#008fe9"
+          },
+          "&::-moz-focus-inner": { "border": 0 }
+        },
+        "hidden": {
+          "display": "none"
+        }
+      },
+      "affix": {
+        "base": {
+          "fontFamily": "base",
+          "fontSize": "base",
+          "lineHeight": "base",
+          "textAlign": "center",
+          "boxSizing": "border-box",
+          "alignItems": "center",
+          "display": "flex" 
+        },
+        "prefix": {
+          "variant": "elements.input.affix.base",
+          "borderRightStyle": "solid",
+          "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
+        }
+      }
+    }
+  },
+  
   "compounds": {
     "card": {
       "base": {
@@ -247,77 +327,9 @@
   },
 
   "input": {
-    "base": {
-      "fontFamily": "base",
-      "fontSize": "base",
-      "lineHeight": 1.33,
-      "color": "text",
-      "borderRadius": "4px",
-      "appearance": "none",
-      "border": "none",
-      "background": "none",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flex": 1,
-      "position": "relative",
-      "verticalAlign": "middle",
-      "width": "100%",
-      "&:focus": {
-        "outline": "none"
-      },
-      "&:disabled": {
-        "outline": "none",
-        "border": "none",
-        "color": "battleshipGrey",
-        "backgroundColor": "veryLightGrey"
-      }
-    },
-    "wrapper": {
-      "backgroundColor": "white",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "position": "relative",
-      "borderRadius": "3px"
-    },
-    "frozen": {
-      "base": {
-        "backgroundColor": "frozen-bg",
+    "textInput": {
+      "wrapper": {
         "borderRadius": "3px"
-      },
-      "button": {
-        "background": "none",
-        "border": "none",
-        "height": "28px",
-        "padding": "0 24px",
-        "width": "69px",
-        "cursor": "pointer",
-        ":focus": {
-          "outline": "2px solid",
-          "outlineColor": "#008fe9"
-        },
-        "&::-moz-focus-inner": { "border": 0 }
-      },
-      "hidden": {
-        "display": "none"
-      }
-    },
-    "affix": {
-      "base": {
-        "fontFamily": "base",
-        "fontSize": "base",
-        "lineHeight": "base",
-        "textAlign": "center",
-        "boxSizing": "border-box"      
-      },
-      "prefix": {
-        "variant": "input.affix.base",
-        "borderRightStyle": "solid",
-        "borderRightWidth": 1
-      },
-      "suffix": {
-        "variant": "input.affix.base",
-        "borderLeftStyle": "solid",
-        "borderLeftWidth": 1
       }
     }
   },

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -115,7 +115,9 @@
     "light-3": "#e6e6e6",
     "hero": "rgba(212, 242, 255, 0.8)",
     "hero-solid": "D4F2F1",
-    "frozen-bg": "#F6F6F6"
+    "frozen-bg": "#F6F6F6",
+    "battleshipGrey": "#65717B",
+    "veryLightGrey": "#E9EBED"
   },
 
   "radii": {
@@ -266,8 +268,8 @@
       "&:disabled": {
         "outline": "none",
         "border": "none",
-        "color": "primary",
-        "background": "veryLightGrey"
+        "color": "battleshipGrey",
+        "backgroundColor": "veryLightGrey"
       }
     },
     "wrapper": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -244,9 +244,29 @@
   },
 
   "input": {
-    "textInput": {
-      "wrapper": {
-        "borderRadius": "3px"
+    "base": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.33,
+      "color": "text",
+      "borderRadius": "4px",
+      "appearance": "none",
+      "border": "none",
+      "background": "none",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flex": 1,
+      "position": "relative",
+      "verticalAlign": "middle",
+      "width": "100%",
+      "&:focus": {
+        "outline": "none"
+      },
+      "&:disabled": {
+        "outline": "none",
+        "border": "none",
+        "color": "primary",
+        "background": "veryLightGrey"
       }
     }
   },

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -285,8 +285,6 @@
       "button": {
         "background": "none",
         "border": "none",
-        "borderLeft": "1px solid",
-        "borderLeftColor": "#59646d",
         "height": "28px",
         "padding": "0 24px",
         "width": "69px",

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -114,7 +114,8 @@
     "light-2": "#f9f9f9",
     "light-3": "#e6e6e6",
     "hero": "rgba(212, 242, 255, 0.8)",
-    "hero-solid": "D4F2F1"
+    "hero-solid": "D4F2F1",
+    "frozen-bg": "#F6F6F6"
   },
 
   "radii": {
@@ -275,6 +276,30 @@
       "display": "flex",
       "position": "relative",
       "borderRadius": "3px"
+    },
+    "frozen": {
+      "base": {
+        "backgroundColor": "frozen-bg",
+        "borderRadius": "3px"
+      },
+      "button": {
+        "background": "none",
+        "border": "none",
+        "borderLeft": "1px solid",
+        "borderLeftColor": "#59646d",
+        "height": "28px",
+        "padding": "0 24px",
+        "width": "69px",
+        "cursor": "pointer",
+        ":focus": {
+          "outline": "2px solid",
+          "outlineColor": "#008fe9"
+        },
+        "&::-moz-focus-inner": { "border": 0 }
+      },
+      "hidden": {
+        "display": "none"
+      }
     },
     "affix": {
       "base": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -240,7 +240,26 @@
           "borderLeftWidth": 1
         }
       }
-    }
+    },
+
+    "input-alert": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.38,
+      "color": "white",
+      "padding": 12,
+      "position": "relative",
+      "borderRadius": "sm",
+      "notificationColor": "#65717B",
+      "alertColor": "#DB1818",
+      "before": {
+        "position": "absolute",
+        "content": "''",
+        "width": 0,
+        "height": 0,
+        "borderBottomStyle": "solid"
+      }
+    }  
   },
   
   "compounds": {
@@ -331,25 +350,6 @@
       "wrapper": {
         "borderRadius": "3px"
       }
-    }
-  },
-
-  "input-alert": {
-    "fontFamily": "base",
-    "fontSize": "base",
-    "lineHeight": 1.38,
-    "color": "white",
-    "padding": 12,
-    "position": "relative",
-    "borderRadius": "sm",
-    "notificationColor": "#65717B",
-    "alertColor": "#DB1818",
-    "before": {
-      "position": "absolute",
-      "content": "''",
-      "width": 0,
-      "height": 0,
-      "borderBottomStyle": "solid"
     }
   },
 

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -322,6 +322,25 @@
     }
   },
 
+  "input-alert": {
+    "fontFamily": "base",
+    "fontSize": "base",
+    "lineHeight": 1.38,
+    "color": "white",
+    "padding": "xs",
+    "position": "relative",
+    "borderRadius": "sm",
+    "notificationColor": "#65717B",
+    "alertColor": "#DB1818",
+    "before": {
+      "position": "absolute",
+      "content": "''",
+      "width": 0,
+      "height": 0,
+      "borderBottomStyle": "solid"
+    }
+  },
+
   "buttons": {
     "variants": {
       "primary": {

--- a/src/themes/uswitch-rebrand/package.json
+++ b/src/themes/uswitch-rebrand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-rebrand-theme",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch-rebrand/theme.json
+++ b/src/themes/uswitch-rebrand/theme.json
@@ -174,7 +174,10 @@
 
     "orange": "#FFAA55",
     "error-red": "#D64226",
-    "success-green": "#2AAA5B"
+    "success-green": "#2AAA5B",
+    "frozen-bg": "#F6F6F6",
+    "battleshipGrey": "#65717B",
+    "veryLightGrey": "#E9EBED"
   },
 
   "radii": {
@@ -397,12 +400,224 @@
   },
 
   "elements": {
+    "input": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": 1.33,
+        "color": "text",
+        "appearance": "none",
+        "border": "none",
+        "background": "none",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flex": 1,
+        "position": "relative",
+        "verticalAlign": "middle",
+        "width": "100%",
+        "&:focus": {
+          "outline": "none"
+        },
+        "&:disabled": {
+          "outline": "none",
+          "border": "none",
+          "color": "battleshipGrey",
+          "backgroundColor": "veryLightGrey"
+        }
+      },
+      "wrapper": {
+        "backgroundColor": "white",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "position": "relative",
+        "borderRadius": "0px"
+      },
+      "frozen": {
+        "base": {
+          "backgroundColor": "frozen-bg",
+          "borderRadius": "0px"
+        },
+        "button": {
+          "background": "none",
+          "border": "none",
+          "height": "28px",
+          "padding": "0 24px",
+          "width": "69px",
+          "cursor": "pointer",
+          ":focus": {
+            "outline": "2px solid",
+            "outlineColor": "#008fe9"
+          },
+          "&::-moz-focus-inner": { "border": 0 }
+        },
+        "hidden": {
+          "display": "none"
+        }
+      },
+      "focus": {
+        "outline": "2px solid",
+        "outline-color": "orange"
+      },
+      "affix": {
+        "base": {
+          "fontFamily": "base",
+          "fontSize": "base",
+          "lineHeight": "base",
+          "textAlign": "center",
+          "boxSizing": "border-box",
+          "alignItems": "center",
+          "display": "flex"
+        },
+        "prefix": {
+          "variant": "elements.input.affix.base",
+          "borderRightStyle": "solid",
+          "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
+        }
+      },
+      "radioish": {
+        "base": {
+          "&:checked + span": {
+            "borderColor": "black",
+            "boxShadow": "linkInset",
+            "color": "black",
+            "&::before": {
+              "borderColor": "black"
+            }
+          },
+          "&:focus + span": {
+            "variant": "elements.input.focus"
+          }
+        },
+        "label": {
+          "borderColor": "grey-40",
+          "borderStyle": "solid",
+          "borderWidth": "1px",
+          "color": "grey-80",
+          "fontWeight": "normal",
+          "padding": "11px 12px 11px 0",
+          "&:before": {
+            "borderColor": "grey-30",
+            "borderStyle": "solid",
+            "borderWidth": "2px"
+          }
+        },
+        "error": {
+          "variant": "elements.input.radioish.label",
+          "color": "error-red"
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.radioish.base"
+          },
+          "slim": {
+            "variant": "elements.input.radioish.base"
+          }
+        }
+      },
+      "radio": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "background": "black",
+              "boxShadow": "inset 0 0 0 2px #fff"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "50%"
+          }
+        }
+      },
+      "checkbox": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "backgroundImage": "url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='-1 -2 14 12'%3E%3Cpath d='M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z' /%3E%3C/svg%3E\")",
+              "backgroundSize": "16px 16px",
+              "backgroundColor": "black",
+              "borderColor": "black"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "4px"
+          }
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.checkbox.base"
+          },
+          "slim": {
+            "variant": "elements.input.checkbox.base",
+            "& + span": {
+              "padding": "0px",
+              "border": "none"
+            },
+            "&:checked + span": {
+              "variant": "elements.input.checkbox.base.&:checked + span",
+              "boxShadow": "none",
+              "&::before": {
+                "variant": "elements.input.checkbox.base.&:checked + span.&::before"
+              }
+            },
+            "&:focus + span": {},
+            "&:focus + span::before": {
+              "variant": "elements.input.focus"
+            }
+          }
+        }
+      },
+      "tile": {
+        "inputColor": "#141424",
+        "borderColor": "light-grey-blue",
+        "borderStyle": "solid",
+        "borderWidth": "2px",
+        "color": "slate-grey",
+        "fontWeight": "normal",
+        "before": {
+          "content": "' '",
+          "borderColor": "light-grey-blue",
+          "borderStyle": "solid",
+          "borderWidth": "2px"
+        }
+      }
+    },
+
     "input-alert": {
       "padding": 16,
       "notificationColor": "primary",
       "alertColor": "error-red",
       "color": "white",
-      "radii": 0
+      "radii": 0,
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.38,
+      "position": "relative",
+      "borderRadius": 0,
+      "before": {
+        "position": "absolute",
+        "content": "''",
+        "width": 0,
+        "height": 0,
+        "borderBottomStyle": "solid"
+      }
     },
 
     "logo": {

--- a/src/themes/uswitch-rebrand/theme.json
+++ b/src/themes/uswitch-rebrand/theme.json
@@ -627,6 +627,27 @@
         "maxWidth": 110,
         "width": "auto"
       }
+    },
+
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1281,7 +1281,6 @@
     },
     "wrapper": {
       "backgroundColor": "white",
-      "border": "solid 1px",
       "boxSizing": "border-box",
       "display": "flex",
       "position": "relative",
@@ -1296,11 +1295,20 @@
       "outline-color": "orange"
     },
     "affix": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": "base",
+        "textAlign": "center",
+        "boxSizing": "border-box"      
+      },
       "prefix": {
+        "variant": "input.affix.base",
         "borderRightStyle": "solid",
         "borderRightWidth": 1
       },
       "suffix": {
+        "variant": "input.affix.base",
         "borderLeftStyle": "solid",
         "borderLeftWidth": 1
       }

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1279,6 +1279,14 @@
         "background": "veryLightGrey"
       }
     },
+    "wrapper": {
+      "backgroundColor": "white",
+      "border": "solid 1px",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "position": "relative",
+      "borderRadius": "3px"
+    },
     "frozen": {
       "backgroundColor": "frozen-bg",
       "borderRadius": "0px"

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -582,6 +582,25 @@
           "borderWidth": "2px"
         }
       }
+    },
+
+    "input-alert": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.38,
+      "color": "white",
+      "padding": 16,
+      "position": "relative",
+      "borderRadius": 0,
+      "notificationColor": "uswitch-navy",
+      "alertColor": "error-red",
+      "before": {
+        "position": "absolute",
+        "content": "''",
+        "width": 0,
+        "height": 0,
+        "borderBottomStyle": "solid"
+      }
     }
   },
 
@@ -1569,25 +1588,6 @@
         "borderStyle": "solid",
         "borderWidth": "2px"
       }
-    }
-  },
-
-  "input-alert": {
-    "fontFamily": "base",
-    "fontSize": "base",
-    "lineHeight": 1.38,
-    "color": "white",
-    "padding": 16,
-    "position": "relative",
-    "borderRadius": 0,
-    "notificationColor": "uswitch-navy",
-    "alertColor": "error-red",
-    "before": {
-      "position": "absolute",
-      "content": "''",
-      "width": 0,
-      "height": 0,
-      "borderBottomStyle": "solid"
     }
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -602,6 +602,27 @@
         "height": 0,
         "borderBottomStyle": "solid"
       }
+    },
+
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -149,6 +149,8 @@
     "black-75": "#4F4F5B",
     "black-50": "#898991",
     "black-25": "#C4C4C8",
+    "battleshipGrey": "#65717B",
+    "veryLightGrey": "#E9EBED",
 
     "uswitch-navy": "#141424",
 
@@ -164,7 +166,7 @@
     "grey-05": "#F3F3F4",
     "white": "#FFFFFF",
 
-    "frozen-bg": "#f6f6f6",
+    "frozen-bg": "#F6F6F6",
 
     "progress-bg": "#E0E9FF",
     "progress-primary": "#84A6FF",
@@ -1253,6 +1255,30 @@
   },
 
   "input": {
+    "base": {
+      "fontFamily": "base",
+      "fontSize": "base",
+      "lineHeight": 1.33,
+      "color": "text",
+      "appearance": "none",
+      "border": "none",
+      "background": "none",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flex": 1,
+      "position": "relative",
+      "verticalAlign": "middle",
+      "width": "100%",
+      "&:focus": {
+        "outline": "none"
+      },
+      "&:disabled": {
+        "outline": "none",
+        "border": "none",
+        "color": "battleshipGrey",
+        "background": "veryLightGrey"
+      }
+    },
     "frozen": {
       "backgroundColor": "frozen-bg",
       "borderRadius": "0px"

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1360,6 +1360,10 @@
           "borderWidth": "2px"
         }
       },
+      "error": {
+        "variant": "input.radioish.label",
+        "color": "error-red"
+      },
       "variants": {
         "normal": {
           "variant": "input.radioish.base"

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -382,14 +382,6 @@
           }
         }
       }
-    },
-
-    "input-alert": {
-      "padding": 16,
-      "notificationColor": "uswitch-navy",
-      "alertColor": "error-red",
-      "color": "white",
-      "radii": 0
     }
   },
 
@@ -1451,6 +1443,25 @@
         "borderStyle": "solid",
         "borderWidth": "2px"
       }
+    }
+  },
+
+  "input-alert": {
+    "fontFamily": "base",
+    "fontSize": "base",
+    "lineHeight": 1.38,
+    "color": "white",
+    "padding": 16,
+    "position": "relative",
+    "borderRadius": 0,
+    "notificationColor": "uswitch-navy",
+    "alertColor": "error-red",
+    "before": {
+      "position": "absolute",
+      "content": "''",
+      "width": 0,
+      "height": 0,
+      "borderBottomStyle": "solid"
     }
   },
 

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1286,8 +1286,6 @@
       "button": {
         "background": "none",
         "border": "none",
-        "borderLeft": "1px solid",
-        "borderLeftColor": "#59646d",
         "height": "28px",
         "padding": "0 24px",
         "width": "69px",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -382,6 +382,206 @@
           }
         }
       }
+    },
+
+    "input": {
+      "base": {
+        "fontFamily": "base",
+        "fontSize": "base",
+        "lineHeight": 1.33,
+        "color": "text",
+        "appearance": "none",
+        "border": "none",
+        "background": "none",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flex": 1,
+        "position": "relative",
+        "verticalAlign": "middle",
+        "width": "100%",
+        "&:focus": {
+          "outline": "none"
+        },
+        "&:disabled": {
+          "outline": "none",
+          "border": "none",
+          "color": "battleshipGrey",
+          "backgroundColor": "veryLightGrey"
+        }
+      },
+      "wrapper": {
+        "backgroundColor": "white",
+        "boxSizing": "border-box",
+        "display": "flex",
+        "position": "relative",
+        "borderRadius": "0px"
+      },
+      "frozen": {
+        "base": {
+          "backgroundColor": "frozen-bg",
+          "borderRadius": "0px"
+        },
+        "button": {
+          "background": "none",
+          "border": "none",
+          "height": "28px",
+          "padding": "0 24px",
+          "width": "69px",
+          "cursor": "pointer",
+          ":focus": {
+            "outline": "2px solid",
+            "outlineColor": "#008fe9"
+          },
+          "&::-moz-focus-inner": { "border": 0 }
+        },
+        "hidden": {
+          "display": "none"
+        }
+      },
+      "focus": {
+        "outline": "2px solid",
+        "outline-color": "orange"
+      },
+      "affix": {
+        "base": {
+          "fontFamily": "base",
+          "fontSize": "base",
+          "lineHeight": "base",
+          "textAlign": "center",
+          "boxSizing": "border-box",
+          "alignItems": "center",
+          "display": "flex"
+        },
+        "prefix": {
+          "variant": "elements.input.affix.base",
+          "borderRightStyle": "solid",
+          "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
+        }
+      },
+      "radioish": {
+        "base": {
+          "&:checked + span": {
+            "borderColor": "black",
+            "boxShadow": "linkInset",
+            "color": "black",
+            "&::before": {
+              "borderColor": "black"
+            }
+          },
+          "&:focus + span": {
+            "variant": "elements.input.focus"
+          }
+        },
+        "label": {
+          "borderColor": "grey-40",
+          "borderStyle": "solid",
+          "borderWidth": "1px",
+          "color": "grey-80",
+          "fontWeight": "normal",
+          "padding": "11px 12px 11px 0",
+          "&:before": {
+            "borderColor": "grey-30",
+            "borderStyle": "solid",
+            "borderWidth": "2px"
+          }
+        },
+        "error": {
+          "variant": "elements.input.radioish.label",
+          "color": "error-red"
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.radioish.base"
+          },
+          "slim": {
+            "variant": "elements.input.radioish.base"
+          }
+        }
+      },
+      "radio": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "background": "black",
+              "boxShadow": "inset 0 0 0 2px #fff"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "50%"
+          }
+        }
+      },
+      "checkbox": {
+        "base": {
+          "variant": "elements.input.radioish.base",
+          "&:checked + span": {
+            "variant": "elements.input.radioish.base.&:checked + span",
+            "&::before": {
+              "variant": "elements.input.radioish.base.&:checked + span.&::before",
+              "backgroundImage": "url(\"data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='-1 -2 14 12'%3E%3Cpath d='M9.603 1L11 2.507 4.681 9 1 4.898l1.453-1.446L4.74 5.999z' /%3E%3C/svg%3E\")",
+              "backgroundSize": "16px 16px",
+              "backgroundColor": "black",
+              "borderColor": "black"
+            }
+          }
+        },
+        "label": {
+          "variant": "elements.input.radioish.label",
+          "&:before": {
+            "variant": "elements.input.radioish.label.&:before",
+            "borderRadius": "4px"
+          }
+        },
+        "variants": {
+          "normal": {
+            "variant": "elements.input.checkbox.base"
+          },
+          "slim": {
+            "variant": "elements.input.checkbox.base",
+            "& + span": {
+              "padding": "0px",
+              "border": "none"
+            },
+            "&:checked + span": {
+              "variant": "elements.input.checkbox.base.&:checked + span",
+              "boxShadow": "none",
+              "&::before": {
+                "variant": "elements.input.checkbox.base.&:checked + span.&::before"
+              }
+            },
+            "&:focus + span": {},
+            "&:focus + span::before": {
+              "variant": "elements.input.focus"
+            }
+          }
+        }
+      },
+      "tile": {
+        "inputColor": "#141424",
+        "borderColor": "light-grey-blue",
+        "borderStyle": "solid",
+        "borderWidth": "2px",
+        "color": "slate-grey",
+        "fontWeight": "normal",
+        "before": {
+          "content": "' '",
+          "borderColor": "light-grey-blue",
+          "borderStyle": "solid",
+          "borderWidth": "2px"
+        }
+      }
     }
   },
 
@@ -1247,81 +1447,13 @@
   },
 
   "input": {
-    "base": {
-      "fontFamily": "base",
-      "fontSize": "base",
-      "lineHeight": 1.33,
-      "color": "text",
-      "appearance": "none",
-      "border": "none",
-      "background": "none",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flex": 1,
-      "position": "relative",
-      "verticalAlign": "middle",
-      "width": "100%",
-      "&:focus": {
-        "outline": "none"
-      },
-      "&:disabled": {
-        "outline": "none",
-        "border": "none",
-        "color": "battleshipGrey",
-        "background": "veryLightGrey"
-      }
-    },
-    "wrapper": {
-      "backgroundColor": "white",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "position": "relative",
-      "borderRadius": "3px"
-    },
     "frozen": {
-      "base": {
-        "backgroundColor": "frozen-bg",
-        "borderRadius": "3px"
-      },
-      "button": {
-        "background": "none",
-        "border": "none",
-        "height": "28px",
-        "padding": "0 24px",
-        "width": "69px",
-        "cursor": "pointer",
-        ":focus": {
-          "outline": "2px solid",
-          "outlineColor": "#008fe9"
-        },
-        "&::-moz-focus-inner": { "border": 0 }
-      },
-      "hidden": {
-        "display": "none"
-      }
+      "backgroundColor": "frozen-bg",
+      "borderRadius": "0px"
     },
     "focus": {
       "outline": "2px solid",
       "outline-color": "orange"
-    },
-    "affix": {
-      "base": {
-        "fontFamily": "base",
-        "fontSize": "base",
-        "lineHeight": "base",
-        "textAlign": "center",
-        "boxSizing": "border-box"      
-      },
-      "prefix": {
-        "variant": "input.affix.base",
-        "borderRightStyle": "solid",
-        "borderRightWidth": 1
-      },
-      "suffix": {
-        "variant": "input.affix.base",
-        "borderLeftStyle": "solid",
-        "borderLeftWidth": 1
-      }
     },
     "radioish": {
       "base": {
@@ -1349,10 +1481,6 @@
           "borderStyle": "solid",
           "borderWidth": "2px"
         }
-      },
-      "error": {
-        "variant": "input.radioish.label",
-        "color": "error-red"
       },
       "variants": {
         "normal": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -592,6 +592,7 @@
       "padding": 16,
       "position": "relative",
       "borderRadius": 0,
+      "radii": 0,
       "notificationColor": "uswitch-navy",
       "alertColor": "error-red",
       "before": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1287,6 +1287,16 @@
       "outline": "2px solid",
       "outline-color": "orange"
     },
+    "affix": {
+      "prefix": {
+        "borderRightStyle": "solid",
+        "borderRightWidth": 1
+      },
+      "suffix": {
+        "borderLeftStyle": "solid",
+        "borderLeftWidth": 1
+      }
+    },
     "radioish": {
       "base": {
         "&:checked + span": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1287,8 +1287,28 @@
       "borderRadius": "3px"
     },
     "frozen": {
-      "backgroundColor": "frozen-bg",
-      "borderRadius": "0px"
+      "base": {
+        "backgroundColor": "frozen-bg",
+        "borderRadius": "3px"
+      },
+      "button": {
+        "background": "none",
+        "border": "none",
+        "borderLeft": "1px solid",
+        "borderLeftColor": "#59646d",
+        "height": "28px",
+        "padding": "0 24px",
+        "width": "69px",
+        "cursor": "pointer",
+        ":focus": {
+          "outline": "2px solid",
+          "outlineColor": "#008fe9"
+        },
+        "&::-moz-focus-inner": { "border": 0 }
+      },
+      "hidden": {
+        "display": "none"
+      }
     },
     "focus": {
       "outline": "2px solid",


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/56200818/86252351-0374a800-bbab-11ea-9e23-b10c6523f8a7.png)

Updated Sponsored By Tag styling for Money. Moved styling out of component and into themes for all brands and updated Money theme. Added providerText prop that defaults to 'Sponsored by' if nothing is passed.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
