### PR TITLE
fix: fourth column on product tables

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.12.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.12.3...@uswitch/trustyle.product-table@2.12.4) (2020-11-04)
+
+
+### Bug Fixes
+
+* fourth column on product tables ([fd18f09](https://github.com/uswitch/trustyle/commit/fd18f09))
+
+
+
+
+
 ## [2.12.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.12.2...@uswitch/trustyle.product-table@2.12.3) (2020-11-03)
 
 

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -6,6 +6,7 @@ import { Addon, AddonArg, CellContext } from '../generics'
 
 import ProductTableCellBase from './cell-base'
 import ProductTableCellCta from './cell-cta'
+import ProductTableCellImage from './cell-image'
 import { ROWS } from './cell-split'
 import RowWrapper from './rowWrapper'
 import Header from './header'
@@ -73,6 +74,10 @@ const ProductTableRow: React.FC<RowProps> = ({
   }
 
   const cols = nonNullChildren.length
+
+  const hasCellImage = nonNullChildren
+    .map((child: any) => child.type)
+    .includes(ProductTableCellImage)
 
   /**
    * Row numbers explained:
@@ -170,7 +175,7 @@ const ProductTableRow: React.FC<RowProps> = ({
                 gridRowStart: 4,
                 gridRowSpan: ROWS,
                 gridColumnStart:
-                  image && child.type === ProductTableCellCta
+                  image && hasCellImage && child.type === ProductTableCellCta
                     ? index
                     : index + 1,
                 gridColumnSpan: 1,
@@ -181,7 +186,9 @@ const ProductTableRow: React.FC<RowProps> = ({
                   variant:
                     image &&
                     child.type !== ProductTableCellCta &&
-                    'compounds.product-table.variants.redesign.cellContext.main'
+                    `compounds.product-table.variants.redesign.cellContext.${
+                      hasCellImage ? 'variants.cellImage' : 'main'
+                    }`
                 }
               }}
               key={index}

--- a/src/compounds/product-table/src/stories.tsx
+++ b/src/compounds/product-table/src/stories.tsx
@@ -733,6 +733,92 @@ MoneyRedesignExample.story = {
   }
 }
 
+export const MoneyRedesignExampleNoImage = () => {
+  return (
+    <ProductTable.Row
+      rowTitle="Santander Standard Loan (Online)"
+      image={
+        <ProductTable.cells.HeaderImage>
+          <img
+            src="https://placekitten.com/200/75?image=9"
+            alt="Salman"
+            sx={{ height: 75, width: '100%', objectFit: 'cover' }}
+          />
+        </ProductTable.cells.HeaderImage>
+      }
+      addons={[
+        {
+          addon: ProductTable.addons.info,
+          component: (
+            <ProductTable.cells.Base sx={{ display: 'block' }}>
+              <div sx={{ fontWeight: 'bold', display: ['none', 'block'] }}>
+                Additional information:
+              </div>
+              <div>
+                Here is some extra information. Here is even more extra
+                information. And more extra information.
+              </div>
+            </ProductTable.cells.Base>
+          ),
+          options: {
+            split: true,
+            headerImage: true
+          }
+        },
+        {
+          addon: ProductTable.addons.footer,
+          component: (
+            <ProductTable.cells.Base sx={{ display: 'block' }}>
+              <div sx={{ fontWeight: 'bold', display: ['inline', 'block'] }}>
+                Representative example:
+              </div>
+              <div>Assumed borrowing of £10,000 over...</div>
+            </ProductTable.cells.Base>
+          ),
+          options: {
+            split: true,
+            headerImage: true
+          }
+        },
+        {
+          addon: ProductTable.addons.accordion,
+          component: (
+            <ProductTable.cells.Base sx={{ display: 'block' }}>
+              <div sx={{ fontSize: ['xxs', 'xs'] }}>More info</div>
+            </ProductTable.cells.Base>
+          )
+        }
+      ]}
+    >
+      <ProductTable.cells.Content label="Loan Amount" headerImage>
+        <ProductTable.data.Auto text="£1000 to £10000" headerImage />
+      </ProductTable.cells.Content>
+      <ProductTable.cells.Content label="Representative APR" headerImage>
+        <ProductTable.data.Auto
+          text="49.9% APR (£1,000 to £10,000)"
+          headerImage
+        />
+      </ProductTable.cells.Content>
+      <ProductTable.cells.Content label="Loan Term" headerImage>
+        <ProductTable.data.Auto text="1 year to 5 years" headerImage />
+      </ProductTable.cells.Content>
+      <ProductTable.cells.Content label="Monthly Cost" headerImage>
+        <ProductTable.data.Auto text="£100,000" headerImage />
+      </ProductTable.cells.Content>
+      <ProductTable.cells.Cta
+        primary={<ButtonLink variant="primary">Apply now</ButtonLink>}
+        headerImage
+      />
+    </ProductTable.Row>
+  )
+}
+
+MoneyRedesignExampleNoImage.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 export const DisabledExample = () => {
   return (
     <React.Fragment>

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.31.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.31.1...@uswitch/trustyle.money-theme@1.31.2) (2020-11-04)
+
+
+### Bug Fixes
+
+* fourth column on product tables ([fd18f09](https://github.com/uswitch/trustyle/commit/fd18f09))
+
+
+
+
+
 # [1.31.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.30.1...@uswitch/trustyle.money-theme@1.31.0) (2020-10-28)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1860,7 +1860,7 @@
                 ":nth-child(4)": {
                   "borderBottom": "none",
                   "display": ["block", "none"]
-                }  
+                }
               }
             }
           }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1844,10 +1844,6 @@
                 "borderBottomColor": "#E7BBC8",
                 "color": ["fuschia", "grey-80"]
               },
-              ":nth-child(4)": {
-                "borderBottom": "none",
-                "display": ["block", "none"]
-              },
               "::before": {
                 "position": "absolute",
                 "display": "block",
@@ -1856,6 +1852,15 @@
                 "borderLeft": ["none", "1px solid #C2C4C8"],
                 "left": 0,
                 "top": 0
+              }
+            },
+            "variants": {
+              "cellImage": {
+                "variant": "compounds.product-table.variants.redesign.cellContext.main",
+                ":nth-child(4)": {
+                  "borderBottom": "none",
+                  "display": ["block", "none"]
+                }  
               }
             }
           }

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.27.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.27.4...@uswitch/trustyle.uswitch-theme@2.27.5) (2020-11-04)
+
+
+### Bug Fixes
+
+* fourth column on product tables ([fd18f09](https://github.com/uswitch/trustyle/commit/fd18f09))
+
+
+
+
+
 ## [2.27.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.27.3...@uswitch/trustyle.uswitch-theme@2.27.4) (2020-10-29)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.27.4",
+  "version": "2.27.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1978,9 +1978,14 @@
                 "borderLeft": ["none", "1px solid #D0D0D3"],
                 "left": 0,
                 "top": 0
-              },
-              ":nth-child(4)": {
-                "display": ["block", "none"]
+              }
+            },
+            "variants": {
+              "cellImage": {
+                "variant": "compounds.product-table.variants.redesign.cellContext.main",
+                ":nth-child(4)": {
+                  "display": ["block", "none"]
+                }
               }
             }
           }


### PR DESCRIPTION
# Description

Don't render fourth column on desktop only on redesign if image is in the cell content (used for Money mobile redesign)

![image](https://user-images.githubusercontent.com/56200818/98100230-76a76700-1e88-11eb-91e5-1c6015e13641.png)


Before:
4th column of data not showing

![image](https://user-images.githubusercontent.com/56200818/98100168-63949700-1e88-11eb-9be7-e25e9d29bde6.png)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
