### PR TITLE
fix: use small padding to fix margin collapse rather than overflow hidden

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.4...@uswitch/trustyle.sponsored-product-rate-table@3.1.5) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.1.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.3...@uswitch/trustyle.sponsored-product-rate-table@3.1.4) (2020-10-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.3...@uswitch/trustyle.sponsored-product-rate-table@3.1.4) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.1.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.2...@uswitch/trustyle.sponsored-product-rate-table@3.1.3) (2020-10-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -19,7 +19,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.icon": "^1.16.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
-    "@uswitch/trustyle.primary-info-block": "^1.0.2",
+    "@uswitch/trustyle.primary-info-block": "^1.0.3",
     "@uswitch/trustyle.sponsored-by-tag": "^2.0.5",
     "@uswitch/trustyle.usp-tag": "^0.1.5"
   }

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -19,7 +19,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.icon": "^1.16.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
-    "@uswitch/trustyle.primary-info-block": "^1.0.1",
+    "@uswitch/trustyle.primary-info-block": "^1.0.2",
     "@uswitch/trustyle.sponsored-by-tag": "^2.0.5",
     "@uswitch/trustyle.usp-tag": "^0.1.5"
   }

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.9...@uswitch/trustyle.sponsored-product@3.1.10) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.1.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.8...@uswitch/trustyle.sponsored-product@3.1.9) (2020-10-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.8...@uswitch/trustyle.sponsored-product@3.1.9) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.1.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.6...@uswitch/trustyle.sponsored-product@3.1.8) (2020-10-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.icon": "^1.16.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
-    "@uswitch/trustyle.primary-info-block": "^1.0.1",
+    "@uswitch/trustyle.primary-info-block": "^1.0.2",
     "@uswitch/trustyle.sponsored-by-tag": "^2.0.5",
     "@uswitch/trustyle.usp-tag": "^0.1.5"
   }

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.icon": "^1.16.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
-    "@uswitch/trustyle.primary-info-block": "^1.0.2",
+    "@uswitch/trustyle.primary-info-block": "^1.0.3",
     "@uswitch/trustyle.sponsored-by-tag": "^2.0.5",
     "@uswitch/trustyle.usp-tag": "^0.1.5"
   }

--- a/src/elements/call-out/CHANGELOG.md
+++ b/src/elements/call-out/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.15](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.0.14...@uswitch/trustyle.call-out@2.0.15) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.call-out
+
+
+
+
+
 ## [2.0.14](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.0.12...@uswitch/trustyle.call-out@2.0.14) (2020-10-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.call-out

--- a/src/elements/call-out/CHANGELOG.md
+++ b/src/elements/call-out/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.16](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.0.15...@uswitch/trustyle.call-out@2.0.16) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.call-out
+
+
+
+
+
 ## [2.0.15](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.0.14...@uswitch/trustyle.call-out@2.0.15) (2020-10-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.call-out

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^1.2.5",
+    "@uswitch/trustyle-utils.palette": "^2.0.0",
     "@uswitch/trustyle.icon": "^1.16.0"
   }
 }

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^2.0.0",
+    "@uswitch/trustyle-utils.palette": "^2.0.1",
     "@uswitch/trustyle.icon": "^1.16.0"
   }
 }

--- a/src/elements/primary-info-block/CHANGELOG.md
+++ b/src/elements/primary-info-block/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.primary-info-block@1.0.1...@uswitch/trustyle.primary-info-block@1.0.2) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.primary-info-block
+
+
+
+
+
 # [1.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.primary-info-block@0.2.20...@uswitch/trustyle.primary-info-block@1.0.0) (2020-10-07)
 
 

--- a/src/elements/primary-info-block/CHANGELOG.md
+++ b/src/elements/primary-info-block/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.primary-info-block@1.0.2...@uswitch/trustyle.primary-info-block@1.0.3) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.primary-info-block
+
+
+
+
+
 ## [1.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.primary-info-block@1.0.1...@uswitch/trustyle.primary-info-block@1.0.2) (2020-10-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.primary-info-block

--- a/src/elements/primary-info-block/package.json
+++ b/src/elements/primary-info-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.primary-info-block",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^1.2.5"
+    "@uswitch/trustyle-utils.palette": "^2.0.0"
   }
 }

--- a/src/elements/primary-info-block/package.json
+++ b/src/elements/primary-info-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.primary-info-block",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^2.0.0"
+    "@uswitch/trustyle-utils.palette": "^2.0.1"
   }
 }

--- a/src/elements/toggle-switch/CHANGELOG.md
+++ b/src/elements/toggle-switch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.toggle-switch@2.0.4...@uswitch/trustyle.toggle-switch@2.0.5) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.toggle-switch
+
+
+
+
+
 ## [2.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.toggle-switch@2.0.1...@uswitch/trustyle.toggle-switch@2.0.2) (2020-08-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.toggle-switch

--- a/src/elements/toggle-switch/CHANGELOG.md
+++ b/src/elements/toggle-switch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.toggle-switch@2.0.5...@uswitch/trustyle.toggle-switch@2.0.6) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.toggle-switch
+
+
+
+
+
 ## [2.0.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.toggle-switch@2.0.4...@uswitch/trustyle.toggle-switch@2.0.5) (2020-10-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.toggle-switch

--- a/src/elements/toggle-switch/package.json
+++ b/src/elements/toggle-switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.toggle-switch",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^2.0.0"
+    "@uswitch/trustyle-utils.palette": "^2.0.1"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.27",

--- a/src/elements/toggle-switch/package.json
+++ b/src/elements/toggle-switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.toggle-switch",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.palette": "^1.2.5"
+    "@uswitch/trustyle-utils.palette": "^2.0.0"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.27",

--- a/src/utils/palette/CHANGELOG.md
+++ b/src/utils/palette/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle-utils.palette@1.2.5...@uswitch/trustyle-utils.palette@2.0.0) (2020-10-13)
+
+
+### Bug Fixes
+
+* use small padding to fix margin collapse rather than overflow hidden ([e2b618e](https://github.com/uswitch/trustyle/commit/e2b618e))
+
+
+### BREAKING CHANGES
+
+* uses padding and not overflow hidden, this could break things
+
+
+
+
+
 ## [1.2.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle-utils.palette@1.2.2...@uswitch/trustyle-utils.palette@1.2.3) (2020-08-11)
 
 **Note:** Version bump only for package @uswitch/trustyle-utils.palette

--- a/src/utils/palette/CHANGELOG.md
+++ b/src/utils/palette/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle-utils.palette@2.0.0...@uswitch/trustyle-utils.palette@2.0.1) (2020-10-13)
+
+**Note:** Version bump only for package @uswitch/trustyle-utils.palette
+
+
+
+
+
 # [2.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle-utils.palette@1.2.5...@uswitch/trustyle-utils.palette@2.0.0) (2020-10-13)
 
 

--- a/src/utils/palette/package.json
+++ b/src/utils/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle-utils.palette",
-  "version": "1.2.5",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/utils/palette/package.json
+++ b/src/utils/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle-utils.palette",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/utils/palette/src/index.tsx
+++ b/src/utils/palette/src/index.tsx
@@ -39,7 +39,7 @@ export const Palette = ({ children, className, px = {}, ...props }: any) => {
     <props.as
       {...props}
       className={`palette ${className}`}
-      sx={{ '&.palette': { ...sx, py: '0.05px' } }}
+      sx={{ py: '0.05px', ...sx }}
     >
       {children}
     </props.as>

--- a/src/utils/palette/src/index.tsx
+++ b/src/utils/palette/src/index.tsx
@@ -39,7 +39,7 @@ export const Palette = ({ children, className, px = {}, ...props }: any) => {
     <props.as
       {...props}
       className={`palette ${className}`}
-      sx={{ '&.palette': { ...sx, overflow: 'hidden' } }}
+      sx={{ '&.palette': { ...sx, py: '0.05px' } }}
     >
       {children}
     </props.as>


### PR DESCRIPTION
BREAKING CHANGE: uses padding and not overflow hidden, this could break things

# Description

Uses padding 0.05px rather than overflow:hidden to prevent margin collapse on palettes

I think that this is a better solution as it should not have any side effects (unlike overflow)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
