### PR TITLE
Pagination select fix

### DIFF
--- a/src/elements/pagination/CHANGELOG.md
+++ b/src/elements/pagination/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.5.1...@uswitch/trustyle.pagination@1.5.2) (2020-10-23)
+
+
+### Bug Fixes
+
+* cant select default checked option on mac os ([11ae774](https://github.com/uswitch/trustyle/commit/11ae774))
+* page and select numbers not updating ([3d55e44](https://github.com/uswitch/trustyle/commit/3d55e44))
+
+
+
+
+
 ## [1.5.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.5.0...@uswitch/trustyle.pagination@1.5.1) (2020-10-21)
 
 

--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -21,7 +21,7 @@ const selectReducer = (
       const start = pageNumbers[i - 1] ? (pageNumbers[i - 1] as number) + 1 : 1
       const end = pageNumbers[i + 1]
         ? (pageNumbers[i + 1] as number)
-        : totalPages
+        : totalPages + 1
 
       r[i] = Array.from<number>({ length: end - start }).map(
         (v, i) => i + start
@@ -139,15 +139,21 @@ const Pagination: React.FC<Props> = ({
   const { theme }: any = useThemeUI()
   const morePage = React.useRef<HTMLSelectElement | null>(null)
 
-  const numbers = getNumbers(currentPage, totalPages, minimized)
+  const [numbers, setNumbers] = React.useState<PaginationNumbers>(
+    getNumbers(currentPage, totalPages, minimized)
+  )
 
   const [selectPages, setSelectPages] = React.useState<SelectPages>(
     selectReducer(numbers, totalPages)
   )
 
+  React.useEffect(
+    () => setNumbers(getNumbers(currentPage, totalPages, minimized)),
+    [minimized, currentPage]
+  )
+
   React.useEffect(() => setSelectPages(selectReducer(numbers, totalPages)), [
-    minimized,
-    currentPage
+    numbers
   ])
 
   const liStyling = {

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -156,6 +156,10 @@ const Pagination: React.FC<Props> = ({
     numbers
   ])
 
+  React.useEffect(() => {
+    if (morePage.current) morePage.current.value = ''
+  }, [selectPages])
+
   const liStyling = {
     display: 'inline-block',
     padding: 'xs',
@@ -266,6 +270,8 @@ const Pagination: React.FC<Props> = ({
 
               <select
                 ref={morePage}
+                defaultChecked={false}
+                defaultValue={''}
                 onChange={e => {
                   onPageChange(parseInt(e.currentTarget.value), e)
                   e.currentTarget.value = '...'


### PR DESCRIPTION
# Description

This should fix:
- bug: on Android phones native select wouldn't change the page
- bug: on Mac OS and iOS devices native select wouldn't change to the page if it was first in list
- bug: no last page in select list
- bug: list of numbers and "..." wouldn't update on current page change

# Checklist

Pull request contains:

- [ ] A new component
- [ xxx ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ x ] Work has been tested in multiple browsers
- [ x ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
