### PR TITLE
fix: legacy product table only render addons in schema

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.5.3...@uswitch/trustyle.legacy-product-table@0.5.4) (2020-12-15)
+
+
+### Bug Fixes
+
+* only render addons in schema ([0f83aaa](https://github.com/uswitch/trustyle/commit/0f83aaa))
+
+
+
+
+
 ## [0.5.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.5.2...@uswitch/trustyle.legacy-product-table@0.5.3) (2020-12-15)
 
 **Note:** Version bump only for package @uswitch/trustyle.legacy-product-table

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -558,22 +558,28 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
           {children}
         </div>
 
-        <AdditionalInfo>
-          {info.map((item, key) => {
-            return <div key={key}>{item}</div>
-          })}
-        </AdditionalInfo>
+        {info.length > 0 && (
+          <AdditionalInfo>
+            {info.map((item, key) => {
+              return <div key={key}>{item}</div>
+            })}
+          </AdditionalInfo>
+        )}
 
-        <Footer label={repExampleLabel}>{representativeExample}</Footer>
+        {representativeExample.length > 0 && (
+          <Footer label={repExampleLabel}>{representativeExample}</Footer>
+        )}
       </RowWrapper>
 
-      <Eligibility
-        hover={hover}
-        eligibilityContent={eligibilityContent}
-        clickableRow={clickableRow}
-        onClickEligibility={onClickEligibility}
-        eligibilityAddon={eligibilityAddon}
-      />
+      {eligibilityContent.length > 0 && (
+        <Eligibility
+          hover={hover}
+          eligibilityContent={eligibilityContent}
+          clickableRow={clickableRow}
+          onClickEligibility={onClickEligibility}
+          eligibilityAddon={eligibilityAddon}
+        />
+      )}
     </article>
   )
 }


### PR DESCRIPTION
# Description

Fix bug that rendered empty eligibility criteria, additional information, and footer addons on legacy product table.

AFTER:
![image](https://user-images.githubusercontent.com/56200818/102253298-0ec05380-3eff-11eb-8572-3e10426b5e1b.png)

BEFORE:
![image](https://user-images.githubusercontent.com/56200818/102253088-d0c32f80-3efe-11eb-810f-e2df95e7631c.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
