### PR TITLE
fix: form sponsored by image size

### DIFF
--- a/src/elements/button/src/index.tsx
+++ b/src/elements/button/src/index.tsx
@@ -30,7 +30,7 @@ const invertTheme = (theme: any, variant: any = {}) => {
   const borderColor = color
 
   const hoverColor = theme.colors[backgroundColor]
-    ? darken(theme.colors[backgroundColor], 0.1)
+    ? darken(theme.colors[backgroundColor], '0.1')
     : null
 
   return {

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -75,7 +75,7 @@ export const ExampleWithFormVariant = () => {
   const providerText: string = text('Text to display', 'You selected:')
   return (
     <React.Fragment>
-      <div sx={{ backgroundColor: 'secondary', padding: 'sm', width: '400px' }}>
+      <div sx={{ backgroundColor: 'secondary', padding: 'sm', width: '500px' }}>
         <SponsoredByTag
           providerLogoSrc={providerLogo}
           providerText={providerText}

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.38.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.38.0...@uswitch/trustyle.money-theme@1.38.1) (2020-12-21)
+
+
+### Bug Fixes
+
+* border radius ([e6c7cff](https://github.com/uswitch/trustyle/commit/e6c7cff))
+* image size ([4b3d745](https://github.com/uswitch/trustyle/commit/4b3d745))
+
+
+
+
+
 # [1.38.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.37.0...@uswitch/trustyle.money-theme@1.38.0) (2020-12-15)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -370,7 +370,7 @@
         "form": {
           "wrapper": {
             "backgroundColor": "grey-05",
-            "borderRadius": "xxs",
+            "borderRadius": "4px",
             "display": "flex",
             "alignItems": "center",
             "justifyContent": "center",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -378,7 +378,9 @@
             "paddingX": "xl"
           },
           "image": {
-            "ml": "md"
+            "ml": "md",
+            "width": "149px",
+            "height": "auto"
           }
         }
       }


### PR DESCRIPTION
# Description

<img width="580" alt="Screenshot 2020-12-21 at 10 15 54" src="https://user-images.githubusercontent.com/14987594/102766449-1015d400-4376-11eb-85b9-5b16fe55c2bb.png">

Ignore the white brackground of the image, that comes from data

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
