### PR TITLE
Support nested modals (do not propagate click events on background)

### DIFF
--- a/src/elements/modal/CHANGELOG.md
+++ b/src/elements/modal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.2...@uswitch/trustyle.modal@2.0.3) (2020-07-21)
+
+
+### Bug Fixes
+
+* Support nested modals (do not propagate click events on background) ([55570d0](https://github.com/uswitch/trustyle/commit/55570d0))
+
+
+
+
+
 ## [2.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.1...@uswitch/trustyle.modal@2.0.2) (2020-07-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.modal

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.modal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/modal/src/index.tsx
+++ b/src/elements/modal/src/index.tsx
@@ -60,6 +60,8 @@ const Overlay: React.FC<OverlayProps> = ({
     let withinModal = false
     let node: Node | null = event.target as Node
 
+    event.stopPropagation()
+
     do {
       withinModal = withinModal || node === modalRef.current
       node = node?.parentNode


### PR DESCRIPTION
# Description

If two nested `Modal` are rendered, click events on the background div can propagate up to the parent modal's background div. This makes both modals call `onClose`. (React bubbles events through portals.)

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

~~- [ ] Includes theme changes for both Uswitch and money~~
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
~~- [ ] PR description includes screenshot of change~~
~~- [ ] If new component, designer has approved screenshot~~
~~- [ ] If the change will affect other teams, that team knows about this change~~
~~- [ ] If introducing a new component behaviour, added a story to cover that case.~~
