### PR TITLE
feat: enable passing of colour and styling for specific usp

### DIFF
--- a/src/compounds/sponsored-product-rate-table/src/index.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/index.tsx
@@ -17,9 +17,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   productImgSrc: string
   productImgAlt: string
   informationDetails: Detail[]
-  usps: string[]
-  uspBackgroundColor?: string
-  uspBeforeColor?: string
+  usps: Usp[]
   href: string
   target: string
   sponsorLogoSrc: string
@@ -75,20 +73,26 @@ const ProductImage = ({ src, alt }: { src: string; alt: string }) => (
   </React.Fragment>
 )
 
-interface UspTagsProps {
-  usps: string[]
-  uspColor: string
-  beforeColor: string
+interface Usp {
+  text: string
+  color?: string
+  beforeColor?: string
+  uspSx?: object
 }
 
-const UspTags: React.FC<UspTagsProps> = ({ usps, uspColor, beforeColor }) => (
+interface UspTagsProps {
+  usps: Usp[]
+}
+
+const UspTags: React.FC<UspTagsProps> = ({ usps }) => (
   <React.Fragment>
-    {usps.map((obj, index) => (
+    {usps.map((usp, index) => (
       <UspTag
-        usp={obj}
-        backgroundColor={uspColor}
-        beforeColor={beforeColor}
+        usp={usp.text}
+        backgroundColor={usp.color}
+        beforeColor={usp.beforeColor}
         key={index}
+        sx={usp.uspSx}
       />
     ))}
   </React.Fragment>
@@ -150,8 +154,6 @@ const SponsoredRateTable: React.FC<Props> = ({
   informationDetails,
   usps,
   backgroundColor = '#FFFFFF',
-  uspBackgroundColor = 'rgba(132,166,255,0.3)',
-  uspBeforeColor = '#84A6FF',
   href,
   target,
   sponsorLogoSrc,
@@ -281,13 +283,7 @@ const SponsoredRateTable: React.FC<Props> = ({
           <InformationBlocks details={informationDetails} />
         </div>
 
-        {usps && (
-          <UspTags
-            usps={usps}
-            uspColor={uspBackgroundColor}
-            beforeColor={uspBeforeColor}
-          />
-        )}
+        {usps && <UspTags usps={usps} />}
 
         <AwardsTag award={award} sx={{ display: [null, 'none'] }} />
 

--- a/src/compounds/sponsored-product-rate-table/src/stories.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/stories.tsx
@@ -22,8 +22,13 @@ export const ExampleWithKnobs = () => {
   )
   const imgAlt = text('Image Alt', 'iPhone 11')
   const usps = [
-    text('USP', 'Free insurance for 2 months'),
-    text('USP2', 'Second USP')
+    { text: text('USP', 'Free insurance for 2 months') },
+    {
+      text: text('USP2', 'Second USP'),
+      color: 'linear-gradient(90deg, #C1B0E6 0%, #C1C0FF 100%)',
+      beforeColor: '#141424',
+      uspSx: { '> span': { color: '#141424' } }
+    }
   ]
   const backgroundColor = text('Background Colour', '#ff55c4')
   const href = text('href', 'https://www.uswitch.com/mobiles/')

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -30,7 +30,7 @@ const invertTheme = (theme: any, variant: any = {}) => {
   const borderColor = color
 
   const hoverColor = theme.colors[backgroundColor]
-    ? darken(theme.colors[backgroundColor], 0.1)
+    ? darken(theme.colors[backgroundColor], '0.1')
     : null
 
   return {

--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -30,7 +30,7 @@ const invertTheme = (theme: any, variant: any = {}) => {
   const borderColor = color
 
   const hoverColor = theme.colors[backgroundColor]
-    ? darken(theme.colors[backgroundColor], '0.1')
+    ? darken(theme.colors[backgroundColor], 0.1)
     : null
 
   return {


### PR DESCRIPTION
# Description

Make usps an array of usps to give flexibility to style usps differently. 

![Screenshot 2020-11-23 at 11 03 16](https://user-images.githubusercontent.com/49326857/99955021-8e815500-2d7b-11eb-885b-ea72e0c67392.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
