### PR TITLE
fix: hero with bg img opacity option

### DIFF
--- a/src/elements/hero-with-background-image/CHANGELOG.md
+++ b/src/elements/hero-with-background-image/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-with-background-image@1.0.7...@uswitch/trustyle.hero-with-background-image@1.0.8) (2020-10-15)
+
+
+### Bug Fixes
+
+* fix hero with background autometed tests ([c8e3d74](https://github.com/uswitch/trustyle/commit/c8e3d74))
+* hero with bg image stories fix, run prettier ([6e8bc77](https://github.com/uswitch/trustyle/commit/6e8bc77))
+* hero with bg img opacity option ([cbbae48](https://github.com/uswitch/trustyle/commit/cbbae48))
+
+
+
+
+
+
 ## [1.0.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-with-background-image@1.0.4...@uswitch/trustyle.hero-with-background-image@1.0.5) (2020-08-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.hero-with-background-image

--- a/src/elements/hero-with-background-image/package.json
+++ b/src/elements/hero-with-background-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero-with-background-image",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/hero-with-background-image/src/index.tsx
+++ b/src/elements/hero-with-background-image/src/index.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import * as React from 'react'
-import { jsx } from 'theme-ui'
+import { jsx, useThemeUI } from 'theme-ui'
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   breadcrumbs?: React.ReactNode
@@ -14,14 +14,40 @@ const HeroWithBackgroundImage: React.FC<Props> = ({
   imageUrl,
   className
 }) => {
+  const { theme }: any = useThemeUI()
+  const heroTheme = theme.modules['hero-with-background-image']
+  const opacity = heroTheme && heroTheme['background-image']?.opacity
+
+  const backgroundImgSx = {
+    backgroundSize: 'cover',
+    backgroundPosition: 'center center',
+    backgroundRepeat: 'no-repeat',
+    backgroundImage: `url(${imageUrl})`
+  }
+
+  // insert pseudo element only if opacity is defined
+  const imgSx = opacity
+    ? {
+        position: 'relative',
+        '::before': {
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          position: 'absolute',
+          content: "''",
+          opacity,
+          zIndex: -100,
+          ...backgroundImgSx
+        }
+      }
+    : backgroundImgSx
+
   return (
     <div
       sx={{
-        backgroundSize: 'cover',
-        backgroundPosition: 'center center',
-        backgroundRepeat: 'no-repeat',
-        variant: 'modules.hero-with-background-image',
-        backgroundImage: `url(${imageUrl})`
+        ...imgSx,
+        variant: 'modules.hero-with-background-image'
       }}
       className={className}
     >

--- a/src/elements/hero-with-background-image/src/stories.tsx
+++ b/src/elements/hero-with-background-image/src/stories.tsx
@@ -127,7 +127,8 @@ HeroWithFlexGridContainer.story = {
 export const AutomatedTests = () => {
   return (
     <AllThemes>
-      <HeroWithBackgroundImage />
+      <HeroWithCustomContainer />
+      <HeroWithFlexGridContainer />
     </AllThemes>
   )
 }

--- a/src/elements/hero-with-background-image/src/stories.tsx
+++ b/src/elements/hero-with-background-image/src/stories.tsx
@@ -127,8 +127,7 @@ HeroWithFlexGridContainer.story = {
 export const AutomatedTests = () => {
   return (
     <AllThemes>
-      <HeroWithCustomContainer />
-      <HeroWithFlexGridContainer />
+      <HeroWithBackgroundImage />
     </AllThemes>
   )
 }

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.13.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.13.3...@uswitch/trustyle.save-on-energy-theme@1.13.4) (2020-10-15)
+
+
+### Bug Fixes
+
+* hero with bg image stories fix, run prettier ([6e8bc77](https://github.com/uswitch/trustyle/commit/6e8bc77))
+* hero with bg img opacity option ([cbbae48](https://github.com/uswitch/trustyle/commit/cbbae48))
+
+
+
+
+
+
 ## [1.13.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.13.0...@uswitch/trustyle.save-on-energy-theme@1.13.1) (2020-08-27)
 
 

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -950,9 +950,9 @@
   },
 
   "modules": {
-    "hero-with-background-image":{
-      "background-image":{
-        "opacity":0.3
+    "hero-with-background-image": {
+      "background-image": {
+        "opacity": 0.3
       }
     },
     "image-callout-content": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -950,6 +950,11 @@
   },
 
   "modules": {
+    "hero-with-background-image":{
+      "background-image":{
+        "opacity":0.3
+      }
+    },
     "image-callout-content": {
       "sm": {
         "pt": "xl"


### PR DESCRIPTION
# Description

Add image opacity option for hero with background image.

# Screenshot

![image](https://user-images.githubusercontent.com/66306693/95949164-63a5f780-0df2-11eb-9417-1fd8b45144bc.png)

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
