### PR TITLE
fix: Add correct dimensions to provider img

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.0...@uswitch/trustyle.sponsored-product-rate-table@3.3.1) (2020-11-24)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 # [3.3.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.2.1...@uswitch/trustyle.sponsored-product-rate-table@3.3.0) (2020-11-23)
 
 

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.6",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.1.0",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.1.1",
     "@uswitch/trustyle.usp-tag": "^0.1.6"
   },
   "devDependencies": {

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.0...@uswitch/trustyle.sponsored-product@3.5.1) (2020-11-24)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 # [3.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.4.1...@uswitch/trustyle.sponsored-product@3.5.0) (2020-11-24)
 
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,7 +21,7 @@
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.6",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.1.0",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.1.1",
     "@uswitch/trustyle.usp-tag": "^0.1.6"
   },
   "devDependencies": {

--- a/src/elements/sponsored-by-tag/CHANGELOG.md
+++ b/src/elements/sponsored-by-tag/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.1.0...@uswitch/trustyle.sponsored-by-tag@2.1.1) (2020-11-24)
+
+
+### Bug Fixes
+
+* Add correct dimensions to provider img ([bc5b0c0](https://github.com/uswitch/trustyle/commit/bc5b0c0))
+
+
+
+
+
 # [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.0.5...@uswitch/trustyle.sponsored-by-tag@2.1.0) (2020-10-28)
 
 

--- a/src/elements/sponsored-by-tag/package.json
+++ b/src/elements/sponsored-by-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-by-tag",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -43,6 +43,8 @@ const SponsoredByTag: React.FC<Props> = ({
       alt={providerName}
       imgixParams={{ fit: 'clip' }}
       critical
+      height={46}
+      width={92}
       sx={{
         variant: `${lookup(variant)}.image`
       }}

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.23.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.23.1...@uswitch/trustyle.bankrate-theme@2.23.2) (2020-11-24)
+
+
+### Bug Fixes
+
+* Add correct dimensions to provider img ([bc5b0c0](https://github.com/uswitch/trustyle/commit/bc5b0c0))
+
+
+
+
+
 ## [2.23.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.23.0...@uswitch/trustyle.bankrate-theme@2.23.1) (2020-11-10)
 
 

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -302,7 +302,9 @@
           "fontStyle": "normal"
         },
         "image": {
-          "height": [40, 56]
+          "max-height": [42, 46],
+          "max-width": 92,
+          "margin-top": [null, "10px"]
         }
       },
       "pros": {

--- a/src/themes/journey/CHANGELOG.md
+++ b/src/themes/journey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.11.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.11.4...@uswitch/trustyle.journey-theme@2.11.5) (2020-11-24)
+
+
+### Bug Fixes
+
+* Add correct dimensions to provider img ([bc5b0c0](https://github.com/uswitch/trustyle/commit/bc5b0c0))
+
+
+
+
+
 ## [2.11.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.11.3...@uswitch/trustyle.journey-theme@2.11.4) (2020-11-10)
 
 

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -414,7 +414,9 @@
           "fontStyle": "normal"
         },
         "image": {
-          "height": [40, 56]
+          "max-height": [42, 46],
+          "max-width": 92,
+          "margin-top": [null, "10px"]
         }
       }
     },

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.13.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.13.6...@uswitch/trustyle.save-on-energy-theme@1.13.7) (2020-11-24)
+
+
+### Bug Fixes
+
+* Add correct dimensions to provider img ([bc5b0c0](https://github.com/uswitch/trustyle/commit/bc5b0c0))
+
+
+
+
+
 ## [1.13.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.13.5...@uswitch/trustyle.save-on-energy-theme@1.13.6) (2020-11-10)
 
 

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -390,7 +390,9 @@
           "fontStyle": "normal"
         },
         "image": {
-          "height": [40, 56]
+          "max-height": [42, 46],
+          "max-width": 92,
+          "margin-top": [null, "10px"]
         }
       }
     },

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.30.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.30.7...@uswitch/trustyle.uswitch-theme@2.30.8) (2020-11-24)
+
+
+### Bug Fixes
+
+* Add correct dimensions to provider img ([bc5b0c0](https://github.com/uswitch/trustyle/commit/bc5b0c0))
+
+
+
+
+
 ## [2.30.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.30.6...@uswitch/trustyle.uswitch-theme@2.30.7) (2020-11-20)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.30.7",
+  "version": "2.30.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1758,7 +1758,9 @@
           "fontStyle": "normal"
         },
         "image": {
-          "height": [40, 56]
+          "max-height": [42, 46],
+          "max-width": 92,
+          "margin-top": [null, "10px"]
         }
       },
       "variants": {


### PR DESCRIPTION
# Description

The provider image is being loaded with a massive resolution when we only display a max of 92x46.
This ensures that we don't exceed those dimensions and load an image that is appropriate. We were loading a massive image before.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
