### PR TITLE
fix/update hero padding bottom

### DIFF
--- a/src/elements/hero/CHANGELOG.md
+++ b/src/elements/hero/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@2.2.0...@uswitch/trustyle.hero@2.3.0) (2020-07-10)
+
+
+### Features
+
+* update hero padding bottom ([f5bf996](https://github.com/uswitch/trustyle/commit/f5bf996))

--- a/src/elements/hero/package.json
+++ b/src/elements/hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/hero/src/index.tsx
+++ b/src/elements/hero/src/index.tsx
@@ -91,7 +91,7 @@ const Hero: React.FC<Props> = ({
             sx={{
               position: 'relative',
               paddingTop: ['sm', 'xxl'],
-              paddingBottom: ['sm', 'xxxl'],
+              paddingBottom: ['sm', 'xxl'],
               variant: 'hero.content'
             }}
           >


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/56200818/87164728-06fde280-c2c1-11ea-863c-c19dccfb4668.png)

Update Hero padding equal on top and bottom.


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
