### PR TITLE
fix: change width in logo collection for money theme

### DIFF
--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1785,8 +1785,8 @@
       "inner": {
         "mr": ["lg", "lg", "md"],
         "img": {
-          "width": "100px",
-          "maxHeight": "64px"
+          "maxWidth": "100px",
+          "height": "64px"
         }
       }
     }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1785,7 +1785,7 @@
       "inner": {
         "mr": ["lg", "lg", "md"],
         "img": {
-          "maxWidth": "100px",
+          "width": "100px",
           "maxHeight": "64px"
         }
       }


### PR DESCRIPTION
# Description

Changed logo collection width in Money theme. Fixes bug that was causing smaller images to not render.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
