### PR TITLE
fix: breadcrumb sizing

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.5.1...@uswitch/trustyle.uswitch-theme@1.5.2) (2020-08-03)
+
+
+### Bug Fixes
+
+* breadcrumb sizing ([17d4fbd](https://github.com/uswitch/trustyle/commit/17d4fbd))
+
+
+
+
+
 ## [1.5.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.5.0...@uswitch/trustyle.uswitch-theme@1.5.1) (2020-08-03)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -318,7 +318,6 @@
       "textDecoration": "none",
       "borderBottom": "1px dashed #898991",
       "lineHeight": "31px",
-      "fontSize": ["base", "md"],
       "fontWeight": "bold",
       "& svg": {
         "fill": "light-1",


### PR DESCRIPTION
# Description

No other theme except uswitch applies a custom font size globally on the anchor and it breaks stuff such as the breadcrumb

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
