### PR TITLE
Make the box shadow on the input element fully configurable in the theme

### DIFF
--- a/src/elements/input/src/styles.ts
+++ b/src/elements/input/src/styles.ts
@@ -4,20 +4,33 @@ import { SxStyleProp } from '../../../../types/theme-ui'
 
 const { tomato, UswitchNavy } = colors
 
+const boxShadow = (theme: any, hasError: boolean, hasFocus: boolean) => {
+  if (hasError) {
+    return (
+      theme.elements.input?.error?.boxShadow ||
+      `inset 0 0 0 1px
+     ${theme.colors[theme.elements.input?.error?.color] ?? tomato}`
+    )
+  } else if (hasFocus) {
+    return (
+      theme.elements.input?.focus?.boxShadow ||
+      `inset 0 0 0 1px ${theme.colors[theme.elements.input?.focus?.color] ??
+        UswitchNavy}`
+    )
+  } else {
+    return (
+      theme.elements.input?.boxShadow || 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)'
+    )
+  }
+}
+
 export const wrapper = (
   hasError: boolean,
   hasFocus: boolean,
   width: 'half' | 'full'
 ): SxStyleProp => ({
   border: 'solid 1px',
-  boxShadow: (theme: any) =>
-    hasError
-      ? `inset 0 0 0 1px ${theme.colors[theme.elements.input?.error?.color] ??
-          tomato}`
-      : hasFocus
-      ? `inset 0 0 0 1px ${theme.colors[theme.elements.input?.focus?.color] ??
-          UswitchNavy}`
-      : 'inset 0 2px 5px 0 rgba(0, 0, 0, 0.1)',
+  boxShadow: (theme: any) => boxShadow(theme, hasError, hasFocus),
   borderColor: (theme: any) =>
     hasError
       ? theme.colors[theme.elements.input?.error?.color] ?? tomato


### PR DESCRIPTION
# Description

In some of our themes we don't want a box shadow, this enables you to configure the box shadow to none.

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
