### PR TITLE
fix: removes vertical margin from responsive addon

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.0.0...@uswitch/trustyle.product-table@2.0.1) (2020-07-17)
+
+
+### Bug Fixes
+
+* removes vertical margin from responsive addon ([2055a0f](https://github.com/uswitch/trustyle/commit/2055a0f))
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@1.4.7...@uswitch/trustyle.product-table@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.product-table

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/addon-responsive.tsx
+++ b/src/compounds/product-table/src/components/addon-responsive.tsx
@@ -33,7 +33,6 @@ const ProductTableAddonResponsive: Addon<AddonProps> = {
           order: bodyOrder,
           extraRules: {
             display: positionsToDisplay(positions, 'body'),
-            marginTop: [0, -6],
             marginBottom: [0, 'sm']
           }
         }}


### PR DESCRIPTION
# Description

Removes vertical margin from responsive addon, which is about to be implemented for images in eevee-components

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.

Old:
<img width="1185" alt="Screen Shot 2020-07-17 at 14 28 17" src="https://user-images.githubusercontent.com/8939909/87791292-ee9a4480-c839-11ea-9bc0-c875a4296a5f.png">

New:
<img width="1184" alt="Screen Shot 2020-07-17 at 14 28 27" src="https://user-images.githubusercontent.com/8939909/87791304-f1953500-c839-11ea-8a3c-6835004f5f1a.png">

