### PR TITLE
fix: remove margin from h2 and p in image-callout

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.32.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.32.12...@uswitch/trustyle.uswitch-theme@2.32.13) (2021-01-18)
+
+
+### Bug Fixes
+
+* remove margin from h2 and p in image-callout ([f72c016](https://github.com/uswitch/trustyle/commit/f72c016))
+
+
+
+
+
+
 ## [2.32.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.32.11...@uswitch/trustyle.uswitch-theme@2.32.12) (2021-01-14)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.32.12",
+  "version": "2.32.13",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -756,8 +756,7 @@
     "rich-text-block": {
       "base": {
         "h2": {
-          "fontSize": [32, 32],
-          "mb": 64
+          "fontSize": [32, 32]
         },
         "h3": {
           "fontSize": 28
@@ -3616,8 +3615,7 @@
               "mb": 72
             },
             "p": {
-              "color": "grey-60",
-              "mt": 72
+              "color": "grey-60"
             }
           },
           "image": {


### PR DESCRIPTION
# Description

remove margin from h2 and p in image-callout

# Screenshots
![image](https://user-images.githubusercontent.com/66306693/104911883-d55e8600-598b-11eb-8b62-0ee23f53f006.png)

![image](https://user-images.githubusercontent.com/66306693/104911927-e60efc00-598b-11eb-9526-f2955b43f4b2.png)


# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
