### PR TITLE
feat: add `buttonProps` to accordion

### DIFF
--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.40](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.39...@uswitch/trustyle.side-nav@1.0.40) (2021-01-06)
+
+**Note:** Version bump only for package @uswitch/trustyle.side-nav
+
+
+
+
+
 ## [1.0.39](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.38...@uswitch/trustyle.side-nav@1.0.39) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-nav

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.11.10"
+    "@uswitch/trustyle.accordion": "^0.12.0"
   }
 }

--- a/src/elements/accordion/CHANGELOG.md
+++ b/src/elements/accordion/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.12.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.11.10...@uswitch/trustyle.accordion@0.12.0) (2021-01-06)
+
+
+### Features
+
+* add `buttonProps` to accordion ([6176171](https://github.com/uswitch/trustyle/commit/6176171))
+
+
+
+
+
 ## [0.11.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.11.9...@uswitch/trustyle.accordion@0.11.10) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.accordion

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.11.10",
+  "version": "0.12.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/accordion/src/index.tsx
+++ b/src/elements/accordion/src/index.tsx
@@ -30,7 +30,10 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   glyphColor?: string
   variant?: string
   scrollToRef?: React.RefObject<HTMLElement>
+  buttonProps?: object | ButtonPropsFn
 }
+
+type ButtonPropsFn = (args: { open: boolean; title: string }) => object
 
 interface TitleProps extends React.HTMLAttributes<HTMLDivElement> {
   as?: React.ElementType
@@ -57,7 +60,8 @@ const Accordion: React.FC<Props> & {
   glyph,
   glyphColor = '',
   scrollToRef,
-  variant
+  variant,
+  buttonProps: buttonPropsFn
 }) => {
   const {
     theme: {
@@ -83,6 +87,11 @@ const Accordion: React.FC<Props> & {
 
   const title =
     typeof openedTitle !== 'undefined' && isOpen ? openedTitle : closedTitle
+
+  const buttonProps =
+    typeof buttonPropsFn === 'function'
+      ? buttonPropsFn({ open: isOpen, title })
+      : buttonPropsFn
 
   return (
     <div
@@ -116,6 +125,7 @@ const Accordion: React.FC<Props> & {
           }
           setIsOpen(!isOpen)
         }}
+        {...buttonProps}
       >
         {icon || glyph ? (
           <div

--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.43](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.42...@uswitch/trustyle.embedded-video@0.4.43) (2021-01-06)
+
+**Note:** Version bump only for package @uswitch/trustyle.embedded-video
+
+
+
+
+
 ## [0.4.42](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.41...@uswitch/trustyle.embedded-video@0.4.42) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.11.10"
+    "@uswitch/trustyle.accordion": "^0.12.0"
   }
 }


### PR DESCRIPTION
# Description

Add `buttonProps` to Accordion which are passed down to the underlying
button element.

This facilitates nerdalytics integration.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.