### PR TITLE
For nested modals, only render the top-most modal

### DIFF
--- a/src/elements/list/CHANGELOG.md
+++ b/src/elements/list/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.list@1.0.0...@uswitch/trustyle.list@1.1.0) (2020-07-28)
+
+
+### Bug Fixes
+
+* add dependency to icon component ([fc69b2a](https://github.com/uswitch/trustyle/commit/fc69b2a))
+
+
+### Features
+
+* Implement icon color through theme.json ([2d3020f](https://github.com/uswitch/trustyle/commit/2d3020f))
+
+
+
+
+
 # [1.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.list@0.3.4...@uswitch/trustyle.list@1.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.list

--- a/src/elements/list/package.json
+++ b/src/elements/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.list",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/modal/CHANGELOG.md
+++ b/src/elements/modal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.3...@uswitch/trustyle.modal@2.1.0) (2020-07-28)
+
+
+### Features
+
+* For nested modals, only render the top-most modal ([fdbcd1e](https://github.com/uswitch/trustyle/commit/fdbcd1e))
+
+
+
+
+
 ## [2.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.2...@uswitch/trustyle.modal@2.0.3) (2020-07-21)
 
 

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.modal",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/modal/src/index.tsx
+++ b/src/elements/modal/src/index.tsx
@@ -1,5 +1,11 @@
 /** @jsx jsx */
-import React, { useCallback, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import { createPortal } from 'react-dom'
 import { jsx } from 'theme-ui'
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
@@ -32,6 +38,20 @@ interface OverlayProps {
   focusLockProps: FocusLockProps
 }
 
+interface OverlayIndexingContext {
+  index: number
+  indexes: number[]
+  setIndexes: (indexes: number[]) => void
+}
+
+const OverlayIndexingContext = React.createContext<OverlayIndexingContext>({
+  index: 0,
+  indexes: [],
+  setIndexes: () => {
+    throw new Error('Not implemented')
+  }
+})
+
 const Overlay: React.FC<OverlayProps> = ({
   ariaLabel,
   children,
@@ -55,6 +75,24 @@ const Overlay: React.FC<OverlayProps> = ({
     }
   }, [])
   const [minHeight, setMinHeight] = useState<number | null>(null)
+  const indexingContext = useContext(OverlayIndexingContext)
+  const { index } = indexingContext
+  const [_indexes, _setIndexes] = useState<number[]>([])
+
+  const indexes = index > 0 ? indexingContext.indexes : _indexes
+  const setIndexes = index > 0 ? indexingContext.setIndexes : _setIndexes
+
+  useEffect(() => {
+    setIndexes(((indexes: number[]) => [
+      ...indexes.filter(v => v !== index),
+      index
+    ]) as any)
+
+    return () => {
+      setIndexes(((indexes: number[]) =>
+        indexes.filter(v => v !== index)) as any)
+    }
+  }, [])
 
   const onBackgroundClick = (event: React.MouseEvent<HTMLElement>): void => {
     let withinModal = false
@@ -92,85 +130,92 @@ const Overlay: React.FC<OverlayProps> = ({
         zIndex: 10000,
         variant: 'elements.overlay'
       }}
+      style={{
+        display: index === Math.max(...indexes) ? 'block' : 'none'
+      }}
       aria-label={ariaLabel}
       aria-modal="true"
       onClick={onBackgroundClick}
       onKeyDown={onKeyDown}
       role={role}
     >
-      <FocusLock autoFocus returnFocus>
-        <div
-          sx={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            overflowY: 'auto',
-            // Enable momentum scrolling on Safari (on iOS) <= 12. No longer required in Safari 13.
-            WebkitOverflowScrolling: 'touch',
-            display: 'flex',
-            flexFlow: 'column'
-          }}
-          ref={scrollRegionRef}
-        >
-          {/* Mobile: push down the modal if it is partial height, UNLESS the content overflows
-            in which case this shrinks to 0px. */}
-          <div sx={{ flex: [height === 'partial' ? 1 : 'initial', 1] }} />
-
+      <OverlayIndexingContext.Provider
+        value={{ index: index + 1, indexes, setIndexes }}
+      >
+        <FocusLock autoFocus returnFocus>
           <div
             sx={{
-              flex: 1,
-              width: '100%',
-              height: 'auto',
-              variant: `elements.modal.variants.${height}`
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              overflowY: 'auto',
+              // Enable momentum scrolling on Safari (on iOS) <= 12. No longer required in Safari 13.
+              WebkitOverflowScrolling: 'touch',
+              display: 'flex',
+              flexFlow: 'column'
             }}
-            style={{
-              // This is needed for IE11, since it doesn't properly support flex-grow
-              ...(minHeight
-                ? {
-                    minHeight: `${minHeight}px`
-                  }
-                : {})
-            }}
-            ref={modalRef}
+            ref={scrollRegionRef}
           >
-            <Measure
-              bounds
-              onResize={({ bounds }) => {
-                if (bounds) {
-                  setMinHeight(bounds?.height ?? null)
-                }
+            {/* Mobile: push down the modal if it is partial height, UNLESS the content overflows
+            in which case this shrinks to 0px. */}
+            <div sx={{ flex: [height === 'partial' ? 1 : 'initial', 1] }} />
+
+            <div
+              sx={{
+                flex: 1,
+                width: '100%',
+                height: 'auto',
+                variant: `elements.modal.variants.${height}`
               }}
+              style={{
+                // This is needed for IE11, since it doesn't properly support flex-grow
+                ...(minHeight
+                  ? {
+                      minHeight: `${minHeight}px`
+                    }
+                  : {})
+              }}
+              ref={modalRef}
             >
-              {({ measureRef }) => (
-                <div ref={measureRef}>
-                  <div sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                    <button
-                      ref={closeButtonRef}
-                      aria-label="Close Modal"
-                      onClick={onClose}
-                      sx={{
-                        variant: 'elements.modal.closeButton'
-                      }}
-                      {...closeButtonProps}
-                    >
-                      <Icon glyph="close" color="#141424" size={18} />
-                    </button>
+              <Measure
+                bounds
+                onResize={({ bounds }) => {
+                  if (bounds) {
+                    setMinHeight(bounds?.height ?? null)
+                  }
+                }}
+              >
+                {({ measureRef }) => (
+                  <div ref={measureRef}>
+                    <div sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      <button
+                        ref={closeButtonRef}
+                        aria-label="Close Modal"
+                        onClick={onClose}
+                        sx={{
+                          variant: 'elements.modal.closeButton'
+                        }}
+                        {...closeButtonProps}
+                      >
+                        <Icon glyph="close" color="#141424" size={18} />
+                      </button>
+                    </div>
+                    <div>{children}</div>
                   </div>
-                  <div>{children}</div>
-                </div>
-              )}
-            </Measure>
+                )}
+              </Measure>
+            </div>
+            <div
+              sx={{
+                flex: [height === 'partial' ? 1 : 'initial', 1],
+                display: ['none', 'block']
+              }}
+            />
           </div>
-          <div
-            sx={{
-              flex: [height === 'partial' ? 1 : 'initial', 1],
-              display: ['none', 'block']
-            }}
-          />
-        </div>
-      </FocusLock>
+        </FocusLock>
+      </OverlayIndexingContext.Provider>
     </aside>,
     document.body
   )

--- a/src/elements/modal/src/stories.tsx
+++ b/src/elements/modal/src/stories.tsx
@@ -88,6 +88,32 @@ FullOverflowingContent.story = {
   }
 }
 
+export const NestedModals = () => (
+  <Modal
+    height="partial"
+    ariaLabel="Top level"
+    onClose={action('Clicked close top')}
+  >
+    <div>Top level modal</div>
+    <div>Top level modal</div>
+    <div>Top level modal</div>
+    <div>Top level modal</div>
+    <Modal
+      height="partial"
+      ariaLabel="Inner"
+      onClose={action('Clicked close inner')}
+    >
+      <div>Inner modal</div>
+    </Modal>
+  </Modal>
+)
+
+NestedModals.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 export const AutomatedTests = () => (
   <AllThemes themes={['uswitch']}>
     <Modal

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.6.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.5.0...@uswitch/trustyle.bankrate-theme@2.6.0) (2020-07-28)
+
+
+### Bug Fixes
+
+* update packages, rebased on master ([0d7a48d](https://github.com/uswitch/trustyle/commit/0d7a48d))
+
+
+### Features
+
+* Implement icon color through theme.json ([2d3020f](https://github.com/uswitch/trustyle/commit/2d3020f))
+* Implement icon color through theme.json ([f0fb94e](https://github.com/uswitch/trustyle/commit/f0fb94e))
+
+
+
+
+
 # [2.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.4.0...@uswitch/trustyle.bankrate-theme@2.5.0) (2020-07-27)
 
 

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.6.1...@uswitch/trustyle.money-theme@1.7.0) (2020-07-28)
+
+
+### Bug Fixes
+
+* update packages, rebased on master ([0d7a48d](https://github.com/uswitch/trustyle/commit/0d7a48d))
+
+
+### Features
+
+* Implement icon color through theme.json ([2d3020f](https://github.com/uswitch/trustyle/commit/2d3020f))
+* Implement icon color through theme.json ([f0fb94e](https://github.com/uswitch/trustyle/commit/f0fb94e))
+
+
+
+
+
 ## [1.6.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.6.0...@uswitch/trustyle.money-theme@1.6.1) (2020-07-27)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.4.0...@uswitch/trustyle.save-on-energy-theme@1.5.0) (2020-07-28)
+
+
+### Bug Fixes
+
+* update packages, rebased on master ([0d7a48d](https://github.com/uswitch/trustyle/commit/0d7a48d))
+
+
+### Features
+
+* Implement icon color through theme.json ([2d3020f](https://github.com/uswitch/trustyle/commit/2d3020f))
+* Implement icon color through theme.json ([f0fb94e](https://github.com/uswitch/trustyle/commit/f0fb94e))
+
+
+
+
+
 # [1.4.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.3.0...@uswitch/trustyle.save-on-energy-theme@1.4.0) (2020-07-27)
 
 

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.4.0...@uswitch/trustyle.uswitch-theme@1.5.0) (2020-07-28)
+
+
+### Features
+
+* For nested modals, only render the top-most modal ([fdbcd1e](https://github.com/uswitch/trustyle/commit/fdbcd1e))
+* Implement icon color through theme.json ([2d3020f](https://github.com/uswitch/trustyle/commit/2d3020f))
+
+
+
+
+
 # [1.4.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.3.0...@uswitch/trustyle.uswitch-theme@1.4.0) (2020-07-27)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -202,7 +202,8 @@
     "frozen-bg": "#F6F6F6",
     "battleshipGrey": "#65717B",
     "veryLightGrey": "#E9EBED",
-    "tomato": "#DB1818"
+    "tomato": "#DB1818",
+    "overlay-bg": "rgba(20, 20, 36, 0.5)"
   },
   "radii": {
     "sm": 0,


### PR DESCRIPTION
# Description

When modals are nested, we want to render only the top-most modal.

Before:

![image](https://user-images.githubusercontent.com/951457/88539667-94536d80-d009-11ea-91d1-f8a8b78494d2.png)

After:

![image](https://user-images.githubusercontent.com/951457/88539677-99182180-d009-11ea-8eb8-ae651ac93c78.png)

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [X] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [X] If the change will affect other teams, that team knows about this change
- [X] If introducing a new component behaviour, added a story to cover that case.
