### PR TITLE
feat: allow ref to be passed into drop-down

### DIFF
--- a/src/compounds/article-intro/CHANGELOG.md
+++ b/src/compounds/article-intro/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.article-intro@1.0.1...@uswitch/trustyle.article-intro@1.0.2) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.article-intro
+
+
+
+
+
 # [1.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.article-intro@0.3.1...@uswitch/trustyle.article-intro@1.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.article-intro

--- a/src/compounds/article-intro/package.json
+++ b/src/compounds/article-intro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.article-intro",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "devDependencies": {
-    "@uswitch/trustyle.author": "^2.0.0"
+    "@uswitch/trustyle.author": "^2.1.0"
   },
   "dependencies": {
     "@uswitch/trustyle.date": "0.0.9"

--- a/src/compounds/interactive-tabs/CHANGELOG.md
+++ b/src/compounds/interactive-tabs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.interactive-tabs@2.0.0...@uswitch/trustyle.interactive-tabs@2.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.interactive-tabs
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.interactive-tabs@1.3.4...@uswitch/trustyle.interactive-tabs@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.interactive-tabs

--- a/src/compounds/interactive-tabs/package.json
+++ b/src/compounds/interactive-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.interactive-tabs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -15,6 +15,6 @@
     "@uswitch/trustyle-utils.get": "^1.0.5",
     "@uswitch/trustyle.carousel": "^1.1.0",
     "@uswitch/trustyle.flex-grid": "^3.0.0",
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.1...@uswitch/trustyle.side-nav@1.0.3) (2020-08-03)
+
+
+### Bug Fixes
+
+* issue with broken side nav on uswitch ([5225314](https://github.com/uswitch/trustyle/commit/5225314))
+
+
+
+
+
 ## [1.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.1...@uswitch/trustyle.side-nav@1.0.2) (2020-08-03)
 
 

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.6.0"
+    "@uswitch/trustyle.accordion": "^0.6.1"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@2.0.0...@uswitch/trustyle.sponsored-product-rate-table@2.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@1.0.3...@uswitch/trustyle.sponsored-product-rate-table@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,7 +16,7 @@
     "@uswitch/trustyle.awards-tag": "^0.0.5",
     "@uswitch/trustyle.button": "^0.11.10",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.imgix-image": "^0.1.36",
     "@uswitch/trustyle.primary-info-block": "^0.2.14",
     "@uswitch/trustyle.sponsored-by-tag": "^2.0.0",

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@2.0.0...@uswitch/trustyle.sponsored-product@2.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@1.0.3...@uswitch/trustyle.sponsored-product@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -18,7 +18,7 @@
     "@uswitch/trustyle.button-link": "^2.0.0",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.8",
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.imgix-image": "^0.1.36",
     "@uswitch/trustyle.primary-info-block": "^0.2.14",
     "@uswitch/trustyle.sponsored-by-tag": "^2.0.0",

--- a/src/compounds/testimonial-card/CHANGELOG.md
+++ b/src/compounds/testimonial-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.testimonial-card@0.1.3...@uswitch/trustyle.testimonial-card@0.1.4) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.testimonial-card
+
+
+
+
+
 ## [0.1.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.testimonial-card@0.1.2...@uswitch/trustyle.testimonial-card@0.1.3) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.testimonial-card

--- a/src/compounds/testimonial-card/package.json
+++ b/src/compounds/testimonial-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.testimonial-card",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   },
   "devDependencies": {
     "@uswitch/trustyle.carousel": "^1.1.0"

--- a/src/elements/accordion/CHANGELOG.md
+++ b/src/elements/accordion/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.6.0...@uswitch/trustyle.accordion@0.6.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.accordion
+
+
+
+
+
 # [0.6.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.5.3...@uswitch/trustyle.accordion@0.6.0) (2020-07-24)
 
 

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,7 +16,7 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.imgix-image": "^0.1.36"
   }
 }

--- a/src/elements/author-profile/CHANGELOG.md
+++ b/src/elements/author-profile/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.author-profile@1.0.0...@uswitch/trustyle.author-profile@1.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.author-profile
+
+
+
+
+
 # [1.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.author-profile@0.2.4...@uswitch/trustyle.author-profile@1.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.author-profile

--- a/src/elements/author-profile/package.json
+++ b/src/elements/author-profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author-profile",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/elements/author/CHANGELOG.md
+++ b/src/elements/author/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.author@2.0.0...@uswitch/trustyle.author@2.1.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # [1.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.author@0.4.1...@uswitch/trustyle.author@1.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.author

--- a/src/elements/author/package.json
+++ b/src/elements/author/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/breadcrumbs/CHANGELOG.md
+++ b/src/elements/breadcrumbs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.breadcrumbs@2.0.0...@uswitch/trustyle.breadcrumbs@2.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.breadcrumbs
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.breadcrumbs@1.3.3...@uswitch/trustyle.breadcrumbs@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.breadcrumbs

--- a/src/elements/breadcrumbs/package.json
+++ b/src/elements/breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.breadcrumbs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/elements/bullet-list-highlight/CHANGELOG.md
+++ b/src/elements/bullet-list-highlight/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bullet-list-highlight@0.3.3...@uswitch/trustyle.bullet-list-highlight@0.3.4) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.bullet-list-highlight
+
+
+
+
+
 ## [0.3.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bullet-list-highlight@0.3.2...@uswitch/trustyle.bullet-list-highlight@0.3.3) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.bullet-list-highlight

--- a/src/elements/bullet-list-highlight/package.json
+++ b/src/elements/bullet-list-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bullet-list-highlight",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.styles": "^0.5.1"
   },
   "devDependencies": {

--- a/src/elements/call-out/CHANGELOG.md
+++ b/src/elements/call-out/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.0.0...@uswitch/trustyle.call-out@2.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.call-out
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@1.2.6...@uswitch/trustyle.call-out@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.call-out

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.palette": "^1.2.1",
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/elements/category/CHANGELOG.md
+++ b/src/elements/category/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.0.0...@uswitch/trustyle.category@2.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.category
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@1.4.5...@uswitch/trustyle.category@2.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.category

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "devDependencies": {
-    "@uswitch/trustyle.breadcrumbs": "^2.0.0"
+    "@uswitch/trustyle.breadcrumbs": "^2.0.1"
   },
   "dependencies": {
     "@uswitch/trustyle.flex-grid": "^3.0.0"

--- a/src/elements/drop-down/CHANGELOG.md
+++ b/src/elements/drop-down/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.drop-down@2.1.2...@uswitch/trustyle.drop-down@2.2.0) (2020-08-03)
+
+
+### Features
+
+* add story for drop-down with ref ([8cb33c4](https://github.com/uswitch/trustyle/commit/8cb33c4))
+* allow ref to be passed in to drop-down ([95fdfbe](https://github.com/uswitch/trustyle/commit/95fdfbe))
+
+
+
+
+
 ## [2.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.drop-down@2.1.1...@uswitch/trustyle.drop-down@2.1.2) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.drop-down

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.5",
-    "@uswitch/trustyle.frozen-input": "^3.0.2",
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.frozen-input": "^3.0.3",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.styles": "^0.5.1"
   },
   "devDependencies": {

--- a/src/elements/drop-down/src/index.tsx
+++ b/src/elements/drop-down/src/index.tsx
@@ -67,9 +67,9 @@ export const DropDown = forwardRef(
     const [hasFocus, setHasFocus] = useState(false)
     const option = options.find(_ => _.value === value)
     const frozenText = option && option.text
-    const inputRef: React.MutableRefObject<HTMLSelectElement | null> = useRef(
-      null
-    )
+    const inputRef =
+      (ref as React.MutableRefObject<HTMLSelectElement | null>) ||
+      useRef<HTMLSelectElement | null>(null)
 
     useImperativeHandle(ref, () => ({
       focus: () => inputRef.current && inputRef.current.focus(),

--- a/src/elements/drop-down/src/stories.tsx
+++ b/src/elements/drop-down/src/stories.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 
 import AllThemes from '../../../utils/all-themes'
@@ -74,6 +74,27 @@ const SelectWithOverlay = () => {
   )
 }
 
+const SelectWithRef = () => {
+  const [val, setVal] = useState()
+  const [placeholder, setPlaceholder] = useState('ref is not working')
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  React.useEffect(() => {
+    if (inputRef.current) setPlaceholder('ref is working')
+  })
+
+  return (
+    <DropDown
+      name="example"
+      placeholder={placeholder}
+      onBlur={() => {}}
+      onChange={setVal}
+      options={options}
+      value={val}
+      ref={inputRef}
+    />
+  )
+}
+
 export const Example = () => (
   <div>
     <ColourSelect />
@@ -96,6 +117,10 @@ export const Example = () => (
     <Spacer />
 
     <SelectWithOverlay />
+
+    <Spacer />
+
+    <SelectWithRef />
   </div>
 )
 

--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.4...@uswitch/trustyle.embedded-video@0.4.5) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.embedded-video
+
+
+
+
+
 ## [0.4.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.3...@uswitch/trustyle.embedded-video@0.4.4) (2020-07-24)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.6.0"
+    "@uswitch/trustyle.accordion": "^0.6.1"
   }
 }

--- a/src/elements/frozen-input/CHANGELOG.md
+++ b/src/elements/frozen-input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.frozen-input@3.0.2...@uswitch/trustyle.frozen-input@3.0.3) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.frozen-input
+
+
+
+
+
 ## [3.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.frozen-input@3.0.1...@uswitch/trustyle.frozen-input@3.0.2) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.frozen-input

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.styles": "^0.5.1"
   },
   "devDependencies": {

--- a/src/elements/hero/CHANGELOG.md
+++ b/src/elements/hero/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@3.1.0...@uswitch/trustyle.hero@3.2.0) (2020-08-03)
+
+
+### Bug Fixes
+
+* fix bbdeals hero story ([fd07f67](https://github.com/uswitch/trustyle/commit/fd07f67))
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # [3.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@3.0.0...@uswitch/trustyle.hero@3.1.0) (2020-07-20)
 
 

--- a/src/elements/hero/package.json
+++ b/src/elements/hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/icon/CHANGELOG.md
+++ b/src/elements/icon/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.icon@1.9.0...@uswitch/trustyle.icon@1.10.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # [1.9.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.icon@1.8.6...@uswitch/trustyle.icon@1.9.0) (2020-07-15)
 
 

--- a/src/elements/icon/package.json
+++ b/src/elements/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.icon",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/input/CHANGELOG.md
+++ b/src/elements/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.2...@uswitch/trustyle.input@2.0.3) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.input
+
+
+
+
+
 ## [2.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.1...@uswitch/trustyle.input@2.0.2) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.input

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,8 +8,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^3.0.2",
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.frozen-input": "^3.0.3",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.styles": "^0.5.1",
     "react-input-mask": "^2.0.4",
     "tiny-debounce": "^0.1.1"

--- a/src/elements/list/CHANGELOG.md
+++ b/src/elements/list/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.list@1.1.0...@uswitch/trustyle.list@1.2.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # [1.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.list@1.0.0...@uswitch/trustyle.list@1.1.0) (2020-07-28)
 
 

--- a/src/elements/list/package.json
+++ b/src/elements/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.list",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/elements/modal/CHANGELOG.md
+++ b/src/elements/modal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.3...@uswitch/trustyle.modal@2.2.0) (2020-08-03)
+
+
+### Features
+
+* For nested modals, only render the top-most modal ([fdbcd1e](https://github.com/uswitch/trustyle/commit/fdbcd1e))
+
+
+
+
+
 # [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.0.3...@uswitch/trustyle.modal@2.1.0) (2020-07-28)
 
 

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.modal",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "body-scroll-lock": "^3.0.3",
     "react-focus-lock": "^2.4.0",
     "react-measure": "^2.3.0"

--- a/src/elements/pagination/CHANGELOG.md
+++ b/src/elements/pagination/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.0.0...@uswitch/trustyle.pagination@1.0.1) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.pagination
+
+
+
+
+
 # [1.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@0.2.3...@uswitch/trustyle.pagination@1.0.0) (2020-07-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.pagination

--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/elements/read-more-card/CHANGELOG.md
+++ b/src/elements/read-more-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.read-more-card@1.3.1...@uswitch/trustyle.read-more-card@1.3.2) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.read-more-card
+
+
+
+
+
 ## [1.3.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.read-more-card@1.3.0...@uswitch/trustyle.read-more-card@1.3.1) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.read-more-card

--- a/src/elements/read-more-card/package.json
+++ b/src/elements/read-more-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.read-more-card",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0"
+    "@uswitch/trustyle.icon": "^1.10.0"
   }
 }

--- a/src/elements/side-drawer/CHANGELOG.md
+++ b/src/elements/side-drawer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.61](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-drawer@0.2.60...@uswitch/trustyle.side-drawer@0.2.61) (2020-08-03)
+
+**Note:** Version bump only for package @uswitch/trustyle.side-drawer
+
+
+
+
+
 ## [0.2.60](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-drawer@0.2.59...@uswitch/trustyle.side-drawer@0.2.60) (2020-07-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-drawer

--- a/src/elements/side-drawer/package.json
+++ b/src/elements/side-drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-drawer",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.icon": "^1.9.0",
+    "@uswitch/trustyle.icon": "^1.10.0",
     "@uswitch/trustyle.styles": "^0.5.1",
     "focus-trap-react": "^6.0.0",
     "react-dom": "^16.7.0",

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.6.0...@uswitch/trustyle.bankrate-theme@2.7.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # [2.6.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.5.0...@uswitch/trustyle.bankrate-theme@2.6.0) (2020-07-28)
 
 ### Bug Fixes

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/broadband-deals/CHANGELOG.md
+++ b/src/themes/broadband-deals/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.broadband-deals-theme@1.1.0...@uswitch/trustyle.broadband-deals-theme@1.3.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # 1.1.0 (2020-08-03)
 
 

--- a/src/themes/broadband-deals/package.json
+++ b/src/themes/broadband-deals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.broadband-deals-theme",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Theme file for broadband deals",
   "main": "index.js",
   "scripts": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.7.1...@uswitch/trustyle.money-theme@1.8.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 ## [1.7.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.7.0...@uswitch/trustyle.money-theme@1.7.2) (2020-08-03)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.6.0...@uswitch/trustyle.save-on-energy-theme@1.7.0) (2020-08-03)
+
+
+### Features
+
+* bbdeals ([79ff8f8](https://github.com/uswitch/trustyle/commit/79ff8f8))
+
+
+
+
+
 # [1.6.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.5.0...@uswitch/trustyle.save-on-energy-theme@1.6.0) (2020-08-03)
 
 

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
# Description

Updates DropDown component to allow a ref to be passed in, otherwise it's defined in useRef

![image](https://user-images.githubusercontent.com/56200818/89187356-15c07800-d595-11ea-87cb-bf8dd88f42f3.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
