### PR TITLE
Fix page movement when using interative tabs

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1716,7 +1716,7 @@
           },
           "color": "grey-60",
           "iconColor": "grey-60",
-          "padding": "md",
+          "padding": 24,
           "mb": [0, "md"],
           "display": "flex",
           "flexDirection": "row",
@@ -1733,6 +1733,7 @@
             "iconColor": "dark-1",
             "position": "relative",
             "mx": ["auto", 0],
+            "padding": "24px 24px 20px 24px",
             "width": ["calc(100% - 48px)", "auto"],
             "backgroundColor": "light-1",
             "boxShadow": [


### PR DESCRIPTION
# Description

Buttons on interactive tabs have different sizes when active/non-active.
Switching between tabs causes the element to shift down the page
slightly.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.