### PR TITLE
fix: clickable row margin

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.3.0...@uswitch/trustyle.product-table@2.3.1) (2020-08-27)
+
+**Note:** Version bump only for package @uswitch/trustyle.product-table
+
+
+
+
+
 # [2.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.1.3...@uswitch/trustyle.product-table@2.3.0) (2020-08-25)
 
 

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -74,7 +74,14 @@ const ProductTableRow: React.FC<RowProps> = ({
       link={clickableRow}
       wrapper={(children?: React.ReactNode) => (
         <a
-          sx={{ textDecoration: 'none' }}
+          sx={{
+            textDecoration: 'none',
+            ':not(:last-child)': {
+              section: {
+                marginBottom: 'md'
+              }
+            }
+          }}
           href={clickableRow}
           target="_blank"
           rel="noopener noreferrer"
@@ -92,7 +99,7 @@ const ProductTableRow: React.FC<RowProps> = ({
           paddingY: 'md',
           marginTop: badges.length ? [10, 15] : 0,
           marginBottom: 'md',
-          ':last-of-type': {
+          ':last-child': {
             marginBottom: 0
           },
           variant: 'compounds.product-table.row.main'


### PR DESCRIPTION
# Description

Fix bug where margin bottom was not added to a clickable row.

AFTER:
![image](https://user-images.githubusercontent.com/56200818/91418291-da3e6400-e849-11ea-8bf8-2ab5ed942356.png)

BEFORE:
![image](https://user-images.githubusercontent.com/56200818/91418402-fe01aa00-e849-11ea-9e51-0e79eb617123.png)


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
