### PR TITLE
fix: mobile pagination not triggering

### DIFF
--- a/src/elements/pagination/CHANGELOG.md
+++ b/src/elements/pagination/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.5.0...@uswitch/trustyle.pagination@1.5.1) (2020-10-21)
+
+
+### Bug Fixes
+
+* mobile pagination not triggering ([f80eea9](https://github.com/uswitch/trustyle/commit/f80eea9))
+
+
+
+
+
 # [1.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.3.7...@uswitch/trustyle.pagination@1.5.0) (2020-10-12)
 
 

--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -37,7 +37,7 @@ function getNumbers(
   isMinimized: boolean = false
 ): PaginationNumbers {
   const AROUND_CURRENT = 1
-  const END_LENGTH = 5 + AROUND_CURRENT * 2
+  const END_LENGTH = isMinimized ? 2 : 5 + AROUND_CURRENT * 2
 
   if (totalPages <= END_LENGTH) {
     return new Array(totalPages).fill('').map((_, i) => i + 1)


### PR DESCRIPTION
# Description

Fix for mobile pagination not triggering when END_LENGTH of desktop less than total pages

Pull request contains:

- [ ] A new component
- [ x ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ x ] Work has been tested in multiple browsers
- [ x ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
