### PR TITLE
fix: margin left to uswitch sponsored by tag image

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.27.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.27.2...@uswitch/trustyle.uswitch-theme@2.27.3) (2020-10-29)
+
+
+### Bug Fixes
+
+* margin left to uswitch sponsored by tag image ([9ebcd26](https://github.com/uswitch/trustyle/commit/9ebcd26))
+
+
+
+
+
 ## [2.27.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.27.0...@uswitch/trustyle.uswitch-theme@2.27.1) (2020-10-28)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1561,7 +1561,8 @@
           },
           "image": {
             "variant": "elements.sponsored-by-tag.base.image",
-            "height": [40, 24]
+            "height": [40, 24],
+            "ml": "xxs"
           }
         }
       }


### PR DESCRIPTION
# Description

Increase margin left for the image in the sponsored by tag

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
