### PR TITLE
Accordion scroll

### DIFF
--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.38](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.37...@uswitch/trustyle.side-nav@1.0.38) (2021-01-05)
+
+**Note:** Version bump only for package @uswitch/trustyle.side-nav
+
+
+
+
+
 ## [1.0.37](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.36...@uswitch/trustyle.side-nav@1.0.37) (2020-12-18)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-nav

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.11.8"
+    "@uswitch/trustyle.accordion": "^0.11.9"
   }
 }

--- a/src/elements/accordion/CHANGELOG.md
+++ b/src/elements/accordion/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.11.8...@uswitch/trustyle.accordion@0.11.9) (2021-01-05)
+
+**Note:** Version bump only for package @uswitch/trustyle.accordion
+
+
+
+
+
 ## [0.11.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.11.7...@uswitch/trustyle.accordion@0.11.8) (2020-12-18)
 
 **Note:** Version bump only for package @uswitch/trustyle.accordion

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/accordion/src/index.tsx
+++ b/src/elements/accordion/src/index.tsx
@@ -29,6 +29,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   glyph?: Glyph
   glyphColor?: string
   variant?: string
+  scrollToRef?: React.RefObject<HTMLElement>
 }
 
 interface TitleProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -55,6 +56,7 @@ const Accordion: React.FC<Props> & {
   icon = '',
   glyph,
   glyphColor = '',
+  scrollToRef,
   variant
 }) => {
   const {
@@ -103,7 +105,17 @@ const Accordion: React.FC<Props> & {
         px={{
           color: 'textColor'
         }}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          if (
+            isOpen &&
+            variant === 'reverse' &&
+            scrollToRef &&
+            scrollToRef.current
+          ) {
+            scrollToRef.current.scrollIntoView({ behavior: 'smooth' })
+          }
+          setIsOpen(!isOpen)
+        }}
       >
         {icon || glyph ? (
           <div

--- a/src/elements/accordion/src/stories.tsx
+++ b/src/elements/accordion/src/stories.tsx
@@ -28,20 +28,70 @@ SingleAccordion.story = {
   }
 }
 
-export const ReverseAccordion = () => (
-  <React.Fragment>
-    <p>Recommendation 1</p>
-    <Accordion
-      title={'Show more recommendations'}
-      openedTitle={'Show less'}
-      variant="reverse"
-    >
-      <p style={{ marginTop: 0, marginBottom: '2000px' }}>Recommendation 2</p>
-      <p>Recommendation 3</p>
-    </Accordion>
-    <p style={{ marginTop: '2000px' }}>Content below</p>
-  </React.Fragment>
-)
+export const ReverseAccordion = () => {
+  const scrollToRef = React.useRef<HTMLHeadingElement>(null)
+  return (
+    <React.Fragment>
+      <h3 ref={scrollToRef}>Recommendation 1</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eu
+        fringilla quam. Fusce vulputate sit amet nisl quis cursus. Proin
+        vehicula lacinia elit quis pretium. Proin eget pellentesque dolor. Nulla
+        volutpat sapien placerat, ultrices libero ut, ornare dui. Donec a est
+        facilisis odio faucibus pretium vitae nec justo. Curabitur gravida diam
+        at sodales maximus. Nulla gravida luctus felis, ac sodales elit.
+      </p>
+      <Accordion
+        title={'Show more recommendations'}
+        openedTitle={'Show less'}
+        variant="reverse"
+        scrollToRef={scrollToRef}
+      >
+        <h3 style={{ marginTop: 0 }}>Recommendation 2</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eu
+          fringilla quam. Fusce vulputate sit amet nisl quis cursus. Proin
+          vehicula lacinia elit quis pretium. Proin eget pellentesque dolor.
+          Nulla volutpat sapien placerat, ultrices libero ut, ornare dui. Donec
+          a est facilisis odio faucibus pretium vitae nec justo. Curabitur
+          gravida diam at sodales maximus. Nulla gravida luctus felis, ac
+          sodales elit.
+        </p>
+        <h3>Recommendation 3</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eu
+          fringilla quam. Fusce vulputate sit amet nisl quis cursus. Proin
+          vehicula lacinia elit quis pretium. Proin eget pellentesque dolor.
+          Nulla volutpat sapien placerat, ultrices libero ut, ornare dui. Donec
+          a est facilisis odio faucibus pretium vitae nec justo. Curabitur
+          gravida diam at sodales maximus. Nulla gravida luctus felis, ac
+          sodales elit.
+        </p>
+      </Accordion>
+      <h3>Content below</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec eu
+        fringilla quam. Fusce vulputate sit amet nisl quis cursus. Proin
+        vehicula lacinia elit quis pretium. Proin eget pellentesque dolor. Nulla
+        volutpat sapien placerat, ultrices libero ut, ornare dui. Donec a est
+        facilisis odio faucibus pretium vitae nec justo. Curabitur gravida diam
+        at sodales maximus. Nulla gravida luctus felis, ac sodales elit.
+      </p>
+      <p>
+        Nullam eu sem nec tellus luctus luctus. Proin ullamcorper pretium ante
+        ut viverra. In in sapien nec ipsum consequat pulvinar eget feugiat
+        lorem. Ut purus ex, porttitor quis eros nec, efficitur mattis neque. Ut
+        aliquet sed lacus vitae fringilla. Nullam non pellentesque erat. Sed
+        rutrum eget mi at fringilla. Praesent efficitur tortor ac placerat
+        semper. Suspendisse rhoncus placerat ultricies. Donec accumsan nisi non
+        urna posuere, et accumsan eros congue. Proin quis imperdiet quam. Nulla
+        sodales et magna luctus dignissim. Integer in maximus ligula, eget
+        lacinia risus. Nam justo nulla, efficitur ac purus sed, molestie
+        faucibus enim.
+      </p>
+    </React.Fragment>
+  )
+}
 
 ReverseAccordion.story = {
   parameters: {

--- a/src/elements/drop-down/src/stories.tsx
+++ b/src/elements/drop-down/src/stories.tsx
@@ -124,6 +124,13 @@ export const Example = () => (
   </div>
 )
 
+export const ExampleInRow = () => (
+  <div sx={{ display: 'flex', flexDirection: 'row' }}>
+    <ColourSelect />
+    <ColourSelect />
+  </div>
+)
+
 Example.story = {
   parameters: {
     percy: { skip: true }

--- a/src/elements/drop-down/src/stories.tsx
+++ b/src/elements/drop-down/src/stories.tsx
@@ -128,6 +128,7 @@ export const ExampleInRow = () => (
   <div sx={{ display: 'flex', flexDirection: 'row' }}>
     <ColourSelect />
     <ColourSelect />
+    <ColourSelect />
   </div>
 )
 

--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.41](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.40...@uswitch/trustyle.embedded-video@0.4.41) (2021-01-05)
+
+**Note:** Version bump only for package @uswitch/trustyle.embedded-video
+
+
+
+
+
 ## [0.4.40](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.39...@uswitch/trustyle.embedded-video@0.4.40) (2020-12-18)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.11.8"
+    "@uswitch/trustyle.accordion": "^0.11.9"
   }
 }

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.32.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.32.2...@uswitch/trustyle.uswitch-theme@2.32.3) (2021-01-05)
+
+
+### Bug Fixes
+
+* remove min width on dropdown ([5fa26e7](https://github.com/uswitch/trustyle/commit/5fa26e7))
+
+
+
+
+
 ## [2.32.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.32.1...@uswitch/trustyle.uswitch-theme@2.32.2) (2021-01-04)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.32.2",
+  "version": "2.32.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1405,8 +1405,7 @@
         }
       },
       "container": {
-        "flex": "1 1 0px",
-        "min-width": "176px"
+        "flex": "1 1 0px"
       },
       "select": {
         "base": {


### PR DESCRIPTION
# Description

- Add option to pass ref to element to scroll to for reverse accordion on close. At the moment when there is a lot of content within the accordion, when it is closed the user is left in a random spot further down the page which they haven't scrolled to yet. 
- Remove min width from dropdown element. Instead the dropdown can be sized using its container.


https://user-images.githubusercontent.com/21021507/103561738-d97da480-4eb1-11eb-8878-1649a5f8ea2f.mov



# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
