### PR TITLE
feat: move styling to themes for all brands, add text prop, update mo…

### DIFF
--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -19,7 +19,7 @@
     "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.imgix-image": "^0.1.36",
     "@uswitch/trustyle.primary-info-block": "^0.2.12",
-    "@uswitch/trustyle.sponsored-by-tag": "^0.0.5",
+    "@uswitch/trustyle.sponsored-by-tag": "^1.0.0",
     "@uswitch/trustyle.usp-tag": "^0.1.0"
   }
 }

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,7 +21,7 @@
     "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.imgix-image": "^0.1.36",
     "@uswitch/trustyle.primary-info-block": "^0.2.12",
-    "@uswitch/trustyle.sponsored-by-tag": "^0.0.5",
+    "@uswitch/trustyle.sponsored-by-tag": "^1.0.0",
     "@uswitch/trustyle.usp-tag": "^0.1.0"
   }
 }

--- a/src/elements/sponsored-by-tag/package.json
+++ b/src/elements/sponsored-by-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-by-tag",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -7,31 +7,26 @@ import { ImgixImage } from '@uswitch/trustyle.imgix-image'
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   providerLogoSrc: string
   className?: string
+  providerText?: string
 }
 
 const SponsoredByTag: React.FC<Props> = ({
   providerLogoSrc,
-  className = ''
+  className = '',
+  providerText = 'Sponsored by'
 }) => (
   <div
     className={className}
     sx={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingY: 4
+      variant: 'elements.sponsoredByTag.base.wrapper'
     }}
   >
     <span
       sx={{
-        color: 'grey-60',
-        fontSize: 'xs',
-        fontFamily: 'base',
-        fontWeight: 'base',
-        fontStyle: 'normal'
+        variant: 'elements.sponsoredByTag.base.text'
       }}
     >
-      Sponsored by
+      {providerText}
     </span>
 
     <ImgixImage
@@ -39,7 +34,7 @@ const SponsoredByTag: React.FC<Props> = ({
       imgixParams={{ fit: 'clip' }}
       critical
       sx={{
-        height: [40, 56]
+        variant: 'elements.sponsoredByTag.base.image'
       }}
     />
   </div>

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -11,15 +11,39 @@ export default {
   title: 'Elements|Sponsored by tag'
 }
 
-export const ExampleWithKnobs = () => {
+export const ExampleWithDefaultText = () => {
   const providerLogo: string = text(
     'Provider logo url',
     'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
   )
+
   return <SponsoredByTag providerLogoSrc={providerLogo} />
 }
 
-ExampleWithKnobs.story = {
+export const ExampleWithTextProp = () => {
+  const providerLogo: string = text(
+    'Provider logo url',
+    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+  )
+
+  const providerText: string = text('Text to display', 'This is example text')
+  return (
+    <React.Fragment>
+      <SponsoredByTag
+        providerLogoSrc={providerLogo}
+        providerText={providerText}
+      />
+    </React.Fragment>
+  )
+}
+
+ExampleWithDefaultText.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+ExampleWithTextProp.story = {
   parameters: {
     percy: { skip: true }
   }
@@ -28,7 +52,8 @@ ExampleWithKnobs.story = {
 export const AutomatedTests = () => {
   return (
     <AllThemes>
-      <ExampleWithKnobs />
+      <ExampleWithDefaultText />
+      <ExampleWithTextProp />
     </AllThemes>
   )
 }

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -335,6 +335,27 @@
         "height": 0,
         "borderBottomStyle": "solid"
       }
+    },
+    
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -554,6 +554,27 @@
         "height": 0,
         "borderBottomStyle": "solid"
       }
+    },
+    
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -678,7 +678,31 @@
       "before": {
         "content": "none"
       }
-    }  
+    },
+
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "flex-end",
+          "paddingY": "xxs"
+        },
+        "text": {
+          "color": "white",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "maxHeight": "32px",
+          "maxWidth": "76px",
+          "pb": [0,"sm"],
+          "ml": "xs"
+        }
+      }
+    }
   },
 
   "compounds": {

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -311,6 +311,29 @@
     }
   },
 
+  "elements": {
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
+    }
+  },
+
   "imageCallout": {
     "imageSize": { "height": 337, "width": 477 },
     "sm": { "display": "flex", "width": 320, "mx": "auto" },

--- a/src/themes/uswitch-rebrand/package.json
+++ b/src/themes/uswitch-rebrand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-rebrand-theme",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch-rebrand/theme.json
+++ b/src/themes/uswitch-rebrand/theme.json
@@ -627,6 +627,27 @@
         "maxWidth": 110,
         "width": "auto"
       }
+    },
+
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -602,6 +602,27 @@
         "height": 0,
         "borderBottomStyle": "solid"
       }
+    },
+
+    "sponsoredByTag": {
+      "base": {
+        "wrapper": {
+          "display": "flex",
+          "alignItems": "center",
+          "justifyContent": "space-between",
+          "paddingY": 4
+        },
+        "text": {
+          "color": "grey-60",
+          "fontSize": "xs",
+          "fontFamily": "base",
+          "fontWeight": "base",
+          "fontStyle": "normal"
+        },
+        "image":{
+          "height": [40, 56]
+        }
+      }
     }
   },
 


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/56200818/86252351-0374a800-bbab-11ea-9e23-b10c6523f8a7.png)

Updated Sponsored By Tag styling for Money. Moved styling out of component and into themes for all brands and updated Money theme. Added providerText prop that defaults to 'Sponsored by' if nothing is passed.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
