### PR TITLE
Revert using /src/ import for icons as it breaks packages

### DIFF
--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.3.1...@uswitch/trustyle.sponsored-product@3.3.2) (2020-11-16)
+
+
+### Bug Fixes
+
+* revert using /src/ import for icons as it breaks packages ([8a36d29](https://github.com/uswitch/trustyle/commit/8a36d29))
+
+
+
+
+
 ## [3.3.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.3.0...@uswitch/trustyle.sponsored-product@3.3.1) (2020-11-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { jsx } from 'theme-ui'
-import { Caret } from '@uswitch/trustyle.icon/src/caret'
+import { Icon } from '@uswitch/trustyle.icon'
 import { ButtonLink } from '@uswitch/trustyle.button-link'
 import PrimaryInfoBlock from '@uswitch/trustyle.primary-info-block'
 import UspTag from '@uswitch/trustyle.usp-tag'
@@ -331,9 +331,10 @@ const SponsoredProduct: React.FC<Props> = ({
                 marginBottom: 'sm'
               }}
             >
-              <Caret
+              <Icon
                 color="white"
                 direction="right"
+                glyph="caret"
                 size={20}
                 sx={{
                   flexShrink: 0

--- a/src/elements/drop-down/CHANGELOG.md
+++ b/src/elements/drop-down/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.drop-down@2.3.12...@uswitch/trustyle.drop-down@2.3.13) (2020-11-16)
+
+**Note:** Version bump only for package @uswitch/trustyle.drop-down
+
+
+
+
+
 ## [2.3.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.drop-down@2.3.11...@uswitch/trustyle.drop-down@2.3.12) (2020-11-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.drop-down

--- a/src/elements/drop-down/package.json
+++ b/src/elements/drop-down/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.drop-down",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.frozen-input": "^3.0.20",
+    "@uswitch/trustyle.frozen-input": "^3.0.21",
     "@uswitch/trustyle.icon": "^1.17.1",
     "@uswitch/trustyle.styles": "^0.5.6"
   },

--- a/src/elements/frozen-input/CHANGELOG.md
+++ b/src/elements/frozen-input/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.21](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.frozen-input@3.0.20...@uswitch/trustyle.frozen-input@3.0.21) (2020-11-16)
+
+
+### Bug Fixes
+
+* revert using /src/ import for icons as it breaks packages ([8a36d29](https://github.com/uswitch/trustyle/commit/8a36d29))
+
+
+
+
+
 ## [3.0.20](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.frozen-input@3.0.19...@uswitch/trustyle.frozen-input@3.0.20) (2020-11-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.frozen-input

--- a/src/elements/frozen-input/package.json
+++ b/src/elements/frozen-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.frozen-input",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/frozen-input/src/index.tsx
+++ b/src/elements/frozen-input/src/index.tsx
@@ -2,8 +2,7 @@
 
 import { Fragment, useEffect, useState } from 'react'
 import { jsx, useThemeUI } from 'theme-ui'
-import { EditJourney } from '@uswitch/trustyle.icon/src/edit-journey'
-import { Edit } from '@uswitch/trustyle.icon/src/edit'
+import { Icon } from '@uswitch/trustyle.icon'
 import { colors } from '@uswitch/trustyle.styles'
 
 interface Props {
@@ -22,7 +21,7 @@ export const FrozenInput: React.FC<Props> = ({
 }) => {
   const [frozen, setFrozen] = useState(freezable && !!text)
   const { theme }: any = useThemeUI()
-  const IconComponent = theme?.name === 'Journey' ? EditJourney : Edit
+  const iconGlyph = theme?.name === 'Journey' ? 'edit-journey' : 'edit'
   const iconColor =
     (theme && theme.colors[theme.elements.input?.frozen?.button?.color]) ||
     colors.UswitchNavy
@@ -69,7 +68,7 @@ export const FrozenInput: React.FC<Props> = ({
           sx={{ variant: 'elements.input.frozen.button' }}
           onClick={() => setFrozen(false)}
         >
-          <IconComponent color={iconColor} />
+          <Icon color={iconColor} glyph={iconGlyph} />
         </button>
       </div>
 

--- a/src/elements/input/CHANGELOG.md
+++ b/src/elements/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.23](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.22...@uswitch/trustyle.input@2.0.23) (2020-11-16)
+
+**Note:** Version bump only for package @uswitch/trustyle.input
+
+
+
+
+
 ## [2.0.22](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.input@2.0.21...@uswitch/trustyle.input@2.0.22) (2020-11-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.input

--- a/src/elements/input/package.json
+++ b/src/elements/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.input",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@uswitch/trustyle.frozen-input": "^3.0.20",
+    "@uswitch/trustyle.frozen-input": "^3.0.21",
     "@uswitch/trustyle.icon": "^1.17.1",
     "@uswitch/trustyle.styles": "^0.5.6",
     "react-input-mask": "^2.0.4",


### PR DESCRIPTION
# Description

Previous changes to try importing specific trustyle icons by using the /src/[Icon] relative url didn't actually work outside storybook. For that reason this changes are being reverted.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
