### PR TITLE
fix: initial open slide reveal bug

### DIFF
--- a/src/elements/slide-reveal/CHANGELOG.md
+++ b/src/elements/slide-reveal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.slide-reveal@1.2.0...@uswitch/trustyle.slide-reveal@1.2.1) (2021-01-04)
+
+
+### Bug Fixes
+
+* add optional initialOpen prop to disable initial open functionality ([1964456](https://github.com/uswitch/trustyle/commit/1964456))
+
+
+
+
+
 # [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.slide-reveal@1.1.4...@uswitch/trustyle.slide-reveal@1.2.0) (2020-10-12)
 
 

--- a/src/elements/slide-reveal/package.json
+++ b/src/elements/slide-reveal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.slide-reveal",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/slide-reveal/src/index.tsx
+++ b/src/elements/slide-reveal/src/index.tsx
@@ -18,9 +18,15 @@ const usePrevious = <T extends {}>(value: T): T | undefined => {
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean
   className?: string
+  initialOpen?: boolean
 }
 
-const SlideReveal: React.FC<Props> = ({ open, children, className }) => {
+const SlideReveal: React.FC<Props> = ({
+  open,
+  children,
+  className,
+  initialOpen = true
+}) => {
   const contentsWrapperEl = React.useRef<HTMLDivElement>(null)
   const [height, setHeight] = React.useState(0)
 
@@ -30,7 +36,7 @@ const SlideReveal: React.FC<Props> = ({ open, children, className }) => {
 
   // Initial is to make sure that content displays when JS is disabled and that
   // initially opened content doesn't animate open
-  const [initial, setInitial] = React.useState(true)
+  const [initial, setInitial] = React.useState(initialOpen)
 
   // Store whether we're transitioning or not so that when the slider is open
   // and not transitioning, we can remove the maxHeight to reduce the


### PR DESCRIPTION
# Description

- Fixes bug where product table filters are initially open on page load
- Add optional prop to set initial state to false

After (on page load):
![image](https://user-images.githubusercontent.com/56200818/103542531-fbb4f980-4e94-11eb-9f6f-ff2486240eac.png)

Before (on page load): 
![image](https://user-images.githubusercontent.com/56200818/103542504-efc93780-4e94-11eb-80bb-d46fb3d0eac8.png)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
