### PR TITLE
move variant styling to node above to resolve variant styling overrid…

### DIFF
--- a/src/elements/hero/src/index.tsx
+++ b/src/elements/hero/src/index.tsx
@@ -55,12 +55,8 @@ const Hero: React.FC<Props> = ({
     React.cloneElement(breadcrumbs, { variant: breadcrumbVariant })
 
   return (
-    <div>
-      <Palette
-        as="div"
-        sx={{ variant: 'elements.hero.wrapper', overflow: 'hidden' }}
-        px={{ backgroundColor: 'backgroundColor' }}
-      >
+    <div sx={{ variant: 'elements.hero.wrapper', overflow: 'hidden' }}>
+      <Palette as="div" px={{ backgroundColor: 'backgroundColor' }}>
         <div
           sx={{
             position: 'relative',


### PR DESCRIPTION
…ing palette

# Description

A variant style applied to heros was overriding our palette styling. This moves the variant to the node above to avoid the conflict