### PR TITLE
fix: legacy product table eligibility bugs and styling 

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.2.1...@uswitch/trustyle.legacy-product-table@0.2.2) (2020-11-26)
+
+
+### Bug Fixes
+
+* eligibility bugs and data cell fonts ([3d27e1c](https://github.com/uswitch/trustyle/commit/3d27e1c))
+
+
+
+
+
 ## [0.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.2.0...@uswitch/trustyle.legacy-product-table@0.2.1) (2020-11-24)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -106,6 +106,7 @@ export const ImageCell: React.FC<React.HTMLAttributes<any>> = ({
 interface DataCellProps extends React.HTMLAttributes<HTMLDivElement> {
   backgroundColor?: string
   borderBottomColor?: string
+  color?: string
   label?: string
 }
 
@@ -113,6 +114,7 @@ export const DataCell: React.FC<DataCellProps> = ({
   children,
   backgroundColor,
   borderBottomColor,
+  color,
   label
 }) => {
   return (
@@ -138,7 +140,7 @@ export const DataCell: React.FC<DataCellProps> = ({
           display: 'flex',
           justifyContent: 'center',
           padding: '5px 5px 0px',
-          color: borderBottomColor
+          color
         }}
       >
         {label}
@@ -191,14 +193,20 @@ export const CtaCell: React.FC<CtaCellProps> = ({ children, styles, href }) => {
   )
 }
 
-const MobileEligibility: React.FC<React.HTMLAttributes<any>> = ({
+interface MobileEligibilityProps
+  extends React.MapHTMLAttributes<HTMLDivElement> {
+  href?: string
+}
+
+const MobileEligibility: React.FC<MobileEligibilityProps> = ({
   children,
-  className
+  className,
+  href
 }) => {
   const [open, setOpen] = React.useState(false)
 
   return (
-    <div className={className}>
+    <div className={className} sx={{ display: ['block', 'none'] }}>
       <div
         sx={{
           background: '#f2f3f4',
@@ -208,7 +216,7 @@ const MobileEligibility: React.FC<React.HTMLAttributes<any>> = ({
           fontSize: '14px',
           overflow: 'hidden',
           boxSizing: 'border-box',
-          display: 'block'
+          display: ['block', 'none']
         }}
       >
         <div sx={{ padding: '15px 20px 20px' }}>
@@ -238,6 +246,7 @@ const MobileEligibility: React.FC<React.HTMLAttributes<any>> = ({
             mx: '20px',
             padding: '.9em 1.85em'
           }}
+          href={href}
         >
           See Deal
         </CtaCell>
@@ -253,7 +262,7 @@ const MobileEligibility: React.FC<React.HTMLAttributes<any>> = ({
           padding: '8px',
           lineHeight: '1.618em',
           color: '#34454E',
-          display: 'flex',
+          display: ['flex', 'none'],
           alignItems: 'center',
           justifyContent: 'center',
           fontSize: '13px',
@@ -430,15 +439,20 @@ export const EligibilityContentRow: React.FC<EligibilityContentRowProps> = ({
 interface EligibilityProps extends React.HTMLAttributes<HTMLDivElement> {
   hover: boolean
   eligibilityContent: React.ReactNode[]
+  clickableRow?: string
 }
 
 const Eligibility: React.FC<EligibilityProps> = ({
   hover,
-  eligibilityContent
+  eligibilityContent,
+  clickableRow
 }) => {
   return (
     <div>
-      <MobileEligibility sx={{ display: ['block', 'none'] }}>
+      <MobileEligibility
+        sx={{ display: ['block', 'none'] }}
+        href={clickableRow}
+      >
         {eligibilityContent.map(item => {
           return item
         })}
@@ -494,7 +508,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
           sx={{
             display: ['initial', 'flex'],
             width: '100%',
-            padding: ['0', '0 15px 10px'],
+            paddingX: ['0', '15px'],
             boxSizing: 'border-box'
           }}
         >
@@ -510,7 +524,11 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
         <Footer>{representativeExample}</Footer>
       </RowWrapper>
 
-      <Eligibility hover={hover} eligibilityContent={eligibilityContent} />
+      <Eligibility
+        hover={hover}
+        eligibilityContent={eligibilityContent}
+        clickableRow={clickableRow}
+      />
     </article>
   )
 }


### PR DESCRIPTION
# Description

* Fix bug where mobile eligibility was also showing on desktop
* Fix font colors for data cells

![image](https://user-images.githubusercontent.com/56200818/100344348-938f1000-2fd8-11eb-8179-ef7b0fd8d279.png)

![image](https://user-images.githubusercontent.com/56200818/100344372-9db10e80-2fd8-11eb-84bc-b3fbdfadffb9.png)




# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
