### PR TITLE
Set useBodyStyles to false to keep the background non-purple

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1,5 +1,6 @@
 {
   "name": "Uswitch",
+  "useBodyStyles": false,
   "breakpoints": ["768px", "992px"],
   "zIndices": {
     "min": 0,


### PR DESCRIPTION
# Description
This pull request sets useBodyStyles to false for Uswitch (we already have this for money, bankrate, etc.). This stops styles being applied on the body object - and hence stops theme ui turning the webpage purple.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

Not adding a new component. Not really a straightforward way to locally test that this does what we expect, either.

- [ N/A] Includes theme changes for both Uswitch and money
- [ N/A] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ N/A] PR description includes screenshot of change
- [ N/A] If new component, designer has approved screenshot
- [ N/A] If the change will affect other teams, that team knows about this change
- [ N/A] If introducing a new component behaviour, added a story to cover that case.
- [ N/A] If component change, version updated
