### PR TITLE
Fix/tabs padding money

### DIFF
--- a/src/compounds/tabs/src/index.tsx
+++ b/src/compounds/tabs/src/index.tsx
@@ -166,7 +166,10 @@ export const Tabs: React.FC<TabsProps> = ({ children, className }) => {
   }, [])
 
   return (
-    <Container className={className}>
+    <Container
+      className={className}
+      sx={{ variant: 'compounds.collectionTabs.variants.containerPadding' }}
+    >
       <div
         ref={tabWrap}
         sx={{

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1011,12 +1011,15 @@
           "right": 0,
           "height": "100%",
           "background": "linear-gradient(to left, rgba(249, 249, 251, 0.99) 0%, rgba(249, 249, 251, 0.26) 100%)"
-      },
+        },
         "borderBottom": {
           "borderBottomWidth": 1,
           "borderBottomStyle": "solid",
           "borderBottomColor": "grey-20",
           "backgroundColor": "grey-05"
+        },
+        "containerPadding": {
+          "padding": 0
         }
       }
     },


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/56200818/87034014-160c6400-c1df-11ea-9aa5-c721962f412c.png)

Removed padding around tabs container for Money only.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [x] If component change, version updated
