### PR TITLE
feat: add info addon to product table

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.4.0...@uswitch/trustyle.product-table@2.5.0) (2020-09-04)
+
+
+### Features
+
+* add info addon to product table ([0b2e84f](https://github.com/uswitch/trustyle/commit/0b2e84f))
+
+
+
+
+
 # [2.4.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.3.3...@uswitch/trustyle.product-table@2.4.0) (2020-09-03)
 
 

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/addon-info.tsx
+++ b/src/compounds/product-table/src/components/addon-info.tsx
@@ -6,27 +6,26 @@ import { Addon, AddonContext, CellContext } from '../generics'
 
 import { ROWS } from './cell-split'
 
-const ProductTableAddonFooter: Addon = {
+const ProductTableAddonInfo: Addon = {
   body: ({ children }) => {
     const { gridColumnSpan } = React.useContext(CellContext)
 
     return (
       <AddonContext.Provider
         value={{
-          inAddon: 'footer',
-          order: 100,
+          inAddon: 'info',
+          order: 99, // should appear above footer on mobile
           extraRules: {
-            borderTop: '1px solid',
             paddingTop: 'sm',
             marginTop: 'xs',
             marginBottom: -6,
-            variant: 'compounds.product-table.addonFooter.main'
+            variant: 'compounds.product-table.addonInfo.main'
           }
         }}
       >
         <CellContext.Provider
           value={{
-            gridRowStart: ROWS + 6,
+            gridRowStart: ROWS + 5, // should appear above footer on desktop
             gridRowSpan: 1,
             gridColumnStart: 1,
             gridColumnSpan
@@ -39,4 +38,4 @@ const ProductTableAddonFooter: Addon = {
   }
 }
 
-export default ProductTableAddonFooter
+export default ProductTableAddonInfo

--- a/src/compounds/product-table/src/index.tsx
+++ b/src/compounds/product-table/src/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import ProductTableRow from './components/row'
 import ProductTableAddonResponsive from './components/addon-responsive'
 import ProductTableAddonFooter from './components/addon-footer'
+import ProductTableAddonInfo from './components/addon-info'
 import ProductTableCellBase from './components/cell-base'
 import ProductTableCellImage from './components/cell-image'
 import ProductTableCellSplit from './components/cell-split'
@@ -34,7 +35,8 @@ const ProductTable = {
   Row: ProductTableRow,
   addons: {
     footer: ProductTableAddonFooter,
-    responsive: ProductTableAddonResponsive
+    responsive: ProductTableAddonResponsive,
+    info: ProductTableAddonInfo
   },
   cells: {
     Base: ProductTableCellBase,

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -43,6 +43,7 @@ export const ExampleWithKnobs = () => {
   const unsplitColumns = columns.filter(col => !col.includes('Split'))
   const headerAddon = select('Header addon', unsplitColumns, 'None')
   const footerAddon = boolean('Show footer via addon?', true)
+  const infoAddon = boolean('Show info via addon?', true)
 
   const firstCol = select('First column', columns, 'Image')
   const secondCol = select('Second column', columns, 'Split Content')
@@ -152,6 +153,19 @@ export const ExampleWithKnobs = () => {
         <ProductTable.cells.Base sx={{ display: 'block' }} mobileOrder={100}>
           <div sx={{ fontSize: ['xxs', 'xs'] }}>
             Representative example: Assumed borrowing of £10,000 over...
+          </div>
+        </ProductTable.cells.Base>
+      )
+    })
+  }
+
+  if (infoAddon) {
+    addons.push({
+      addon: ProductTable.addons.info,
+      component: (
+        <ProductTable.cells.Base sx={{ display: 'block' }} mobileOrder={100}>
+          <div sx={{ fontSize: ['xxs', 'xs'] }}>
+            Here&apos;s some extra info...
           </div>
         </ProductTable.cells.Base>
       )


### PR DESCRIPTION
# Description

<img width="1117" alt="Screen Shot 2020-09-04 at 14 20 48" src="https://user-images.githubusercontent.com/8939909/92243778-e8c7f380-eeb9-11ea-8df6-582111292241.png">

Adds an info addon to the product table. This addon appears above the footer, to show compliance and other extra info.(The grey text here on the old table):
<img width="1041" alt="Screen Shot 2020-09-04 at 14 19 59" src="https://user-images.githubusercontent.com/8939909/92243700-c8983480-eeb9-11ea-9673-860f399d1c89.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
