### PR TITLE
feat: add true-speeds theme variant to button.

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.2...@uswitch/trustyle.sponsored-product-rate-table@3.1.3) (2020-10-12)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.0...@uswitch/trustyle.sponsored-product-rate-table@3.1.2) (2020-10-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -14,7 +14,7 @@
   "dependencies": {
     "@uswitch/trustyle.arrangement": "^2.0.20",
     "@uswitch/trustyle.awards-tag": "^0.2.0",
-    "@uswitch/trustyle.button": "^2.3.9",
+    "@uswitch/trustyle.button": "^2.4.0",
     "@uswitch/trustyle.button-link": "^2.1.3",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.icon": "^1.16.0",

--- a/src/elements/button/CHANGELOG.md
+++ b/src/elements/button/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.4.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button@2.3.9...@uswitch/trustyle.button@2.4.0) (2020-10-12)
+
+
+### Features
+
+* add true-speeds theme variant to button. ([df2a701](https://github.com/uswitch/trustyle/commit/df2a701))
+
+
+
+
+
 ## [2.3.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button@2.3.7...@uswitch/trustyle.button@2.3.9) (2020-10-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.button

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "2.3.9",
+  "version": "2.4.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -12,6 +12,7 @@ export type Variant =
   | 'continue'
   | 'inverse'
   | 'reversed'
+  | 'true-speeds'
   | 'link'
   | 'hero'
   | 'hero.centered'

--- a/src/elements/button/src/stories.tsx
+++ b/src/elements/button/src/stories.tsx
@@ -24,6 +24,22 @@ const sizeOptions = {
 export const AllVariants = () => {
   return (
     <div css={css({ padding: number('Padding', 10) })}>
+      <Button
+        variant={'true-speeds'}
+        size={'small'}
+        onClick={action('true-speeds-click')}
+      >
+        <div
+          css={css({
+            display: 'flex'
+          })}
+        >
+          <Icon color={'green'} glyph={'checkmark'} size={20} />
+          <span css={css({ padding: '0px 5px' })}>Checked by Uswitch</span>
+          <Icon color={'black'} glyph={'question'} size={20} />
+        </div>
+      </Button>
+      <Spacer />
       {theme() &&
         Object.keys(theme().elements.buttons.variants).map((key, index) => (
           <React.Fragment key={index}>

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.21.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.20.1...@uswitch/trustyle.uswitch-theme@2.21.0) (2020-10-12)
+
+
+### Bug Fixes
+
+* remove unnecessary important css attribute. ([603e9b2](https://github.com/uswitch/trustyle/commit/603e9b2))
+
+
+### Features
+
+* add true-speeds theme variant to button. ([df2a701](https://github.com/uswitch/trustyle/commit/df2a701))
+* make prettier happy. ([71bd0b4](https://github.com/uswitch/trustyle/commit/71bd0b4))
+
+
+
+
+
 ## [2.20.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.20.0...@uswitch/trustyle.uswitch-theme@2.20.1) (2020-10-12)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.20.1",
+  "version": "2.21.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1071,6 +1071,16 @@
             "fontFamily": "heading",
             "color": "primary"
           }
+        },
+        "true-speeds" : {
+          "variant": "elements.buttons.base",
+          "padding": 4,
+          "backgroundColor": "light-1",
+          "border": "2px solid",
+          "borderColor": "success-green",
+          "fontSize": "14px !important",
+          "fontStyle": "normal",
+          "lineHeight": "21px"
         }
       }
     },

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1078,7 +1078,7 @@
           "backgroundColor": "light-1",
           "border": "2px solid",
           "borderColor": "success-green",
-          "fontSize": "14px !important",
+          "fontSize": "14px",
           "fontStyle": "normal",
           "lineHeight": "21px"
         }

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1072,7 +1072,7 @@
             "color": "primary"
           }
         },
-        "true-speeds" : {
+        "true-speeds": {
           "variant": "elements.buttons.base",
           "padding": 4,
           "backgroundColor": "light-1",


### PR DESCRIPTION
# Description

Adds true speed variant to button within Uswitch Theme. 

<img width="225" alt="Screenshot 2020-10-12 at 13 03 47" src="https://user-images.githubusercontent.com/47602619/95744861-f9734280-0c8b-11eb-80c8-26e339bce3c1.png">


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
