### PR TITLE
fix: Fix btn link dark text on dark bg

### DIFF
--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.17](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.16...@uswitch/trustyle.embedded-video@0.4.17) (2020-10-07)
+
+
+### Bug Fixes
+
+* set iframe title in EmbeddedVideo ([65c346b](https://github.com/uswitch/trustyle/commit/65c346b))
+
+
+
+
+
 ## [0.4.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.12...@uswitch/trustyle.embedded-video@0.4.13) (2020-09-09)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.16.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.16.1...@uswitch/trustyle.uswitch-theme@2.16.2) (2020-10-07)
+
+
+### Bug Fixes
+
+* Fix btn link dark text on dark bg ([37a817b](https://github.com/uswitch/trustyle/commit/37a817b))
+
+
+
+
+
 # [2.16.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.15.0...@uswitch/trustyle.uswitch-theme@2.16.0) (2020-10-07)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -918,6 +918,7 @@
           "backgroundColor": "primary",
           "color": "light-1",
           ":hover": {
+            "color": "light-1",
             "backgroundColor": "grey-70"
           },
           ":disabled": {
@@ -985,6 +986,7 @@
           "border": "2px solid",
           "borderColor": "light-1",
           ":hover": {
+            "color": "light-1",
             "backgroundColor": "grey-80"
           },
           ":disabled": {


### PR DESCRIPTION
# Description
When hovering a btn link, the text goes dark on dark bg variants.
E.g. Primary and Reversed.

Before
![Screenshot 2020-10-07 at 15 15 35](https://user-images.githubusercontent.com/3267705/95343049-fc4aed80-08af-11eb-83dc-6ca9ad8ee88c.png)

After
![Screenshot 2020-10-07 at 15 15 06](https://user-images.githubusercontent.com/3267705/95342991-ea694a80-08af-11eb-925a-66c10aa03c4a.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
