### PR TITLE
chore: import specific icons from src to avoid importing all icons

### DIFF
--- a/src/compounds/ad-banner/CHANGELOG.md
+++ b/src/compounds/ad-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.ad-banner@2.3.4...@uswitch/trustyle.ad-banner@2.3.5) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.ad-banner
+
+
+
+
+
 ## [2.3.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.ad-banner@2.3.3...@uswitch/trustyle.ad-banner@2.3.4) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.ad-banner

--- a/src/compounds/ad-banner/package.json
+++ b/src/compounds/ad-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.ad-banner",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle.awards-tag": "^0.2.0",
-    "@uswitch/trustyle.button-link": "^2.1.7",
+    "@uswitch/trustyle.button-link": "^3.0.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40"
   }
 }

--- a/src/compounds/hero-card/CHANGELOG.md
+++ b/src/compounds/hero-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-card@2.0.10...@uswitch/trustyle.hero-card@2.0.11) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.hero-card
+
+
+
+
+
 ## [2.0.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-card@2.0.9...@uswitch/trustyle.hero-card@2.0.10) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.hero-card

--- a/src/compounds/hero-card/package.json
+++ b/src/compounds/hero-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero-card",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.button-link": "^2.1.7"
+    "@uswitch/trustyle.button-link": "^3.0.0"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.18](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.17...@uswitch/trustyle.sponsored-product-rate-table@3.1.18) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.1.17](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.1.16...@uswitch/trustyle.sponsored-product-rate-table@3.1.17) (2020-11-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.1.17",
+  "version": "3.1.18",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -14,8 +14,8 @@
   "dependencies": {
     "@uswitch/trustyle.arrangement": "^2.0.20",
     "@uswitch/trustyle.awards-tag": "^0.2.0",
-    "@uswitch/trustyle.button": "^2.4.5",
-    "@uswitch/trustyle.button-link": "^2.1.7",
+    "@uswitch/trustyle.button": "^3.0.0",
+    "@uswitch/trustyle.button-link": "^3.0.0",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.icon": "^1.17.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40",

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.3.0...@uswitch/trustyle.sponsored-product@3.3.1) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 # [3.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.2.0...@uswitch/trustyle.sponsored-product@3.3.0) (2020-11-13)
 
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -15,7 +15,7 @@
     "@uswitch/trustyle.arrangement": "^2.0.20",
     "@uswitch/trustyle.awards-tag": "^0.2.0",
     "@uswitch/trustyle.badge": "^2.0.4",
-    "@uswitch/trustyle.button-link": "^2.1.7",
+    "@uswitch/trustyle.button-link": "^3.0.0",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.icon": "^1.17.1",

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { jsx } from 'theme-ui'
-import { Icon } from '@uswitch/trustyle.icon'
+import { Caret } from '@uswitch/trustyle.icon/src/caret'
 import { ButtonLink } from '@uswitch/trustyle.button-link'
 import PrimaryInfoBlock from '@uswitch/trustyle.primary-info-block'
 import UspTag from '@uswitch/trustyle.usp-tag'
@@ -336,10 +336,9 @@ const SponsoredProduct: React.FC<Props> = ({
                 marginBottom: 'sm'
               }}
             >
-              <Icon
+              <Caret
                 color="white"
                 direction="right"
-                glyph="caret"
                 size={20}
                 sx={{
                   flexShrink: 0

--- a/src/elements/button-link/CHANGELOG.md
+++ b/src/elements/button-link/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button-link@2.1.7...@uswitch/trustyle.button-link@3.0.0) (2020-11-13)
+
+
+### Features
+
+* remove unused icon dependency ([bcbfc03](https://github.com/uswitch/trustyle/commit/bcbfc03))
+
+
+### BREAKING CHANGES
+
+* Buttons will no longer accept before/after Icon properties
+
+
+
+
+
 ## [2.1.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button-link@2.1.6...@uswitch/trustyle.button-link@2.1.7) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.button-link

--- a/src/elements/button-link/package.json
+++ b/src/elements/button-link/package.json
@@ -17,7 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.icon": "^1.17.1"
+    "@uswitch/trustyle-utils.get": "^1.0.9"
   }
 }

--- a/src/elements/button-link/package.json
+++ b/src/elements/button-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button-link",
-  "version": "2.1.7",
+  "version": "3.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button-link/src/index.tsx
+++ b/src/elements/button-link/src/index.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { jsx, Styled, useThemeUI } from 'theme-ui'
-import { Glyph, Icon } from '@uswitch/trustyle.icon'
 import get from '@uswitch/trustyle-utils.get'
 
 type Overwrite<T, U> = Omit<T, keyof U> & U
@@ -26,8 +25,6 @@ export const ButtonLink = <
   children,
   variant,
   size = 'large',
-  beforeIcon,
-  afterIcon,
   ...props
 }: Props<T>) => {
   const { theme }: any = useThemeUI()
@@ -64,21 +61,7 @@ export const ButtonLink = <
       }}
       {...props}
     >
-      {beforeIcon && (
-        <span
-          sx={{ variant: `elements.buttons.variants.${variant}.beforeIcon` }}
-        >
-          <Icon color="white" glyph={beforeIcon as Glyph} direction="left" />
-        </span>
-      )}
       {children}
-      {afterIcon && (
-        <span
-          sx={{ variant: `elements.buttons.variants.${variant}.afterIcon` }}
-        >
-          <Icon color="white" glyph={afterIcon as Glyph} direction="right" />
-        </span>
-      )}
     </Styled.a>
   )
 }

--- a/src/elements/button/CHANGELOG.md
+++ b/src/elements/button/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button@2.4.5...@uswitch/trustyle.button@3.0.0) (2020-11-13)
+
+
+### Features
+
+* remove unused icon dependency ([bcbfc03](https://github.com/uswitch/trustyle/commit/bcbfc03))
+
+
+### BREAKING CHANGES
+
+* Buttons will no longer accept before/after Icon properties
+
+
+
+
+
 ## [2.4.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button@2.4.4...@uswitch/trustyle.button@2.4.5) (2020-11-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.button

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@theme-ui/color": "^0.3.1",
     "@types/theme-ui__color": "0.3.0",
-    "@uswitch/trustyle-utils.get": "^1.0.7",
-    "@uswitch/trustyle.icon": "^1.17.1"
+    "@uswitch/trustyle-utils.get": "^1.0.7"
   }
 }

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "2.4.5",
+  "version": "3.0.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
 import { darken } from '@theme-ui/color'
 import get from '@uswitch/trustyle-utils.get'
-import { Glyph, Icon } from '@uswitch/trustyle.icon'
 
 export type Variant =
   | 'primary'
@@ -23,8 +22,6 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   iconPosition?: IconPosition
   inverse?: boolean
   size?: string
-  beforeIcon?: string
-  afterIcon?: string
 }
 
 const invertTheme = (theme: any, variant: any = {}) => {
@@ -63,8 +60,6 @@ export const Button: React.FC<Props> = ({
   onClick,
   size = 'large',
   inverse = false,
-  beforeIcon,
-  afterIcon,
   ...props
 }) => {
   const { theme }: any = useThemeUI()
@@ -116,13 +111,7 @@ export const Button: React.FC<Props> = ({
       onClick={onClick}
       {...props}
     >
-      {beforeIcon && (
-        <Icon color="white" glyph={beforeIcon as Glyph} direction="left" />
-      )}
       {children}
-      {afterIcon && (
-        <Icon color="white" glyph={afterIcon as Glyph} direction="right" />
-      )}
     </button>
   )
 }

--- a/src/elements/cta/CHANGELOG.md
+++ b/src/elements/cta/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.cta@1.0.10...@uswitch/trustyle.cta@1.0.11) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.cta
+
+
+
+
+
 ## [1.0.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.cta@1.0.9...@uswitch/trustyle.cta@1.0.10) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.cta

--- a/src/elements/cta/package.json
+++ b/src/elements/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.cta",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.button-link": "^2.1.7"
+    "@uswitch/trustyle.button-link": "^3.0.0"
   }
 }

--- a/src/elements/drop-down/CHANGELOG.md
+++ b/src/elements/drop-down/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.drop-down@2.3.11...@uswitch/trustyle.drop-down@2.3.12) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.drop-down
+
+
+
+
+
 ## [2.3.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.drop-down@2.3.10...@uswitch/trustyle.drop-down@2.3.11) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.drop-down

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.frozen-input": "^3.0.19",
+    "@uswitch/trustyle.frozen-input": "^3.0.20",
     "@uswitch/trustyle.icon": "^1.17.1",
     "@uswitch/trustyle.styles": "^0.5.6"
   },

--- a/src/elements/frozen-input/CHANGELOG.md
+++ b/src/elements/frozen-input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.20](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.frozen-input@3.0.19...@uswitch/trustyle.frozen-input@3.0.20) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.frozen-input
+
+
+
+
+
 ## [3.0.19](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.frozen-input@3.0.18...@uswitch/trustyle.frozen-input@3.0.19) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.frozen-input

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -2,7 +2,8 @@
 
 import { Fragment, useEffect, useState } from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
-import { Icon } from '@uswitch/trustyle.icon'
+import { EditJourney } from '@uswitch/trustyle.icon/src/edit-journey'
+import { Edit } from '@uswitch/trustyle.icon/src/edit'
 import { colors } from '@uswitch/trustyle.styles'
 
 interface Props {
@@ -21,7 +22,7 @@ export const FrozenInput: React.FC<Props> = ({
 }) => {
   const [frozen, setFrozen] = useState(freezable && !!text)
   const { theme }: any = useThemeUI()
-  const iconGlyph = theme?.name === 'Journey' ? 'edit-journey' : 'edit'
+  const IconComponent = theme?.name === 'Journey' ? EditJourney : Edit
   const iconColor =
     (theme && theme.colors[theme.elements.input?.frozen?.button?.color]) ||
     colors.UswitchNavy
@@ -68,7 +69,7 @@ export const FrozenInput: React.FC<Props> = ({
           sx={{ variant: 'elements.input.frozen.button' }}
           onClick={() => setFrozen(false)}
         >
-          <Icon color={iconColor} glyph={iconGlyph} />
+          <IconComponent color={iconColor} />
         </button>
       </div>
 

--- a/src/elements/input/CHANGELOG.md
+++ b/src/elements/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.22](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.21...@uswitch/trustyle.input@2.0.22) (2020-11-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.input
+
+
+
+
+
 ## [2.0.21](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.20...@uswitch/trustyle.input@2.0.21) (2020-11-11)
 
 **Note:** Version bump only for package @uswitch/trustyle.input

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^3.0.19",
+    "@uswitch/trustyle.frozen-input": "^3.0.20",
     "@uswitch/trustyle.icon": "^1.17.1",
     "@uswitch/trustyle.styles": "^0.5.6",
     "react-input-mask": "^2.0.4",


### PR DESCRIPTION
BREAKING CHANGE

# Description
The `trustyle.icon` package brings all the icons with its default export. This makes bundles really bloated when we're only looking to use one or two icons.
The purpose of this PR is to make some components directly import the icons they need.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
