### PR TITLE
fix: center margins on logo collection for Money

### DIFF
--- a/src/elements/modal/CHANGELOG.md
+++ b/src/elements/modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.1...@uswitch/trustyle.modal@2.0.2) (2020-07-21)
+
+**Note:** Version bump only for package @uswitch/trustyle.modal
+
+
+
+
+
 ## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.0...@uswitch/trustyle.modal@2.0.1) (2020-07-21)
 
 

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.modal",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.1.1...@uswitch/trustyle.bankrate-theme@2.1.2) (2020-07-21)
+
+**Note:** Version bump only for package @uswitch/trustyle.bankrate-theme
+
+
+
+
+
 # [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.0.1...@uswitch/trustyle.bankrate-theme@2.1.0) (2020-07-20)
 
 

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.1.1...@uswitch/trustyle.money-theme@1.1.2) (2020-07-21)
+
+
+### Bug Fixes
+
+* center margins on logo collection for Money ([461ff00](https://github.com/uswitch/trustyle/commit/461ff00))
+
+
+
+
+
 # [1.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.0.2...@uswitch/trustyle.money-theme@1.1.0) (2020-07-20)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -417,7 +417,8 @@
     "logo-collection": {
       "base": {
         "inner": {
-          "mr": ["lg", "lg", "md"],
+          "ml": ["sm", "sm", "0px"],
+          "mr": ["sm", "sm", "md"],
           "img": {
             "maxWidth": "100px",
             "height": "64px"


### PR DESCRIPTION
# Description

Fix margin for logo collection to center logos on mobile for Money

![image](https://user-images.githubusercontent.com/56200818/88055639-3e894c00-cb57-11ea-911f-8703b94398c4.png)


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
