### PR TITLE
Make danger provide message instead of fail for non semantic commits

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,4 +1,4 @@
-import { danger, fail, message } from 'danger'
+import { danger, message } from 'danger'
 
 const modifiedMD = danger.git.modified_files.join('- ')
 message('Changed Files in this PR: \n - ' + modifiedMD)
@@ -16,7 +16,7 @@ danger.git.commits.forEach(commit => {
       /^(feat:)|(fix:)|(major:)|(chore:)|(docs:)|Merge branch/g
     )
   ) {
-    fail(
+    message(
       `Commit message '${commit.message}' does match the correct format. Please follow [conventional commits](https://www.conventionalcommits.org)`
     )
   }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,4 +1,4 @@
-import { danger, message } from 'danger'
+import { danger, message, warn } from 'danger'
 
 const modifiedMD = danger.git.modified_files.join('- ')
 message('Changed Files in this PR: \n - ' + modifiedMD)
@@ -16,7 +16,7 @@ danger.git.commits.forEach(commit => {
       /^(feat:)|(fix:)|(major:)|(chore:)|(docs:)|Merge branch/g
     )
   ) {
-    message(
+    warn(
       `Commit message '${commit.message}' does match the correct format. Please follow [conventional commits](https://www.conventionalcommits.org)`
     )
   }


### PR DESCRIPTION
As we are not using semantic commits for anything under the hood having them fail the build is OTT