### PR TITLE
feat: allow hero to be styled with palette

### DIFF
--- a/src/elements/hero/CHANGELOG.md
+++ b/src/elements/hero/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@3.4.4...@uswitch/trustyle.hero@3.5.0) (2020-10-29)
+
+
+### Bug Fixes
+
+* BBdeals foreground image ([a42ed8c](https://github.com/uswitch/trustyle/commit/a42ed8c))
+
+
+### Features
+
+* allow hero to be styled with palette ([9863bfb](https://github.com/uswitch/trustyle/commit/9863bfb))
+
+
+
+
+
 ## [3.4.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero@3.4.0...@uswitch/trustyle.hero@3.4.2) (2020-09-23)
 
 

--- a/src/elements/hero/package.json
+++ b/src/elements/hero/package.json
@@ -12,6 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.get": "^1.0.9"
+    "@uswitch/trustyle-utils.get": "^1.0.9",
+    "@uswitch/trustyle-utils.palette": "^1.2.5"
   }
 }

--- a/src/elements/hero/package.json
+++ b/src/elements/hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/hero/src/index.tsx
+++ b/src/elements/hero/src/index.tsx
@@ -131,22 +131,22 @@ const Hero: React.FC<Props> = ({
             </div>
           </Container>
         </div>
-        {fgImage && (
-          <img
-            sx={{
-              maxWidth: '100%',
-              position: 'relative',
-              display: 'none',
-              marginTop: `-${bottomImageOverflow}`,
-              marginLeft: 'auto',
-              marginRight: 'auto',
-              variant: 'elements.hero.bottomImage'
-            }}
-            src={fgImage}
-            role="presentation"
-          />
-        )}
       </Palette>
+      {fgImage && (
+        <img
+          sx={{
+            maxWidth: '100%',
+            position: 'relative',
+            display: 'none',
+            marginTop: `-${bottomImageOverflow}`,
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            variant: 'elements.hero.bottomImage'
+          }}
+          src={fgImage}
+          role="presentation"
+        />
+      )}
     </div>
   )
 }

--- a/src/elements/hero/src/index.tsx
+++ b/src/elements/hero/src/index.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 import get from '@uswitch/trustyle-utils.get'
+import { Palette } from '@uswitch/trustyle-utils.palette'
 
 type ArrayOrNot<T> = T | T[]
 
@@ -55,92 +56,97 @@ const Hero: React.FC<Props> = ({
 
   return (
     <div>
-      <div
-        sx={{
-          position: 'relative',
-          overflow: 'hidden',
-          variant: 'elements.hero.wrapper',
-          backgroundColor: customBgColor || undefined
-        }}
-        className={className}
+      <Palette
+        as="div"
+        sx={{ variant: 'elements.hero.wrapper', overflow: 'hidden' }}
+        px={{ backgroundColor: 'backgroundColor' }}
       >
-        <Container>
-          {breadcrumbs && (
-            <div
-              sx={{ paddingTop: 'sm', variant: 'elements.hero.breadcrumbs' }}
-            >
-              {breadcrumbWithVariant}
-            </div>
-          )}
-          <div
-            sx={{
-              position: 'relative',
-              display: 'block',
-              flexDirection: 'row-reverse'
-            }}
-          >
-            <div
-              sx={{
-                position: 'absolute',
-                left: [0, '45%'],
-                right: 0,
-                top: 0,
-                bottom: 0,
-                display: [
-                  fgImageOnMobile ? 'block' : 'none',
-                  fgImageOnTablet ? 'block' : 'none',
-                  'block'
-                ],
-                ...(fgImage && fgImageType === 'background'
-                  ? {
-                      backgroundImage: `url(${fgImage})`,
-                      backgroundRepeat: 'no-repeat',
-                      ...fgImagePosition
-                    }
-                  : undefined),
-                variant: 'elements.hero.image'
-              }}
-            >
-              {fgImage && fgImageType === 'img' && (
-                <img
-                  sx={{
-                    maxWidth: '100%',
-                    position: 'absolute',
-                    ...fgImagePosition
-                  }}
-                  src={fgImage}
-                  role="presentation"
-                />
-              )}
-            </div>
+        <div
+          sx={{
+            position: 'relative',
+            overflow: 'hidden',
+            backgroundColor: customBgColor || undefined
+          }}
+          className={className}
+        >
+          <Container>
+            {breadcrumbs && (
+              <div
+                sx={{ paddingTop: 'sm', variant: 'elements.hero.breadcrumbs' }}
+              >
+                {breadcrumbWithVariant}
+              </div>
+            )}
             <div
               sx={{
                 position: 'relative',
-                paddingTop: ['sm', 'xxl'],
-                paddingBottom: ['sm', 'xxl'],
-                variant: 'elements.hero.content'
+                display: 'block',
+                flexDirection: 'row-reverse'
               }}
             >
-              {children}
+              <div
+                sx={{
+                  position: 'absolute',
+                  left: [0, '45%'],
+                  right: 0,
+                  top: 0,
+                  bottom: 0,
+                  display: [
+                    fgImageOnMobile ? 'block' : 'none',
+                    fgImageOnTablet ? 'block' : 'none',
+                    'block'
+                  ],
+                  ...(fgImage && fgImageType === 'background'
+                    ? {
+                        backgroundImage: `url(${fgImage})`,
+                        backgroundRepeat: 'no-repeat',
+                        ...fgImagePosition
+                      }
+                    : undefined),
+                  variant: 'elements.hero.image'
+                }}
+              >
+                {fgImage && fgImageType === 'img' && (
+                  <img
+                    sx={{
+                      maxWidth: '100%',
+                      position: 'absolute',
+                      ...fgImagePosition
+                    }}
+                    src={fgImage}
+                    role="presentation"
+                  />
+                )}
+              </div>
+              <div
+                sx={{
+                  position: 'relative',
+                  paddingTop: ['sm', 'xxl'],
+                  paddingBottom: ['sm', 'xxl'],
+                  variant: 'elements.hero.content'
+                }}
+              >
+                {children}
+              </div>
             </div>
-          </div>
-        </Container>
-      </div>
-      {fgImage && (
-        <img
-          sx={{
-            maxWidth: '100%',
-            position: 'relative',
-            display: 'none',
-            marginTop: `-${bottomImageOverflow}`,
-            marginLeft: 'auto',
-            marginRight: 'auto',
-            variant: 'elements.hero.bottomImage'
-          }}
-          src={fgImage}
-          role="presentation"
-        />
-      )}
+          </Container>
+        </div>
+        {fgImage && (
+          <img
+            sx={{
+              maxWidth: '100%',
+              position: 'relative',
+              display: 'none',
+              marginTop: `-${bottomImageOverflow}`,
+              marginLeft: 'auto',
+              marginRight: 'auto',
+              variant: 'elements.hero.bottomImage'
+            }}
+            src={fgImage}
+            role="presentation"
+          />
+        )}
+      </Palette>
     </div>
   )
 }

--- a/src/elements/hero/src/stories.tsx
+++ b/src/elements/hero/src/stories.tsx
@@ -1,7 +1,8 @@
 /** @jsx jsx */
 import * as React from 'react'
 import { jsx, Styled } from 'theme-ui'
-import { boolean, select, text } from '@storybook/addon-knobs'
+import { boolean, color, select, text } from '@storybook/addon-knobs'
+import { PaletteProvider } from '@uswitch/trustyle-utils.palette'
 
 import Breadcrumbs from '../../breadcrumbs/src'
 import { Button } from '../../button/src'
@@ -9,6 +10,7 @@ import { Col, Container, Row } from '../../../layout/flex-grid/src'
 import IconTile from '../../icon-tile/src'
 import AllThemes from '../../../utils/all-themes'
 import Author from '../../../elements/author/src'
+import theme from '../../../utils/theme-selector'
 
 import Hero from './'
 
@@ -269,6 +271,87 @@ BBDealsExample.story = {
     percy: { skip: true }
   }
 }
+
+export const ExampleWithPalette = () => {
+  const breadcrumbsVariant = select(
+    'Breadcrumbs variant',
+    variants,
+    'base'
+  ) as Variant
+  const headline = text(
+    'Headline',
+    'Short snappy headline that runs over two lines'
+  )
+  const fgImageKey = select(
+    'Foreground image',
+    Object.keys(people),
+    'Jumping guy'
+  )
+
+  const bgColor = text('Custom Color', '')
+  const fgImage = people[fgImageKey]
+  const imageOnMobile = boolean('Display foreground image on mobile?', true)
+  const imageOnTablet = boolean('Display foreground image on Tablet?', true)
+
+  const applyPalette = boolean('Apply palette?', false, 'Palette')
+  const backgroundColor = color(
+    'accentColor',
+    theme().elements['hero']?.wrapper?.backgroundColor,
+    'Palette'
+  )
+
+  const breadcrumbs = (
+    <Breadcrumbs
+      crumbs={crumbs}
+      title="Understanding energy bills and electricity bills - FAQs and more"
+      variant={breadcrumbsVariant}
+    />
+  )
+
+  return (
+    <div sx={{ margin: -10 }}>
+      <PaletteProvider
+        value={{
+          backgroundColor: applyPalette ? backgroundColor : null
+        }}
+      >
+        <Hero
+          container={Container}
+          fgImage={fgImage.img}
+          fgImagePosition={fgImage.position}
+          fgImageOnMobile={imageOnMobile}
+          fgImageOnTablet={imageOnTablet}
+          customBgColor={bgColor}
+          breadcrumbs={breadcrumbs}
+        >
+          <Row>
+            <Col span={[12, 5]}>
+              <Styled.h1 sx={{ marginTop: 0, fontSize: ['lg', 'xl', 'xxl'] }}>
+                {headline}
+              </Styled.h1>
+              <div sx={{ backgroundColor: 'white', padding: 20 }}>
+                <Styled.p sx={{ marginTop: 0 }}>
+                  Lorem ipsum, or lipsum as it is sometimes known, is dummy text
+                  used in laying out print, graphic or web designs.
+                </Styled.p>
+                <div sx={{ button: { width: 'auto' } }}>
+                  <Button variant="primary">Optional CTA</Button>
+                </div>
+              </div>
+            </Col>
+          </Row>
+        </Hero>
+      </PaletteProvider>
+    </div>
+  )
+}
+
+ExampleWithPalette.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 // @todo test with more than one image and position
 export const AutomatedTests = () => {
   return (


### PR DESCRIPTION
# Description

Allow Hero component background color to be set with a Palette in Contentful

![image](https://user-images.githubusercontent.com/56200818/94462219-13ecec80-01b3-11eb-8ceb-fcaa87570056.png)

![image](https://user-images.githubusercontent.com/56200818/94462231-1b13fa80-01b3-11eb-8c9a-273605c11946.png)



# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
