### PR TITLE
feat: add suffix to simple input component

### DIFF
--- a/src/elements/simple-input/CHANGELOG.md
+++ b/src/elements/simple-input/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.simple-input@0.2.0...@uswitch/trustyle.simple-input@0.3.0) (2020-08-06)
+
+
+### Features
+
+* add suffix to simple input component ([0dfae68](https://github.com/uswitch/trustyle/commit/0dfae68))
+
+
+
+
+
 # [0.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.simple-input@0.1.0...@uswitch/trustyle.simple-input@0.2.0) (2020-08-05)
 
 

--- a/src/elements/simple-input/package.json
+++ b/src/elements/simple-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.simple-input",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/simple-input/src/index.tsx
+++ b/src/elements/simple-input/src/index.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react'
 import { jsx } from 'theme-ui'
 
-export interface Props {
+export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   hasError?: boolean | undefined
   type: string
   placeholder?: string
@@ -11,18 +11,18 @@ export interface Props {
   onChange?: any
   defaultValue?: string
   prefix?: string
+  suffix?: string
 }
 
 export const SimpleInput = React.forwardRef(
   (props: Props, ref?: React.Ref<HTMLInputElement>) => {
     const {
       hasError,
-      type,
       placeholder,
-      name,
       onChange,
       defaultValue,
-      prefix
+      prefix,
+      suffix
     } = props
     const [hasFocus, setHasFocus] = useState(false)
 
@@ -46,15 +46,19 @@ export const SimpleInput = React.forwardRef(
           sx={{
             variant: 'elements.simple-input.base'
           }}
-          name={name}
-          type={type}
           placeholder={placeholder}
           ref={ref}
           onChange={onChange}
           defaultValue={defaultValue}
           onFocus={() => setHasFocus(true)}
           onBlur={() => setHasFocus(false)}
+          {...props}
         />
+        {suffix && (
+          <span sx={{ variant: 'elements.simple-input.affix.suffix' }}>
+            {suffix}
+          </span>
+        )}
       </div>
     )
   }

--- a/src/elements/simple-input/src/stories.tsx
+++ b/src/elements/simple-input/src/stories.tsx
@@ -30,6 +30,14 @@ export const Example = () => {
       <SimpleInput prefix="£" name="example" type="text" />
       <Spacer />
       <SimpleInput
+        suffix="years"
+        name="example"
+        type="number"
+        min="1"
+        max="5"
+      />
+      <Spacer />
+      <SimpleInput
         hasError
         prefix="£"
         name="example"

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.8.0...@uswitch/trustyle.bankrate-theme@2.9.0) (2020-08-06)
+
+
+### Features
+
+* add suffix to simple input component ([0dfae68](https://github.com/uswitch/trustyle/commit/0dfae68))
+
+
+
+
+
 # [2.8.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.7.0...@uswitch/trustyle.bankrate-theme@2.8.0) (2020-08-05)
 
 

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -515,6 +515,11 @@
           "variant": "elements.simple-input.affix.base",
           "borderRightStyle": "solid",
           "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.simple-input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
         }
       },
       "variants": {

--- a/src/themes/journey/CHANGELOG.md
+++ b/src/themes/journey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.8.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.7.0...@uswitch/trustyle.journey-theme@2.8.0) (2020-08-06)
+
+
+### Features
+
+* add suffix to simple input component ([0dfae68](https://github.com/uswitch/trustyle/commit/0dfae68))
+
+
+
+
+
 # [2.7.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.6.0...@uswitch/trustyle.journey-theme@2.7.0) (2020-08-05)
 
 

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -600,6 +600,11 @@
           "variant": "elements.simple-input.affix.base",
           "borderRightStyle": "solid",
           "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.simple-input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
         }
       },
       "variants": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.9.0...@uswitch/trustyle.money-theme@1.10.0) (2020-08-06)
+
+
+### Features
+
+* add suffix to simple input component ([0dfae68](https://github.com/uswitch/trustyle/commit/0dfae68))
+* update prefix and suffix designs for Money ([98fc672](https://github.com/uswitch/trustyle/commit/98fc672))
+
+
+
+
+
 # [1.9.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.8.0...@uswitch/trustyle.money-theme@1.9.0) (2020-08-05)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -785,6 +785,9 @@
         },
         "prefix": {
           "variant": "elements.simple-input.affix.base"
+        },
+        "suffix": {
+          "variant": "elements.simple-input.affix.base"
         }
       },
       "variants": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -779,7 +779,8 @@
         "base": {
           "alignItems": "center",
           "display": "flex",
-          "color": "text",
+          "color": "grey-80",
+          "fontWeight": "bold",
           "my": "xs",
           "px": "12px"
         },
@@ -794,19 +795,13 @@
         "error": {
           "variant": "elements.simple-input.wrapper",
           "borderColor": "error",
-          "boxShadow": "errorInset",
-          "span": {
-            "color": "error"
-          }
+          "boxShadow": "errorInset"
         },
         "focus": {
           "variant": "elements.simple-input.wrapper",
           "outline": "none",
           "borderColor": "plum",
-          "boxShadow": "plumInset",
-          "span": {
-            "color": "plum"
-          }
+          "boxShadow": "plumInset"
         }
       }
     },

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.9.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.8.0...@uswitch/trustyle.save-on-energy-theme@1.9.0) (2020-08-06)
+
+
+### Features
+
+* add suffix to simple input component ([0dfae68](https://github.com/uswitch/trustyle/commit/0dfae68))
+
+
+
+
+
 # [1.8.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.7.0...@uswitch/trustyle.save-on-energy-theme@1.8.0) (2020-08-05)
 
 

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -552,6 +552,11 @@
           "variant": "elements.simple-input.affix.base",
           "borderRightStyle": "solid",
           "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.simple-input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
         }
       },
       "variants": {

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.6.0...@uswitch/trustyle.uswitch-theme@1.7.0) (2020-08-06)
+
+
+### Features
+
+* add suffix to simple input component ([0dfae68](https://github.com/uswitch/trustyle/commit/0dfae68))
+
+
+
+
+
 # [1.6.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@1.5.2...@uswitch/trustyle.uswitch-theme@1.6.0) (2020-08-05)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1349,6 +1349,11 @@
           "variant": "elements.simple-input.affix.base",
           "borderRightStyle": "solid",
           "borderRightWidth": 1
+        },
+        "suffix": {
+          "variant": "elements.simple-input.affix.base",
+          "borderLeftStyle": "solid",
+          "borderLeftWidth": 1
         }
       },
       "variants": {


### PR DESCRIPTION
# Description

Add suffix to SimpleInput componet

money:
![image](https://user-images.githubusercontent.com/56200818/89531389-11d86400-d7e8-11ea-90cf-3a7bb7b33486.png)


uswitch:
![image](https://user-images.githubusercontent.com/56200818/89524096-dcc61480-d7db-11ea-9b0a-4ecec025e753.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
