### PR TITLE
fix/legacy product table styling changes

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.2.2...@uswitch/trustyle.legacy-product-table@0.2.3) (2020-11-27)
+
+
+### Bug Fixes
+
+* eligibility stlying ([5d2aad7](https://github.com/uswitch/trustyle/commit/5d2aad7))
+* representative example label and additional info font ([8b2b48b](https://github.com/uswitch/trustyle/commit/8b2b48b))
+* update cta cell ([67e7d7f](https://github.com/uswitch/trustyle/commit/67e7d7f))
+* update datacell font and spacing ([013d1c0](https://github.com/uswitch/trustyle/commit/013d1c0))
+
+
+
+
+
 ## [0.2.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.2.1...@uswitch/trustyle.legacy-product-table@0.2.2) (2020-11-26)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -181,7 +181,10 @@ export const CtaCell: React.FC<CtaCellProps> = ({ children, styles, href }) => {
           background: 'linear-gradient(90deg, #924A8B 5%, #DB4D75 95%)',
           color: '#fff',
           fontSize: '16px',
-          fontWeight: 400,
+          fontWeight: 300,
+          ':hover': {
+            opacity: 1
+          },
           ...styles
         }}
       >

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -217,12 +217,16 @@ const MobileEligibility: React.FC<MobileEligibilityProps> = ({
           display: ['block', 'none']
         }}
       >
-        <div sx={{ padding: '15px 20px 20px' }}>
+        <div
+          sx={{ padding: '15px 20px 20px', lineHeight: ['1.618em', 'inherit'] }}
+        >
           <div
             sx={{
               fontSize: '14px',
               color: '#858f94',
-              marginBottom: '5px'
+              marginBottom: '5px',
+              textAlign: 'left',
+              fontWeight: 300
             }}
           >
             Eligibility
@@ -401,7 +405,8 @@ export const EligibilityContentRow: React.FC<EligibilityContentRowProps> = ({
       sx={{
         fontSize: '13px',
         display: 'flex',
-        width: '100%'
+        width: '100%',
+        textAlign: 'left'
       }}
     >
       <label

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -125,15 +125,13 @@ export const DataCell: React.FC<DataCellProps> = ({
         backgroundColor,
         borderBottomColor,
         padding: '5px 0px 10px',
-        margin: ['2px 0', '2px'],
-        '> strong': {
-          background: 'none'
-        },
+        margin: ['4px 0', '2px'],
+        marginX: ['15px', '2px'],
         fontFamily: 'Varela Round,Arial,sans-serif',
         color: '#191919'
       }}
     >
-      <strong
+      <span
         sx={{
           fontFamily: 'Open Sans,Arial,sans-serif',
           fontSize: '11px',
@@ -144,7 +142,7 @@ export const DataCell: React.FC<DataCellProps> = ({
         }}
       >
         {label}
-      </strong>
+      </span>
       <div
         sx={{
           display: 'flex',

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -14,7 +14,8 @@ const AdditionalInfo: React.FC<React.HTMLAttributes<any>> = ({ children }) => {
         margin: '15px 0',
         paddingLeft: [0, '160px'],
         fontSize: '12px',
-        color: '#858f94'
+        color: '#858f94',
+        fontWeight: '300'
       }}
     >
       {children}
@@ -22,7 +23,11 @@ const AdditionalInfo: React.FC<React.HTMLAttributes<any>> = ({ children }) => {
   )
 }
 
-const Footer: React.FC<React.HTMLAttributes<any>> = ({ children }) => {
+interface FooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  label?: string
+}
+
+const Footer: React.FC<FooterProps> = ({ children, label }) => {
   return (
     <footer
       sx={{
@@ -36,6 +41,7 @@ const Footer: React.FC<React.HTMLAttributes<any>> = ({ children }) => {
         lineHeight: 'normal'
       }}
     >
+      {label}
       {children}
     </footer>
   )
@@ -473,6 +479,7 @@ const Eligibility: React.FC<EligibilityProps> = ({
 }
 interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   representativeExample: string
+  repExampleLabel?: string
   info: string[]
   title: string
   eligibilityContent: React.ReactNode[]
@@ -482,6 +489,7 @@ interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
 const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
   children,
   representativeExample,
+  repExampleLabel,
   info,
   title,
   eligibilityContent,
@@ -527,7 +535,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
           })}
         </AdditionalInfo>
 
-        <Footer>{representativeExample}</Footer>
+        <Footer label={repExampleLabel}>{representativeExample}</Footer>
       </RowWrapper>
 
       <Eligibility

--- a/src/compounds/legacy-product-table/src/stories.tsx
+++ b/src/compounds/legacy-product-table/src/stories.tsx
@@ -15,7 +15,7 @@ export default {
   title: 'Compounds/Legacy Product Table'
 }
 
-const repExample = `Representative Example: The representative rate is 29% APR (fixed) so
+const repExample = `The representative rate is 29% APR (fixed) so
 if you borrow £4,000 over 3 years at a rate of 17% p.a. (fixed) plus a
 service fee of 8.74% p.a. you will repay £160.61 per month & £5,781.96
 in total.`
@@ -39,6 +39,7 @@ const ExampleProductTable = () => {
   return (
     <LegacyProductTable
       representativeExample={repExample}
+      repExampleLabel="Representative example: "
       info={info}
       title={title}
       eligibilityContent={eligibilityContent}


### PR DESCRIPTION
# Description

Update legacy product table styling to match original design

![image](https://user-images.githubusercontent.com/56200818/100470712-a553de80-30d0-11eb-9a9b-945d6fb0b947.png)
![image](https://user-images.githubusercontent.com/56200818/100470730-b3096400-30d0-11eb-856b-dfe797eac404.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
