### PR TITLE
fix: allow button to be clicked inside of eligibility criteria

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.12.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.12.2...@uswitch/trustyle.product-table@2.12.3) (2020-11-03)
+
+
+### Bug Fixes
+
+* allow button to be clicked inside of eligibility criteria ([3d31db4](https://github.com/uswitch/trustyle/commit/3d31db4))
+* refactor handleClick ([75db3a7](https://github.com/uswitch/trustyle/commit/75db3a7))
+
+
+
+
+
 ## [2.12.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.12.1...@uswitch/trustyle.product-table@2.12.2) (2020-10-29)
 
 

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/rowWrapper.tsx
+++ b/src/compounds/product-table/src/components/rowWrapper.tsx
@@ -34,13 +34,11 @@ const linkWrapper = (
   headerImage?: React.ReactNode
 ) => {
   const handleClick = (e: any) => {
-    if (checkClickTargetIsLink(e)) {
-      return e
-    }
-
-    if (checkClickTargetIsAccordion(10, e)) {
+    if (checkClickTargetIsAccordion(10, e) && !checkClickTargetIsLink(e)) {
       e.preventDefault()
     }
+
+    return e
   }
 
   return (

--- a/src/compounds/product-table/src/components/rowWrapper.tsx
+++ b/src/compounds/product-table/src/components/rowWrapper.tsx
@@ -22,12 +22,22 @@ const checkClickTargetIsAccordion = (n: number, e: any) => {
   return false
 }
 
+const checkClickTargetIsLink = (e: any) => {
+  if (e.target.nodeName.toLowerCase() === 'a') {
+    return true
+  }
+}
+
 const linkWrapper = (
   link: string,
   children: React.ReactNode,
   headerImage?: React.ReactNode
 ) => {
   const handleClick = (e: any) => {
+    if (checkClickTargetIsLink(e)) {
+      return e
+    }
+
     if (checkClickTargetIsAccordion(10, e)) {
       e.preventDefault()
     }


### PR DESCRIPTION
# Description

Fix bug that did not allow buttons to be clicked inside of eligibility criteria section of the product table 

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
