### PR TITLE
fix: rich-text-block variants update

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -897,7 +897,7 @@
           "position": "relative",
           "display": "flex",
           "flex-direction": ["column", "row"],
-          "alignItems": ["center", "initial"],
+          "alignItems": "center",
           "::before": {
             "content": "''",
             "zIndex": -1,
@@ -937,11 +937,18 @@
           },
           "img": {
             "width": "100%",
+            "maxWidth": [96, "grid.lg.2"],
             "height": "100%",
             "pb": 0
           },
           "h3": {
             "mb": ["xxs", "sm"]
+          },
+          "h2": {
+            "variant": "styles.h3",
+            "b": {
+              "fontSize": ["md", "xl"]
+            }
           },
           "p": {
             "mb": "xs",


### PR DESCRIPTION
# Description

Rich text left variant styling, alignment, mobile margins and font sizes.

# Screenshots

### Desktop
![image](https://user-images.githubusercontent.com/66306693/104195628-29fd8080-5423-11eb-913c-72a195fa3e47.png)

### Mobile
![image](https://user-images.githubusercontent.com/66306693/104195665-34b81580-5423-11eb-91e0-29f58674235a.png)


# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
