### PR TITLE
fix: hero breadcrumb styling for Money

### DIFF
--- a/src/elements/hero/CHANGELOG.md
+++ b/src/elements/hero/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.6.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@2.2.0...@uswitch/trustyle.hero@2.6.0) (2020-07-15)
+
+
+### Bug Fixes
+
+* hero breadcrumb styling for Money ([bf296a9](https://github.com/uswitch/trustyle/commit/bf296a9))
+
+
+### Features
+
+* update hero padding bottom ([69a339b](https://github.com/uswitch/trustyle/commit/69a339b))
+
+
+
+
+
 # [2.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@2.2.0...@uswitch/trustyle.hero@2.5.0) (2020-07-13)
 
 

--- a/src/elements/hero/package.json
+++ b/src/elements/hero/package.json
@@ -10,5 +10,8 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.27",
     "react": "^16.7.0"
+  },
+  "dependencies": {
+    "@uswitch/trustyle-utils.get": "^1.0.5"
   }
 }

--- a/src/elements/hero/package.json
+++ b/src/elements/hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/hero/src/index.tsx
+++ b/src/elements/hero/src/index.tsx
@@ -1,12 +1,13 @@
 /** @jsx jsx */
 
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, useThemeUI } from 'theme-ui'
+import get from '@uswitch/trustyle-utils.get'
 
 type ArrayOrNot<T> = T | T[]
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  breadcrumbs?: React.ReactNode
+  breadcrumbs?: React.ReactElement
   container?: React.FC<any>
   fgImage?: string
   fgImageType?: 'background' | 'img'
@@ -40,6 +41,12 @@ const Hero: React.FC<Props> = ({
   children,
   className
 }) => {
+  const { theme }: any = useThemeUI()
+  const breadcrumbVariant = get(theme, 'hero.breadcrumbs.variant')
+  const breadcrumbWithVariant =
+    breadcrumbs &&
+    React.cloneElement(breadcrumbs, { variant: breadcrumbVariant })
+
   return (
     <div
       sx={{ position: 'relative', overflow: 'hidden', variant: 'hero.wrapper' }}
@@ -48,7 +55,7 @@ const Hero: React.FC<Props> = ({
       <Container>
         {breadcrumbs && (
           <div sx={{ paddingTop: 'sm', variant: 'hero.breadcrumbs' }}>
-            {breadcrumbs}
+            {breadcrumbWithVariant}
           </div>
         )}
         <div

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.21.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@0.21.5...@uswitch/trustyle.money-theme@0.21.6) (2020-07-15)
+
+
+### Bug Fixes
+
+* hero breadcrumb styling for Money ([bf296a9](https://github.com/uswitch/trustyle/commit/bf296a9))
+
+
+
+
+
 ## [0.21.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@0.21.4...@uswitch/trustyle.money-theme@0.21.5) (2020-07-15)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1135,6 +1135,9 @@
       "h1, h2, h3, h4, h5, h6": {
         "color": "inherit"
       }
+    },
+    "breadcrumbs": {
+      "variant": "light"
     }
   },
 


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/56200818/87536995-da1b4800-c691-11ea-9295-9c0031c25092.png)

Fix styling of hero breadcrumbs for Money

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
- [ ] If component change, version updated
