### PR TITLE
feat: icon tile vertically align styling

### DIFF
--- a/src/elements/icon-tile/CHANGELOG.md
+++ b/src/elements/icon-tile/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.icon-tile@2.0.2...@uswitch/trustyle.icon-tile@2.1.0) (2020-09-21)
+
+
+### Bug Fixes
+
+* add enum ([599afd5](https://github.com/uswitch/trustyle/commit/599afd5))
+* export enum ([5b2c779](https://github.com/uswitch/trustyle/commit/5b2c779))
+* import on stories ([8cf1760](https://github.com/uswitch/trustyle/commit/8cf1760))
+* use displayVariant ([1d7547f](https://github.com/uswitch/trustyle/commit/1d7547f))
+
+
+### Features
+
+* add styling for vertically aligning tile icon ([98c6632](https://github.com/uswitch/trustyle/commit/98c6632))
+
+
+
+
+
 ## [2.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.icon-tile@2.0.1...@uswitch/trustyle.icon-tile@2.0.2) (2020-08-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.icon-tile

--- a/src/elements/icon-tile/package.json
+++ b/src/elements/icon-tile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.icon-tile",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/icon-tile/src/index.tsx
+++ b/src/elements/icon-tile/src/index.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import { jsx, Styled } from 'theme-ui'
 
-enum DisplayVariant {
+export enum DisplayVariant {
   Horizontal = 'horizontal',
   Vertical = 'vertical'
 }

--- a/src/elements/icon-tile/src/index.tsx
+++ b/src/elements/icon-tile/src/index.tsx
@@ -3,11 +3,16 @@
 import * as React from 'react'
 import { jsx, Styled } from 'theme-ui'
 
+enum DisplayVariant {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical'
+}
 interface Props extends React.HTMLAttributes<any> {
   icon: React.ReactNode
   className?: string
-  displayVariant?: string
+  displayVariant?: DisplayVariant
 }
+
 const IconTile: React.FC<Props> = ({
   icon,
   children,
@@ -20,12 +25,16 @@ const IconTile: React.FC<Props> = ({
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection:
-          displayVariant === 'vertical'
+          displayVariant === DisplayVariant.Vertical
             ? 'column'
             : ['column', 'column', 'row'],
-        height: displayVariant === 'vertical' ? 136 : [136, 136, 95],
+        height:
+          displayVariant === DisplayVariant.Vertical ? 136 : [136, 136, 95],
         backgroundColor: 'white',
-        padding: displayVariant === 'vertical' ? 'sm' : ['sm', 'sm', 'lg'],
+        padding:
+          displayVariant === DisplayVariant.Vertical
+            ? 'sm'
+            : ['sm', 'sm', 'lg'],
         paddingTop: 0,
         textAlign: 'center',
         borderRadius: 8,
@@ -41,7 +50,7 @@ const IconTile: React.FC<Props> = ({
     >
       <div
         sx={{
-          flex: displayVariant === 'vertical' ? 1 : [1, null, 0],
+          flex: displayVariant === DisplayVariant.Vertical ? 1 : [1, null, 0],
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center'
@@ -51,7 +60,8 @@ const IconTile: React.FC<Props> = ({
       </div>
       <Styled.p
         sx={{
-          flex: displayVariant === 'vertical' ? null : [null, null, 1],
+          flex:
+            displayVariant === DisplayVariant.Vertical ? null : [null, null, 1],
           fontSize: 'md',
           marginY: 0,
           variant: 'elements.icon-tile.text'

--- a/src/elements/icon-tile/src/index.tsx
+++ b/src/elements/icon-tile/src/index.tsx
@@ -6,23 +6,26 @@ import { jsx, Styled } from 'theme-ui'
 interface Props extends React.HTMLAttributes<any> {
   icon: React.ReactNode
   className?: string
-  alignVertically?: boolean
+  displayVariant?: string
 }
 const IconTile: React.FC<Props> = ({
   icon,
   children,
   className,
-  alignVertically
+  displayVariant
 }) => {
   return (
     <div
       sx={{
         boxSizing: 'border-box',
         display: 'flex',
-        flexDirection: alignVertically ? 'column' : ['column', 'column', 'row'],
-        height: alignVertically ? 136 : [136, 136, 95],
+        flexDirection:
+          displayVariant === 'vertical'
+            ? 'column'
+            : ['column', 'column', 'row'],
+        height: displayVariant === 'vertical' ? 136 : [136, 136, 95],
         backgroundColor: 'white',
-        padding: alignVertically ? 'sm' : ['sm', 'sm', 'lg'],
+        padding: displayVariant === 'vertical' ? 'sm' : ['sm', 'sm', 'lg'],
         paddingTop: 0,
         textAlign: 'center',
         borderRadius: 8,
@@ -38,7 +41,7 @@ const IconTile: React.FC<Props> = ({
     >
       <div
         sx={{
-          flex: alignVertically ? 1 : [1, null, 0],
+          flex: displayVariant === 'vertical' ? 1 : [1, null, 0],
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center'
@@ -48,7 +51,7 @@ const IconTile: React.FC<Props> = ({
       </div>
       <Styled.p
         sx={{
-          flex: alignVertically ? null : [null, null, 1],
+          flex: displayVariant === 'vertical' ? null : [null, null, 1],
           fontSize: 'md',
           marginY: 0,
           variant: 'elements.icon-tile.text'

--- a/src/elements/icon-tile/src/index.tsx
+++ b/src/elements/icon-tile/src/index.tsx
@@ -6,17 +6,23 @@ import { jsx, Styled } from 'theme-ui'
 interface Props extends React.HTMLAttributes<any> {
   icon: React.ReactNode
   className?: string
+  alignVertically?: boolean
 }
-const IconTile: React.FC<Props> = ({ icon, children, className }) => {
+const IconTile: React.FC<Props> = ({
+  icon,
+  children,
+  className,
+  alignVertically
+}) => {
   return (
     <div
       sx={{
         boxSizing: 'border-box',
         display: 'flex',
-        flexDirection: ['column', 'column', 'row'],
-        height: [136, 136, 95],
+        flexDirection: alignVertically ? 'column' : ['column', 'column', 'row'],
+        height: alignVertically ? 136 : [136, 136, 95],
         backgroundColor: 'white',
-        padding: ['sm', 'sm', 'lg'],
+        padding: alignVertically ? 'sm' : ['sm', 'sm', 'lg'],
         paddingTop: 0,
         textAlign: 'center',
         borderRadius: 8,
@@ -32,7 +38,7 @@ const IconTile: React.FC<Props> = ({ icon, children, className }) => {
     >
       <div
         sx={{
-          flex: [1, null, 0],
+          flex: alignVertically ? 1 : [1, null, 0],
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center'
@@ -42,7 +48,7 @@ const IconTile: React.FC<Props> = ({ icon, children, className }) => {
       </div>
       <Styled.p
         sx={{
-          flex: [null, null, 1],
+          flex: alignVertically ? null : [null, null, 1],
           fontSize: 'md',
           marginY: 0,
           variant: 'elements.icon-tile.text'

--- a/src/elements/icon-tile/src/stories.tsx
+++ b/src/elements/icon-tile/src/stories.tsx
@@ -20,11 +20,16 @@ export const ExampleWithKnobs = () => {
     ['carInsurance', 'creditCards', 'loans', 'mortgages'],
     'carInsurance'
   )
+  const alignVertically = boolean('Vertically align icon and text?', false)
 
   const iconImg = (
     <img src={require(`../../../../static/money-icons/${icon}.svg`)} />
   )
-  const justTile = <IconTile icon={iconImg}>{tileText}</IconTile>
+  const justTile = (
+    <IconTile icon={iconImg} alignVertically={alignVertically}>
+      {tileText}
+    </IconTile>
+  )
 
   return layoutStory ? (
     <div sx={{ margin: -10, backgroundColor: '#924A8B', paddingY: 'md' }}>

--- a/src/elements/icon-tile/src/stories.tsx
+++ b/src/elements/icon-tile/src/stories.tsx
@@ -20,13 +20,17 @@ export const ExampleWithKnobs = () => {
     ['carInsurance', 'creditCards', 'loans', 'mortgages'],
     'carInsurance'
   )
-  const alignVertically = boolean('Vertically align icon and text?', false)
+  const displayVariant = select(
+    'Display Variant',
+    ['horizontal', 'vertical'],
+    'horizontal'
+  )
 
   const iconImg = (
     <img src={require(`../../../../static/money-icons/${icon}.svg`)} />
   )
   const justTile = (
-    <IconTile icon={iconImg} alignVertically={alignVertically}>
+    <IconTile icon={iconImg} displayVariant={displayVariant}>
       {tileText}
     </IconTile>
   )

--- a/src/elements/icon-tile/src/stories.tsx
+++ b/src/elements/icon-tile/src/stories.tsx
@@ -6,9 +6,7 @@ import { boolean, select, text } from '@storybook/addon-knobs'
 import { Col, Container, Row } from '../../../layout/flex-grid/src'
 import AllThemes from '../../../utils/all-themes'
 
-import IconTile from './'
-
-import { DisplayVariant } from './'
+import IconTile, { DisplayVariant } from './'
 
 export default {
   title: 'Elements|Icon Tile'

--- a/src/elements/icon-tile/src/stories.tsx
+++ b/src/elements/icon-tile/src/stories.tsx
@@ -8,6 +8,8 @@ import AllThemes from '../../../utils/all-themes'
 
 import IconTile from './'
 
+import { DisplayVariant } from './'
+
 export default {
   title: 'Elements|Icon Tile'
 }
@@ -22,8 +24,8 @@ export const ExampleWithKnobs = () => {
   )
   const displayVariant = select(
     'Display Variant',
-    ['horizontal', 'vertical'],
-    'horizontal'
+    DisplayVariant,
+    DisplayVariant.Horizontal
   )
 
   const iconImg = (


### PR DESCRIPTION
# Description

Add option to vertically align the icon tile on desktop and mobile

![image](https://user-images.githubusercontent.com/56200818/93609874-45e89c80-f9c4-11ea-9d32-abff93ec8c58.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
