### PR TITLE
Change Modal to use legacy Icon so that close icon works

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,3 @@ Definition of done:
 - [ ] If new component, designer has approved screenshot
 - [ ] If the change will affect other teams, that team knows about this change
 - [ ] If introducing a new component behaviour, added a story to cover that case.
-- [ ] If component change, version updated

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -13,7 +13,7 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.themed-icon": "^1.1.1",
+    "@uswitch/trustyle.icon": "^1.9.0",
     "body-scroll-lock": "^3.0.3",
     "react-focus-lock": "^2.4.0",
     "react-measure": "^2.3.0"

--- a/src/elements/modal/src/index.tsx
+++ b/src/elements/modal/src/index.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom'
 import { jsx } from 'theme-ui'
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 import FocusLock from 'react-focus-lock'
-import ThemedIcon from '@uswitch/trustyle.themed-icon'
+import { Icon } from '@uswitch/trustyle.icon'
 import Measure from 'react-measure'
 
 type ModalMobileHeight = 'full' | 'partial'
@@ -150,12 +150,7 @@ const Overlay: React.FC<OverlayProps> = ({
                       }}
                       {...closeButtonProps}
                     >
-                      <ThemedIcon
-                        icon="close"
-                        sx={{
-                          variant: 'elements.modal.closeIcon'
-                        }}
-                      />
+                      <Icon glyph="close" color="#141424" size={18} />
                     </button>
                   </div>
                   <div>{children}</div>


### PR DESCRIPTION
# Description

The ThemedIcon doesn't currently work, so updating the Modal to use the existing `Icon` component for the timebeing.

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

~~- [ ] Includes theme changes for both Uswitch and money~~
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
~~- [ ] PR description includes screenshot of change~~
~~- [ ] If new component, designer has approved screenshot~~
~~- [ ] If the change will affect other teams, that team knows about this change~~
~~- [ ] If introducing a new component behaviour, added a story to cover that case.~~
