### PR TITLE
Enable styling of specific usps in sponsored product rate table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10811,6 +10811,15 @@
     "@types/theme-ui": {
       "version": "file:types/theme-ui"
     },
+    "@types/theme-ui__color": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/theme-ui__color/-/theme-ui__color-0.3.0.tgz",
+      "integrity": "sha512-Ocb194qCeq+9Le3wC99UBAC8qJxxjSGrjoJULR4pxvJS3lXICW3hSo/dB6CDWvvTLIhtCwasjBa0B3ypw+z0Ww==",
+      "dev": true,
+      "requires": {
+        "polished": "^3.4.1"
+      }
+    },
     "@types/uglify-js": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
@@ -14513,9 +14522,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==",
       "dev": true
     },
     "currently-unhandled": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/react-input-mask": "^2.0.3",
     "@types/react-measure": "^2.0.6",
     "@types/react-transition-group": "^2.9.2",
+    "@types/theme-ui__color": "0.3.0",
     "@types/styled-system": "^5.1.9",
     "@types/webpack-env": "^1.15.2",
     "@typescript-eslint/eslint-plugin": "^1.10.2",

--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.1.1...@uswitch/trustyle.legacy-product-table@0.1.2) (2020-11-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.legacy-product-table
+
+
+
+
+
 ## [0.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.1.0...@uswitch/trustyle.legacy-product-table@0.1.1) (2020-11-20)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.button": "^3.0.0",
+    "@uswitch/trustyle.button": "^3.0.1",
     "@uswitch/trustyle.icon": "^1.18.0"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.2.1...@uswitch/trustyle.sponsored-product-rate-table@3.3.0) (2020-11-23)
+
+
+### Features
+
+* update story for sponsored product rate table ([1226a5c](https://github.com/uswitch/trustyle/commit/1226a5c))
+
+
+
+
+
 ## [3.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.2.0...@uswitch/trustyle.sponsored-product-rate-table@3.2.1) (2020-11-16)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@uswitch/trustyle.arrangement": "^2.0.20",
     "@uswitch/trustyle.awards-tag": "^0.2.0",
-    "@uswitch/trustyle.button": "^3.0.0",
+    "@uswitch/trustyle.button": "^3.0.1",
     "@uswitch/trustyle.button-link": "^3.0.0",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40",

--- a/src/compounds/sponsored-product-rate-table/src/index.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/index.tsx
@@ -17,9 +17,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   productImgSrc: string
   productImgAlt: string
   informationDetails: Detail[]
-  usps: string[]
-  uspBackgroundColor?: string
-  uspBeforeColor?: string
+  usps: Usp[]
   href: string
   target: string
   sponsorLogoSrc: string
@@ -75,20 +73,26 @@ const ProductImage = ({ src, alt }: { src: string; alt: string }) => (
   </React.Fragment>
 )
 
-interface UspTagsProps {
-  usps: string[]
-  uspColor: string
-  beforeColor: string
+interface Usp {
+  text: string
+  color?: string
+  beforeColor?: string
+  uspSx?: object
 }
 
-const UspTags: React.FC<UspTagsProps> = ({ usps, uspColor, beforeColor }) => (
+interface UspTagsProps {
+  usps: Usp[]
+}
+
+const UspTags: React.FC<UspTagsProps> = ({ usps }) => (
   <React.Fragment>
-    {usps.map((obj, index) => (
+    {usps.map((usp, index) => (
       <UspTag
-        usp={obj}
-        backgroundColor={uspColor}
-        beforeColor={beforeColor}
+        usp={usp.text}
+        backgroundColor={usp.color}
+        beforeColor={usp.beforeColor}
         key={index}
+        sx={usp.uspSx}
       />
     ))}
   </React.Fragment>
@@ -150,8 +154,6 @@ const SponsoredRateTable: React.FC<Props> = ({
   informationDetails,
   usps,
   backgroundColor = '#FFFFFF',
-  uspBackgroundColor = 'rgba(132,166,255,0.3)',
-  uspBeforeColor = '#84A6FF',
   href,
   target,
   sponsorLogoSrc,
@@ -281,13 +283,7 @@ const SponsoredRateTable: React.FC<Props> = ({
           <InformationBlocks details={informationDetails} />
         </div>
 
-        {usps && (
-          <UspTags
-            usps={usps}
-            uspColor={uspBackgroundColor}
-            beforeColor={uspBeforeColor}
-          />
-        )}
+        {usps && <UspTags usps={usps} />}
 
         <AwardsTag award={award} sx={{ display: [null, 'none'] }} />
 

--- a/src/compounds/sponsored-product-rate-table/src/stories.tsx
+++ b/src/compounds/sponsored-product-rate-table/src/stories.tsx
@@ -22,8 +22,13 @@ export const ExampleWithKnobs = () => {
   )
   const imgAlt = text('Image Alt', 'iPhone 11')
   const usps = [
-    text('USP', 'Free insurance for 2 months'),
-    text('USP2', 'Second USP')
+    { text: text('USP', 'Free insurance for 2 months') },
+    {
+      text: text('USP2', 'Second USP'),
+      color: 'linear-gradient(90deg, #C1B0E6 0%, #C1C0FF 100%)',
+      beforeColor: '#141424',
+      uspSx: { '> span': { color: '#141424' } }
+    }
   ]
   const backgroundColor = text('Background Colour', '#ff55c4')
   const href = text('href', 'https://www.uswitch.com/mobiles/')

--- a/src/elements/button/CHANGELOG.md
+++ b/src/elements/button/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button@3.0.0...@uswitch/trustyle.button@3.0.1) (2020-11-23)
+
+
+### Bug Fixes
+
+* add csstype dependency to button to fix build ([8219606](https://github.com/uswitch/trustyle/commit/8219606))
+* hoist types package in button dependencies to trustyle package json to fix build error ([2df5b89](https://github.com/uswitch/trustyle/commit/2df5b89))
+
+
+
+
+
 # [3.0.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button@2.4.5...@uswitch/trustyle.button@3.0.0) (2020-11-13)
 
 

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@theme-ui/color": "^0.3.1",
-    "@types/theme-ui__color": "0.3.0",
     "@uswitch/trustyle-utils.get": "^1.0.7"
   }
 }

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -8,6 +8,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "csstype": "^3.0.2",
     "typescript": "^3.6.2"
   },
   "peerDependencies": {

--- a/src/elements/button/package.json
+++ b/src/elements/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",


### PR DESCRIPTION
# Description

Adds flexibility in sponsored product rate table to style specific usps differently. 

![Screenshot 2020-11-23 at 11 03 16](https://user-images.githubusercontent.com/49326857/99955021-8e815500-2d7b-11eb-885b-ea72e0c67392.png)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
