### PR TITLE
fix: adjust position of award if product img is not provided.

### DIFF
--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.0...@uswitch/trustyle.sponsored-product@3.1.1) (2020-10-01)
+
+
+### Bug Fixes
+
+* adjust position of award if product img is not provided. ([a701c5d](https://github.com/uswitch/trustyle/commit/a701c5d))
+* update second usp in story so as not to be the same. ([d0c7ed4](https://github.com/uswitch/trustyle/commit/d0c7ed4))
+
+
+
+
+
 # [3.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.0.0...@uswitch/trustyle.sponsored-product@3.1.0) (2020-09-29)
 
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -209,7 +209,8 @@ const SponsoredProduct: React.FC<Props> = ({
         sx={{
           display: 'flex',
           flexDirection: [null, 'column'],
-          width: [null, '45%']
+          width: [null, '45%'],
+          justifyContent: imgSrc ? 'flex-start' : 'space-between'
         }}
       >
         <div
@@ -255,14 +256,14 @@ const SponsoredProduct: React.FC<Props> = ({
         {award && (
           <div
             sx={{
-              width: 106,
+              width: imgSrc ? 106 : 120,
               display: ['none', 'flex'],
               alignItems: 'center',
               marginTop: 'xs'
             }}
           >
             <svg
-              height="48"
+              height={imgSrc ? '48' : '60'}
               viewBox="0 0 22 23"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"

--- a/src/compounds/sponsored-product/src/stories.tsx
+++ b/src/compounds/sponsored-product/src/stories.tsx
@@ -88,7 +88,7 @@ export const ExampleWithKnobs = () => {
           <Col offset={[0.05, 2, 2]} span={[4, 4, 4]}>
             <SponsoredProduct
               title={'Sky Superfast Broadband'}
-              usps={['£22 p/m & no setup cost']}
+              usps={['£22 p/m & no setup cost', '£22 p/m & no setup cost']}
               sponsorName={'Sky'}
               sponsorSrc={
                 'https://uswitch-cms.imgix.net/uswitch-assets-eu/broadband/images/providers/sky.png?auto=compress%2Cformat&amp;fit=clip&amp;ixlib=react-9.0.1&amp;w=120'

--- a/src/compounds/sponsored-product/src/stories.tsx
+++ b/src/compounds/sponsored-product/src/stories.tsx
@@ -88,7 +88,7 @@ export const ExampleWithKnobs = () => {
           <Col offset={[0.05, 2, 2]} span={[4, 4, 4]}>
             <SponsoredProduct
               title={'Sky Superfast Broadband'}
-              usps={['£22 p/m & no setup cost', '£22 p/m & no setup cost']}
+              usps={['£22 p/m & no setup cost', 'Best Broadband ever']}
               sponsorName={'Sky'}
               sponsorSrc={
                 'https://uswitch-cms.imgix.net/uswitch-assets-eu/broadband/images/providers/sky.png?auto=compress%2Cformat&amp;fit=clip&amp;ixlib=react-9.0.1&amp;w=120'


### PR DESCRIPTION
# Description

If product image isn't provided for sponsored product component. Awards image is shifted to the bottom of the component. 

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
