### PR TITLE
feat: usps now array of usps. Means you can pass color for specfic usp.

### DIFF
--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.2.0...@uswitch/trustyle.sponsored-product@3.3.0) (2020-11-13)
+
+
+### Bug Fixes
+
+* Remove unused props. ([559afae](https://github.com/uswitch/trustyle/commit/559afae))
+
+
+### Features
+
+* usps now array of usps. Means you can pass color for specfic usp. ([1ac8f25](https://github.com/uswitch/trustyle/commit/1ac8f25))
+
+
+
+
+
 # [3.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.1.17...@uswitch/trustyle.sponsored-product@3.2.0) (2020-11-11)
 
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -13,12 +13,18 @@ import { Stack } from '@uswitch/trustyle.arrangement'
 import { ImgixImage } from '@uswitch/trustyle.imgix-image'
 import { Container } from '@uswitch/trustyle.flex-grid'
 
+interface Usp {
+  text: string
+  color?: string
+  beforeColor?: string
+}
+
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   title: string
   imgSrc?: string
   imgAlt?: string
   informationDetails?: Detail[]
-  usps?: string[]
+  usps?: Usp[]
   uspBackgroundColor?: string
   uspBeforeColor?: string
   href?: string
@@ -69,24 +75,17 @@ const InformationBlocks: React.FC<InformationBlocksProps> = ({
 )
 
 interface UspTagsProps {
-  usps: string[]
-  uspColor: string
-  beforeColor: string
+  usps: Usp[]
   uspSx?: object
 }
 
-const UspTags: React.FC<UspTagsProps> = ({
-  usps,
-  uspColor,
-  beforeColor,
-  uspSx = {}
-}) => (
+const UspTags: React.FC<UspTagsProps> = ({ usps, uspSx = {} }) => (
   <React.Fragment>
-    {usps.map((obj, index) => (
+    {usps.map((usp, index) => (
       <UspTag
-        usp={obj}
-        backgroundColor={uspColor}
-        beforeColor={beforeColor}
+        usp={usp.text}
+        backgroundColor={usp.color}
+        beforeColor={usp.beforeColor}
         key={index}
         sx={uspSx}
       />

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -25,8 +25,6 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   imgAlt?: string
   informationDetails?: Detail[]
   usps?: Usp[]
-  uspBackgroundColor?: string
-  uspBeforeColor?: string
   href?: string
   target?: string
   sponsorSrc: string
@@ -162,8 +160,6 @@ const SponsoredProduct: React.FC<Props> = ({
   informationDetails,
   badgeVariant = 'sponsored',
   usps,
-  uspBackgroundColor = 'rgba(132,166,255,0.3)',
-  uspBeforeColor = '#84A6FF',
   boxShadowColor = 'rgba(20, 20, 36, 0.15)',
   href = '',
   target = '',
@@ -383,14 +379,7 @@ const SponsoredProduct: React.FC<Props> = ({
             </div>
           )}
 
-          {usps && (
-            <UspTags
-              usps={usps}
-              uspColor={uspBackgroundColor}
-              beforeColor={uspBeforeColor}
-              uspSx={uspSx}
-            />
-          )}
+          {usps && <UspTags usps={usps} uspSx={uspSx} />}
         </Stack>
 
         <div sx={{ display: ['block', 'none'] }}>

--- a/src/compounds/sponsored-product/src/stories.tsx
+++ b/src/compounds/sponsored-product/src/stories.tsx
@@ -20,8 +20,8 @@ export const ExampleWithKnobs = () => {
   )
   const imgAlt = text('Image Alt', 'iPhone 11')
   const usps = [
-    text('USP', 'Free insurance for 2 months'),
-    text('USP2', 'Uswitch Award')
+    { text: text('USP', 'Free insurance for 2 months') },
+    { text: text('USP2', 'Uswitch Award') }
   ]
   const href = text('href', 'https://www.uswitch.com/mobiles/')
   const target = text('target', '_blank')
@@ -88,7 +88,14 @@ export const ExampleWithKnobs = () => {
           <Col offset={[0.05, 2, 2]} span={[4, 4, 4]}>
             <SponsoredProduct
               title={'Sky Superfast Broadband'}
-              usps={['£22 p/m & no setup cost', 'Superfast Broadband ever']}
+              usps={[
+                { text: '£22 p/m & no setup cost' },
+                {
+                  text: 'Superfast Broadband ever',
+                  color: 'linear-gradient(90deg, #C1B0E6 0%, #C1C0FF 100%)',
+                  beforeColor: '#141424'
+                }
+              ]}
               boxShadowColor={'#AC96DE'}
               sponsorName={'Sky'}
               sponsorSrc={


### PR DESCRIPTION
# Description

Allows Sponsored Product usps to be styled individually. Meaning that a specifc usp can be given a different color if so desired.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
