### PR TITLE
fix: Change Info block container height to minHeight to prevent overlap

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.0.2...@uswitch/trustyle.sponsored-product-rate-table@3.0.3) (2020-10-12)
+
+
+### Bug Fixes
+
+* Change Info block container height to minHeight ([1ab46e8](https://github.com/uswitch/trustyle/commit/1ab46e8))
+
+
+
+
+
 ## [3.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.0.1...@uswitch/trustyle.sponsored-product-rate-table@3.0.2) (2020-10-09)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product-rate-table/src/index.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/index.tsx
@@ -272,7 +272,7 @@ const SponsoredRateTable: React.FC<Props> = ({
             display: 'grid',
             gridGap: ['xs', 12],
             gridTemplateColumns: '1fr 1fr',
-            height: [92, campaignImgHeight]
+            minHeight: [92, campaignImgHeight]
           }}
         >
           <InformationBlocks details={informationDetails} />


### PR DESCRIPTION
# Description
Changes info block container from height to minHeight to account for cases where there's a long description, preventing text overlapping USP underneath.

Before
![Screenshot 2020-10-12 at 09 40 41](https://user-images.githubusercontent.com/3267705/95725076-13525c80-0c6f-11eb-8d7e-27f7800b3483.png)

After
![Screenshot 2020-10-12 at 09 41 01](https://user-images.githubusercontent.com/3267705/95725100-1a796a80-0c6f-11eb-97a6-3e3c4fbe5932.png)

<!-- Explain the purpose of this Pull Request. -->

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
