### PR TITLE
fix: offset not working if equal to 0

### DIFF
--- a/src/compounds/interactive-tabs/CHANGELOG.md
+++ b/src/compounds/interactive-tabs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.interactive-tabs@2.1.6...@uswitch/trustyle.interactive-tabs@2.1.7) (2021-01-20)
+
+**Note:** Version bump only for package @uswitch/trustyle.interactive-tabs
+
+
+
+
+
 ## [2.1.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.interactive-tabs@2.1.5...@uswitch/trustyle.interactive-tabs@2.1.6) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.interactive-tabs

--- a/src/compounds/interactive-tabs/package.json
+++ b/src/compounds/interactive-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.interactive-tabs",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
     "@uswitch/trustyle.carousel": "^1.1.4",
-    "@uswitch/trustyle.flex-grid": "^3.5.0"
+    "@uswitch/trustyle.flex-grid": "^3.5.1"
   },
   "devDependencies": {
     "@uswitch/trustyle.icon": "^1.19.1"

--- a/src/compounds/tabs/CHANGELOG.md
+++ b/src/compounds/tabs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.tabs@1.0.9...@uswitch/trustyle.tabs@1.0.10) (2021-01-20)
+
+**Note:** Version bump only for package @uswitch/trustyle.tabs
+
+
+
+
+
 ## [1.0.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.tabs@1.0.8...@uswitch/trustyle.tabs@1.0.9) (2020-10-16)
 
 **Note:** Version bump only for package @uswitch/trustyle.tabs

--- a/src/compounds/tabs/package.json
+++ b/src/compounds/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.tabs",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -12,6 +12,6 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.flex-grid": "^3.5.0"
+    "@uswitch/trustyle.flex-grid": "^3.5.1"
   }
 }

--- a/src/elements/card/CHANGELOG.md
+++ b/src/elements/card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.12.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.card@1.12.3...@uswitch/trustyle.card@1.12.4) (2021-01-20)
+
+**Note:** Version bump only for package @uswitch/trustyle.card
+
+
+
+
+
 ## [1.12.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.card@1.12.2...@uswitch/trustyle.card@1.12.3) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.card

--- a/src/elements/card/package.json
+++ b/src/elements/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.card",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {
@@ -12,7 +12,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.flex-grid": "^3.5.0",
+    "@uswitch/trustyle.flex-grid": "^3.5.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40"
   },
   "devDependencies": {

--- a/src/elements/category/CHANGELOG.md
+++ b/src/elements/category/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.30](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.0.29...@uswitch/trustyle.category@2.0.30) (2021-01-20)
+
+**Note:** Version bump only for package @uswitch/trustyle.category
+
+
+
+
+
 ## [2.0.29](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.0.28...@uswitch/trustyle.category@2.0.29) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.category

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -15,6 +15,6 @@
     "@uswitch/trustyle.breadcrumbs": "^2.1.6"
   },
   "dependencies": {
-    "@uswitch/trustyle.flex-grid": "^3.5.0"
+    "@uswitch/trustyle.flex-grid": "^3.5.1"
   }
 }

--- a/src/layout/flex-grid/CHANGELOG.md
+++ b/src/layout/flex-grid/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.flex-grid@3.5.0...@uswitch/trustyle.flex-grid@3.5.1) (2021-01-20)
+
+
+### Bug Fixes
+
+* offset not working if equal to 0 ([390e6e9](https://github.com/uswitch/trustyle/commit/390e6e9))
+
+
+
+
+
 # [3.5.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.flex-grid@3.4.2...@uswitch/trustyle.flex-grid@3.5.0) (2020-10-16)
 
 

--- a/src/layout/flex-grid/package.json
+++ b/src/layout/flex-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.flex-grid",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/layout/flex-grid/src/index.tsx
+++ b/src/layout/flex-grid/src/index.tsx
@@ -29,7 +29,7 @@ const uncastArrayIfSingle = (arr: number[]): number | number[] =>
 const toPx = (value: number) => `${value}px`
 
 const getValueFromBreakpointIndex = (arr: number[], index: number): number => {
-  if (arr[index]) return arr[index]
+  if (arr[index] !== undefined) return arr[index]
   return arr[arr.length - 1]
 }
 


### PR DESCRIPTION
# Description

Offset would return last member of array if it was equal to 0.

# Checklist

Pull request contains:

- [ ] A new component
- [ x ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ x ] Work has been tested in multiple browsers
- [ x ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
