### PR TITLE
fix: add gradient image left variant design for image callout module

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2622,6 +2622,7 @@
         },
         "inner": {
           "display": "flex",
+          "flexDirection": ["column", "row"],
           "justifyContent": ["flex-start", "flex-start", "space-between"],
           "width": [null, 768, 1200]
         },
@@ -2731,15 +2732,71 @@
           }
         },
         "gradientImageLeft": {
-          "inner": {
-            "flexDirection": ["column", "row"],
-            "alignItems": ["center", "center", "flex-start"]
+          "wrapper": {
+            "pt": ["xxl", 0, 124],
+            "pb": ["xxs", "xs", "xl"]
           },
-          "colorBlock": {
-            "background": "linear-gradient(90deg, #C1D3FF 0%, #BEE8F3 100%)"
+          "image": {
+            "mt": 0,
+            "width": "fit-content",
+            "maxHeight": "inherit",
+            "objectFit": "cover"
+          },
+          "image-container": {
+            "maxWidth": ["100%", "100%", "grid.lg.6"],
+            "position": "relative",
+            "maxHeight": [383, 850, 970],
+            "width": "100%",
+            "height": "auto",
+            "my": [0, 0, 0],
+            "alignSelf": ["auto", "auto", "center"]
           },
           "content": {
-            "pl": [null, 50, 0]
+            "maxWidth": ["100%", "100%", "grid.lg.5"],
+            "h2": {
+              "color": "grey-20",
+              "mb": ["md", "md", "xxl"],
+              "pb": "sm",
+              "mt": ["lg", null, 0]
+            },
+            "span > div": {
+              "display": "flex",
+              "mb": ["md", "md", "xl"],
+              "pb": ["sm", "sm", 0],
+              ">a:first-of-type": {
+                "mr": ["sm", "sm", "md"],
+                "borderBottom": "none",
+                "color": "white",
+                "img,svg": {
+                  "filter": "invert(100%) sepia(0%) saturate(2%) hue-rotate(234deg) brightness(104%) contrast(101%)",
+                  "width": "auto",
+                  "height": [24, 24, 28],
+                  "mt": [2, 4, 4]
+                }
+              }
+            },
+            "h3": {
+              "&,&>a": {
+                "color": "white",
+                "borderBottom": "none"
+              }
+            },
+            "p": {
+              "color": "grey-20",
+              "mb": 0
+            }
+          },
+          "colorBlock": {
+            "background": "linear-gradient(90deg, #AC96DE 0%, #ACAAFF 100%)",
+            "left": [-40, -40, -104],
+            "top": [-40, -40, -104],
+            "width": ["98%", "98%", "95%"]
+          },
+          "inner": {
+            "display": "flex",
+            "flexDirection": ["column", "row", "row"],
+            "justifyContent": ["flex-start", "space-between"],
+            "alignItems": ["center", null, null]
           }
         },
         "gradientImageRight": {


### PR DESCRIPTION
# Description

Image callout design for Black Friday pages.

# Screenshots
**Note: black background is not implemented. It is defined on photos just to contrast font.**

### Desktop
![image](https://user-images.githubusercontent.com/66306693/96851999-ed8c3b00-1458-11eb-8571-9ea9c9525110.png)

### Tablet
![image](https://user-images.githubusercontent.com/66306693/96852042-f7ae3980-1458-11eb-923e-56cc734ccaa8.png)

### Mobile
![image](https://user-images.githubusercontent.com/66306693/96852088-03016500-1459-11eb-98b3-6b4ee5236f57.png)


# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
