### PR TITLE
Theme is sometimes undefined in server side rendering - temporary fix

### DIFF
--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.frozen-input": "^3.0.0",
+    "@uswitch/trustyle.frozen-input": "^3.0.1",
     "@uswitch/trustyle.icon": "^1.8.6",
     "@uswitch/trustyle.styles": "^0.5.1"
   },

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -23,7 +23,7 @@ export const FrozenInput: React.FC<Props> = ({
   const { theme }: any = useThemeUI()
   const iconGlyph = theme?.name === 'Journey' ? 'edit-journey' : 'edit'
   const iconColor =
-    theme.colors[theme.elements.input?.frozen?.button?.color] ||
+    (theme && theme.colors[theme.elements.input?.frozen?.button?.color]) ||
     colors.UswitchNavy
 
   useEffect(() => {

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^3.0.0",
+    "@uswitch/trustyle.frozen-input": "^3.0.1",
     "@uswitch/trustyle.icon": "^1.8.4",
     "@uswitch/trustyle.styles": "^0.5.1",
     "react-input-mask": "^2.0.4",


### PR DESCRIPTION
# Description

In some cases (when used in the sort component) the theme is not defined when the frozen input is server side rendered. Need to look more into this to figure out why, but this is a temporary fix to stop it from breaking.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
