### PR TITLE
fix: uswitch sponsored-by-tag

### DIFF
--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.23](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.22...@uswitch/trustyle.side-nav@1.0.23) (2020-10-28)
+
+**Note:** Version bump only for package @uswitch/trustyle.side-nav
+
+
+
+
+
 ## [1.0.22](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.21...@uswitch/trustyle.side-nav@1.0.22) (2020-10-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-nav

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.9.5"
+    "@uswitch/trustyle.accordion": "^0.9.6"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.7...@uswitch/trustyle.sponsored-product-rate-table@3.1.8) (2020-10-28)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.1.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.6...@uswitch/trustyle.sponsored-product-rate-table@3.1.7) (2020-10-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.icon": "^1.16.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.5",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.0.5",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.1.0",
     "@uswitch/trustyle.usp-tag": "^0.1.5"
   }
 }

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.12...@uswitch/trustyle.sponsored-product@3.1.13) (2020-10-28)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.1.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.11...@uswitch/trustyle.sponsored-product@3.1.12) (2020-10-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,7 +21,7 @@
     "@uswitch/trustyle.icon": "^1.16.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.5",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.0.5",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.1.0",
     "@uswitch/trustyle.usp-tag": "^0.1.5"
   }
 }

--- a/src/elements/accordion/CHANGELOG.md
+++ b/src/elements/accordion/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.9.5...@uswitch/trustyle.accordion@0.9.6) (2020-10-28)
+
+**Note:** Version bump only for package @uswitch/trustyle.accordion
+
+
+
+
+
 ## [0.9.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.9.4...@uswitch/trustyle.accordion@0.9.5) (2020-10-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.accordion

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.26](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.25...@uswitch/trustyle.embedded-video@0.4.26) (2020-10-28)
+
+**Note:** Version bump only for package @uswitch/trustyle.embedded-video
+
+
+
+
+
 ## [0.4.25](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.24...@uswitch/trustyle.embedded-video@0.4.25) (2020-10-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.9.5"
+    "@uswitch/trustyle.accordion": "^0.9.6"
   }
 }

--- a/src/elements/sponsored-by-tag/CHANGELOG.md
+++ b/src/elements/sponsored-by-tag/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.0.5...@uswitch/trustyle.sponsored-by-tag@2.1.0) (2020-10-28)
+
+
+### Features
+
+* hero variant for sponsored-by-tag ([2236321](https://github.com/uswitch/trustyle/commit/2236321))
+
+
+
+
+
 ## [2.0.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.0.1...@uswitch/trustyle.sponsored-by-tag@2.0.2) (2020-08-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-by-tag

--- a/src/elements/sponsored-by-tag/package.json
+++ b/src/elements/sponsored-by-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-by-tag",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -4,28 +4,35 @@ import * as React from 'react'
 import { jsx } from 'theme-ui'
 import { ImgixImage } from '@uswitch/trustyle.imgix-image'
 
+const lookup = (variant: string) =>
+  variant === 'base'
+    ? 'elements.sponsored-by-tag.base'
+    : `elements.sponsored-by-tag.variants.${variant}`
+
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   providerLogoSrc: string
   className?: string
   providerText?: string
   providerName: string
+  variant?: 'base' | 'hero'
 }
 
 const SponsoredByTag: React.FC<Props> = ({
   providerLogoSrc,
   className = '',
   providerText = 'Sponsored by',
-  providerName
+  providerName,
+  variant = 'base'
 }) => (
   <div
     className={className}
     sx={{
-      variant: 'elements.sponsored-by-tag.base.wrapper'
+      variant: `${lookup(variant)}.wrapper`
     }}
   >
     <span
       sx={{
-        variant: 'elements.sponsored-by-tag.base.text'
+        variant: `${lookup(variant)}.text`
       }}
     >
       {providerText}
@@ -37,7 +44,7 @@ const SponsoredByTag: React.FC<Props> = ({
       imgixParams={{ fit: 'clip' }}
       critical
       sx={{
-        variant: 'elements.sponsored-by-tag.base.image'
+        variant: `${lookup(variant)}.image`
       }}
     />
   </div>

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -45,6 +45,26 @@ export const ExampleWithTextProp = () => {
   )
 }
 
+export const ExampleWithHeroVariant = () => {
+  const providerName: string = text('Provider name', 'Three')
+  const providerLogo: string = text(
+    'Provider logo url',
+    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+  )
+
+  const providerText: string = text('Text to display', 'This is example text')
+  return (
+    <React.Fragment>
+      <SponsoredByTag
+        providerLogoSrc={providerLogo}
+        providerText={providerText}
+        providerName={providerName}
+        variant="hero"
+      />
+    </React.Fragment>
+  )
+}
+
 ExampleWithDefaultText.story = {
   parameters: {
     percy: { skip: true }
@@ -57,6 +77,11 @@ ExampleWithTextProp.story = {
   }
 }
 
+ExampleWithHeroVariant.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
 export const AutomatedTests = () => {
   return (
     <AllThemes>

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.30.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.30.0...@uswitch/trustyle.money-theme@1.30.1) (2020-10-28)
+
+**Note:** Version bump only for package @uswitch/trustyle.money-theme
+
+
+
+
+
 # [1.30.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.29.0...@uswitch/trustyle.money-theme@1.30.0) (2020-10-28)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.27.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.26.0...@uswitch/trustyle.uswitch-theme@2.27.0) (2020-10-28)
+
+
+### Features
+
+* hero variant for sponsored-by-tag ([2236321](https://github.com/uswitch/trustyle/commit/2236321))
+
+
+
+
+
 # [2.26.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.25.0...@uswitch/trustyle.uswitch-theme@2.26.0) (2020-10-22)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1549,6 +1549,21 @@
         "image": {
           "height": [40, 56]
         }
+      },
+      "variants": {
+        "hero": {
+          "wrapper": {
+            "variant": "elements.sponsored-by-tag.base.wrapper",
+            "justifyContent": "flex-start"
+          },
+          "text": {
+            "variant": "elements.sponsored-by-tag.base.text"
+          },
+          "image": {
+            "variant": "elements.sponsored-by-tag.base.image",
+            "height": [40, 24]
+          }
+        }
       }
     },
     "sponsorship": {


### PR DESCRIPTION
# Description

Fixing sponsored tag styling as per https://www.figma.com/file/PAhSkRBmvjcxHWAnxLUYEy/Finance---heroes?node-id=26%3A6

![Screenshot 2020-10-26 at 14 37 37](https://user-images.githubusercontent.com/14987594/97186250-f5214c00-1798-11eb-9bd6-0e90283096d5.png)
![Screenshot 2020-10-26 at 14 37 49](https://user-images.githubusercontent.com/14987594/97186260-f94d6980-1798-11eb-8b46-ee01c92f496f.png)


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.

