### PR TITLE
fix: force first render to be for desktop

### DIFF
--- a/src/elements/pagination/CHANGELOG.md
+++ b/src/elements/pagination/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.5.2...@uswitch/trustyle.pagination@1.5.3) (2020-10-26)
+
+
+### Bug Fixes
+
+* force first render to befor desktop ([8a1c49d](https://github.com/uswitch/trustyle/commit/8a1c49d))
+
+
+
+
+
 ## [1.5.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.pagination@1.5.1...@uswitch/trustyle.pagination@1.5.2) (2020-10-23)
 
 

--- a/src/elements/pagination/package.json
+++ b/src/elements/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.pagination",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/pagination/src/index.tsx
+++ b/src/elements/pagination/src/index.tsx
@@ -140,7 +140,7 @@ const Pagination: React.FC<Props> = ({
   const morePage = React.useRef<HTMLSelectElement | null>(null)
 
   const [numbers, setNumbers] = React.useState<PaginationNumbers>(
-    getNumbers(currentPage, totalPages, minimized)
+    getNumbers(currentPage, totalPages, false)
   )
 
   const [selectPages, setSelectPages] = React.useState<SelectPages>(


### PR DESCRIPTION
# Description

For some reason if the first render is set to the value of minimized variable it fails to update. Changed it for now.

# Checklist

Pull request contains:

- [ ] A new component
- [ x ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ x ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
