### PR TITLE
fix: get accordion values from correct part of theme

### DIFF
--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.5...@uswitch/trustyle.side-nav@1.0.6) (2020-08-11)
+
+**Note:** Version bump only for package @uswitch/trustyle.side-nav
+
+
+
+
+
 ## [1.0.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.3...@uswitch/trustyle.side-nav@1.0.5) (2020-08-10)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-nav

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.6.3"
+    "@uswitch/trustyle.accordion": "^0.6.4"
   }
 }

--- a/src/elements/accordion/CHANGELOG.md
+++ b/src/elements/accordion/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.6.3...@uswitch/trustyle.accordion@0.6.4) (2020-08-11)
+
+
+### Bug Fixes
+
+* get accordion values from correct part of theme ([a8c2d25](https://github.com/uswitch/trustyle/commit/a8c2d25))
+
+
+
+
+
 ## [0.6.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.6.0...@uswitch/trustyle.accordion@0.6.3) (2020-08-10)
 
 **Note:** Version bump only for package @uswitch/trustyle.accordion

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/accordion/src/index.tsx
+++ b/src/elements/accordion/src/index.tsx
@@ -64,7 +64,7 @@ const Accordion: React.FC<Props> & {
   }
 
   return (
-    <div sx={{ variant: 'accordion' }} className={className}>
+    <div sx={{ variant: 'compounds.accordion' }} className={className}>
       <button
         sx={{
           cursor: 'pointer',
@@ -152,7 +152,7 @@ const Accordion: React.FC<Props> & {
           '> p:last-child': {
             marginBottom: 'xs'
           },
-          variant: 'accordion.base.content'
+          variant: 'compounds.accordion.base.content'
         }}
       >
         {children}

--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.7...@uswitch/trustyle.embedded-video@0.4.8) (2020-08-11)
+
+**Note:** Version bump only for package @uswitch/trustyle.embedded-video
+
+
+
+
+
 ## [0.4.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.4...@uswitch/trustyle.embedded-video@0.4.7) (2020-08-10)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.6.3"
+    "@uswitch/trustyle.accordion": "^0.6.4"
   }
 }

--- a/src/elements/input/CHANGELOG.md
+++ b/src/elements/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.6...@uswitch/trustyle.input@2.0.7) (2020-08-11)
+
+**Note:** Version bump only for package @uswitch/trustyle.input
+
+
+
+
+
 ## [2.0.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.5...@uswitch/trustyle.input@2.0.6) (2020-08-11)
 
 

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",


### PR DESCRIPTION
# Description

Fix Accordion component to use values from the correct part of the theme

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
