### PR TITLE
fix: a11y: add alt tag to SlideReveal story

### DIFF
--- a/axe-tests.runner.js
+++ b/axe-tests.runner.js
@@ -42,7 +42,6 @@ const BROKEN_STORIES = [
   'Elements/Link List',
   'Elements/Pagination',
   'Elements/Simple Input',
-  'Elements/Slide Reveal',
   'Elements/Text Input',
   'Global Styles/Typography',
   'Layout/Arrangement',

--- a/src/elements/slide-reveal/src/stories.tsx
+++ b/src/elements/slide-reveal/src/stories.tsx
@@ -21,6 +21,7 @@ export const ExampleWithKnobs = () => {
       <img
         src="https://placekitten.com/408/287?image=5"
         sx={{ maxWidth: '100%' }}
+        alt="Cat"
       />
       <p>test content</p>
     </SlideReveal>


### PR DESCRIPTION
# Description

Fixes story so we can enable `a11y` check against `SlideReveal`

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc