### PR TITLE
fix: update money theme to increase powered by logo size

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.7.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.7.0...@uswitch/trustyle.money-theme@1.7.1) (2020-07-28)
+
+
+### Bug Fixes
+
+* update money theme to increase powered by logo size ([0910de9](https://github.com/uswitch/trustyle/commit/0910de9))
+
+
+
+
+
 # [1.7.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.6.1...@uswitch/trustyle.money-theme@1.7.0) (2020-07-28)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -368,21 +368,22 @@
       "base": {
         "wrapper": {
           "display": "flex",
-          "alignItems": "center",
+          "alignItems": "flex-end",
           "justifyContent": "flex-end",
-          "paddingY": "xxs"
+          "paddingY": "xxs",
+          "pt": "md"
         },
         "text": {
           "color": "white",
           "fontSize": "xs",
           "fontFamily": "base",
           "fontWeight": "base",
-          "fontStyle": "normal"
+          "fontStyle": "normal",
+          "lineHeight": "1"
         },
         "image": {
           "maxHeight": "32px",
-          "maxWidth": "76px",
-          "pb": [0, "sm"],
+          "maxWidth": ["88px", "104px"],
           "ml": "xs"
         }
       }


### PR DESCRIPTION
# Description

Increase size of powered by logo for Money

![image](https://user-images.githubusercontent.com/56200818/88691954-69464800-d0f5-11ea-938d-f394f8fbddae.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
