### PR TITLE
fix: h2 font size and line height update

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.1.0...@uswitch/trustyle.legacy-product-table@0.1.1) (2020-11-20)
+
+
+### Bug Fixes
+
+* prettier ([2d6c008](https://github.com/uswitch/trustyle/commit/2d6c008))
+
+
+
+
+
+
 # 0.1.0 (2020-11-19)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.30.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.30.6...@uswitch/trustyle.uswitch-theme@2.30.7) (2020-11-20)
+
+
+### Bug Fixes
+
+* h2 font size and line height update ([03972d2](https://github.com/uswitch/trustyle/commit/03972d2))
+
+
+
+
+
+
 ## [2.30.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.30.4...@uswitch/trustyle.uswitch-theme@2.30.6) (2020-11-19)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.30.6",
+  "version": "2.30.7",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -288,7 +288,8 @@
     },
     "h2": {
       "variant": "styles.headings",
-      "fontSize": ["md", "lg", "xl"],
+      "fontSize": ["md", "xl", "xxl"],
+      "lineHeight": ["sm", "xs", "xs"],
       "mt": "lg",
       "mb": "md"
     },


### PR DESCRIPTION
# Description

h2 font size and line height update

# Screenshots

### Desktop
![image](https://user-images.githubusercontent.com/66306693/99803834-5c34e500-2b3a-11eb-803f-81d450e86cb1.png)

### Tablet
![image](https://user-images.githubusercontent.com/66306693/99803861-65be4d00-2b3a-11eb-9114-bdacf449897c.png)

### Mobile
![image](https://user-images.githubusercontent.com/66306693/99803882-6fe04b80-2b3a-11eb-8260-7c28190ced57.png)


# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
