### PR TITLE
Table cell alignment

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.6.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.6.2...@uswitch/trustyle.product-table@2.6.3) (2020-09-14)
+
+**Note:** Version bump only for package @uswitch/trustyle.product-table
+
+
+
+
+
 ## [2.6.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.6.1...@uswitch/trustyle.product-table@2.6.2) (2020-09-09)
 
 

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/cell-content.tsx
+++ b/src/compounds/product-table/src/components/cell-content.tsx
@@ -93,11 +93,11 @@ const BlockContent: React.FC<CellPrimaryProps> = ({
     sx={{
       height: accent ? '100%' : 'auto',
       display: 'grid',
-      alignItems: 'center',
+      alignItems: 'start',
       gridTemplateColumns: '100%',
       msGridColumns: '100%',
-      gridTemplateRows: 'auto auto',
-      msGridRows: 'auto auto',
+      gridTemplateRows: '1fr',
+      msGridRows: '1fr',
       padding: accent ? 'sm' : '',
       variant: `compounds.product-table.cellContent.${
         accent ? 'accent' : 'main'

--- a/src/compounds/product-table/src/components/data-auto.tsx
+++ b/src/compounds/product-table/src/components/data-auto.tsx
@@ -45,7 +45,7 @@ const ProductTableDataAuto: React.FC<DataAutoProps> = ({ text }) => {
     <div>
       {autoFormat(text).map(({ word, size }, index) =>
         size === 'small' ? (
-          <span sx={{ fontSize: ['xs', 'md'] }} key={index}>
+          <span sx={{ margin: '0 5px', fontSize: ['xs', 'md'] }} key={index}>
             {word}
           </span>
         ) : (

--- a/src/compounds/product-table/src/components/data-value.tsx
+++ b/src/compounds/product-table/src/components/data-value.tsx
@@ -19,7 +19,7 @@ const ProductTableDataValue: React.FC<DataValueProps> = ({
     <span>
       {numberFormatter(value, unit)}
       {typeof value === 'number' && subscript ? (
-        <span sx={{ fontSize: ['xs', 'md'] }}>{` ${subscript}`}</span>
+        <span sx={{ fontSize: ['xs', 'md'] }}>{`${subscript}`}</span>
       ) : null}
     </span>
   )


### PR DESCRIPTION
# Description

- make all columns equal height, which aligns bottom text,  and aligns value text to start

- adds margin to auto formatter, and removes space from custom formatter (as that can be added in if required)

<img width="1211" alt="Screen Shot 2020-09-14 at 16 59 59" src="https://user-images.githubusercontent.com/8939909/93109279-c5682a00-f6ab-11ea-92bd-9c4402f937a9.png">


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.

