### PR TITLE
feat: add form input colors and box-shadow to themes

### DIFF
--- a/src/elements/loading-spinner/CHANGELOG.md
+++ b/src/elements/loading-spinner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.loading-spinner@0.3.1...@uswitch/trustyle.loading-spinner@0.3.3) (2020-07-22)
+
+**Note:** Version bump only for package @uswitch/trustyle.loading-spinner
+
+
+
+
+
 ## [0.3.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.loading-spinner@0.3.1...@uswitch/trustyle.loading-spinner@0.3.2) (2020-07-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.loading-spinner

--- a/src/elements/loading-spinner/CHANGELOG.md
+++ b/src/elements/loading-spinner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.loading-spinner@0.3.1...@uswitch/trustyle.loading-spinner@0.3.4) (2020-07-22)
+
+**Note:** Version bump only for package @uswitch/trustyle.loading-spinner
+
+
+
+
+
 ## [0.3.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.loading-spinner@0.3.1...@uswitch/trustyle.loading-spinner@0.3.3) (2020-07-22)
 
 **Note:** Version bump only for package @uswitch/trustyle.loading-spinner

--- a/src/elements/loading-spinner/package.json
+++ b/src/elements/loading-spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.loading-spinner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/loading-spinner/package.json
+++ b/src/elements/loading-spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.loading-spinner",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.1.2...@uswitch/trustyle.bankrate-theme@2.3.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.1.2...@uswitch/trustyle.bankrate-theme@2.2.0) (2020-07-22)
 
 

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.1.2...@uswitch/trustyle.bankrate-theme@2.2.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 ## [2.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.1.1...@uswitch/trustyle.bankrate-theme@2.1.2) (2020-07-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.bankrate-theme

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -386,7 +386,8 @@
           "textAlign": "center",
           "boxSizing": "border-box",
           "alignItems": "center",
-          "display": "flex"
+          "display": "flex",
+          "color": "text"
         },
         "prefix": {
           "variant": "elements.input.affix.base",

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -13,7 +13,8 @@
   "shadows": {
     "box": "2px 2px 25px #0004",
     "linkInset": "inset 0 0 0 1px #008fe9",
-    "card": "rgba(0, 0, 72, 0.28) 0px 23px 28px -16px, rgba(0, 0, 72, 0.06) 0px -2px 11px 0px"
+    "card": "rgba(0, 0, 72, 0.28) 0px 23px 28px -16px, rgba(0, 0, 72, 0.06) 0px -2px 11px 0px",
+    "formInput": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
   },
 
   "fonts": {
@@ -347,7 +348,7 @@
         "color": "grey-90"
       },
       "formInput": {
-        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+        "boxShadow": "formInput"
       },
       "frozen": {
         "base": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -97,6 +97,7 @@
     "frozen-bg": "#F6F6F6",
     "battleshipGrey": "#65717B",
     "veryLightGrey": "#E9EBED",
+    "tomato": "#DB1818",
 
     "experimental-text": "#29335C",
     "button-secondary": "#FFFFFF",
@@ -336,6 +337,18 @@
           "backgroundColor": "veryLightGrey"
         }
       },
+      "default": {
+        "color": "grey-90"
+      },
+      "error": {
+        "color": "tomato"
+      },
+      "focus": {
+        "color": "grey-90"
+      },
+      "formInput": {
+        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+      },
       "frozen": {
         "base": {
           "backgroundColor": "frozen-bg",
@@ -397,7 +410,7 @@
       "position": "relative",
       "borderRadius": "sm",
       "notificationColor": "#65717B",
-      "alertColor": "#DB1818",
+      "alertColor": "tomato",
       "before": {
         "position": "absolute",
         "content": "''",

--- a/src/themes/journey/CHANGELOG.md
+++ b/src/themes/journey/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.1.0...@uswitch/trustyle.journey-theme@2.2.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.0.1...@uswitch/trustyle.journey-theme@2.1.0) (2020-07-20)
 
 

--- a/src/themes/journey/CHANGELOG.md
+++ b/src/themes/journey/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.1.0...@uswitch/trustyle.journey-theme@2.3.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.1.0...@uswitch/trustyle.journey-theme@2.2.0) (2020-07-22)
 
 

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -12,7 +12,8 @@
 
   "shadows": {
     "box": "2px 2px 25px #0004",
-    "linkInset": "inset 0 0 0 1px #141424"
+    "linkInset": "inset 0 0 0 1px #141424",
+    "formInput": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
   },
 
   "fonts": {
@@ -378,7 +379,7 @@
         "color": "tomato"
       },
       "formInput": {
-        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+        "boxShadow": "formInput"
       },
       "affix": {
         "base": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -388,7 +388,8 @@
           "textAlign": "center",
           "boxSizing": "border-box",
           "alignItems": "center",
-          "display": "flex"
+          "display": "flex",
+          "color": "text"
         },
         "prefix": {
           "variant": "elements.input.affix.base",

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -155,6 +155,7 @@
     "anakiwa": "#99e2ff",
     "uswitch-navy": "#141424",
     "veryLightGrey": "#E9EBED",
+    "tomato": "#DB1818",
 
     "frozen-bg": "#f6f6f6",
 
@@ -367,7 +368,17 @@
       },
       "focus": {
         "outline": "2px solid",
-        "outline-color": "orange"
+        "outline-color": "orange",
+        "color": "primary"
+      },
+      "default": {
+        "color": "primary"
+      },
+      "error": {
+        "color": "tomato"
+      },
+      "formInput": {
+        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
       },
       "affix": {
         "base": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.1.2...@uswitch/trustyle.money-theme@1.3.0) (2020-07-22)
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.1.2...@uswitch/trustyle.money-theme@1.2.0) (2020-07-22)
 
 

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.1.2...@uswitch/trustyle.money-theme@1.2.0) (2020-07-22)
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 ## [1.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.1.1...@uswitch/trustyle.money-theme@1.1.2) (2020-07-21)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -572,6 +572,12 @@
       "error": {
         "color": "error"
       },
+      "focus": {
+        "color": "plum"
+      },
+      "formInput": {
+        "boxShadow": "none"
+      },
       "frozen": {
         "base": {
           "backgroundColor": "grey-10",
@@ -598,9 +604,6 @@
         "hidden": {
           "display": "none"
         }
-      },
-      "focus": {
-        "color": "plum"
       },
       "affix": {
         "base": {

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.1.1...@uswitch/trustyle.save-on-energy-theme@1.2.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [1.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.0.1...@uswitch/trustyle.save-on-energy-theme@1.1.0) (2020-07-20)
 
 

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.1.1...@uswitch/trustyle.save-on-energy-theme@1.3.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.1.1...@uswitch/trustyle.save-on-energy-theme@1.2.0) (2020-07-22)
 
 

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -20,6 +20,10 @@
     "md": "26px"
   },
 
+  "shadows": {
+    "formInput": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+  },
+
   "fontSizes": {
     "base": 16,
     "xxs": 12,
@@ -305,7 +309,7 @@
         }
       },
       "formInput": {
-        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+        "boxShadow": "formInput"
       },
       "default": {
         "color": "uswitch-navy"

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -120,7 +120,8 @@
     "battleshipGrey": "#65717B",
     "veryLightGrey": "#E9EBED",
     "uswitch-navy": "#141424",
-    "grey-60": "#6D6F73"
+    "grey-60": "#6D6F73",
+    "error": "#DB1818"
   },
 
   "radii": {
@@ -303,6 +304,18 @@
           "backgroundColor": "veryLightGrey"
         }
       },
+      "formInput": {
+        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+      },
+      "default": {
+        "color": "uswitch-navy"
+      },
+      "error": {
+        "color": "error"
+      },
+      "focus": {
+        "color": "uswitch-navy"
+      },
       "wrapper": {
         "backgroundColor": "white",
         "boxSizing": "border-box",
@@ -364,7 +377,7 @@
       "position": "relative",
       "borderRadius": "sm",
       "notificationColor": "#65717B",
-      "alertColor": "#DB1818",
+      "alertColor": "error",
       "before": {
         "position": "absolute",
         "content": "''",

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -353,7 +353,8 @@
           "textAlign": "center",
           "boxSizing": "border-box",
           "alignItems": "center",
-          "display": "flex"
+          "display": "flex",
+          "color": "text"
         },
         "prefix": {
           "variant": "elements.input.affix.base",

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.0.2...@uswitch/trustyle.uswitch-theme@1.1.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 ## [1.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.0.0...@uswitch/trustyle.uswitch-theme@1.0.1) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.0.2...@uswitch/trustyle.uswitch-theme@1.2.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* affix color ([3cceca4](https://github.com/uswitch/trustyle/commit/3cceca4))
+* move boxshadow to shadows in theme ([155f287](https://github.com/uswitch/trustyle/commit/155f287))
+
+
+### Features
+
+* add form input colors and boxshadow to themes ([6a020c5](https://github.com/uswitch/trustyle/commit/6a020c5))
+
+
+
+
+
 # [1.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.0.2...@uswitch/trustyle.uswitch-theme@1.1.0) (2020-07-22)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1071,7 +1071,8 @@
           "textAlign": "center",
           "boxSizing": "border-box",
           "alignItems": "center",
-          "display": "flex"
+          "display": "flex",
+          "color": "text"
         },
         "prefix": {
           "variant": "elements.input.affix.base",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -7,7 +7,8 @@
     "max": 100
   },
   "shadows": {
-    "box": "2px 2px 25px #0004"
+    "box": "2px 2px 25px #0004",
+    "formInput": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
   },
   "fonts": {
     "base": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,sans-serif",
@@ -1061,7 +1062,7 @@
         "color": "tomato"
       },
       "formInput": {
-        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
+        "boxShadow": "formInput"
       },
       "affix": {
         "base": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -198,7 +198,8 @@
     "success-green": "#2AAA5B",
     "frozen-bg": "#F6F6F6",
     "battleshipGrey": "#65717B",
-    "veryLightGrey": "#E9EBED"
+    "veryLightGrey": "#E9EBED",
+    "tomato": "#DB1818"
   },
   "radii": {
     "sm": 0,
@@ -1050,7 +1051,17 @@
       },
       "focus": {
         "outline": "2px solid",
-        "outline-color": "orange"
+        "outline-color": "orange",
+        "color": "primary"
+      },
+      "default": {
+        "color": "primary"
+      },
+      "error": {
+        "color": "tomato"
+      },
+      "formInput": {
+        "boxShadow": "inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)"
       },
       "affix": {
         "base": {


### PR DESCRIPTION
# Description

Added input box-shadow and error/focus/default colors to the themes. No change to existing Input styling, for use in Form Input in eevee.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
