### PR TITLE
fix: add rich-text-block hero variant

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.32.18](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.32.17...@uswitch/trustyle.uswitch-theme@2.32.18) (2021-01-25)
+
+
+### Bug Fixes
+
+* add rich-text-block hero variant ([cbf2bf0](https://github.com/uswitch/trustyle/commit/cbf2bf0))
+
+
+
+
+
 ## [2.32.17](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.32.16...@uswitch/trustyle.uswitch-theme@2.32.17) (2021-01-22)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.32.17",
+  "version": "2.32.18",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -822,6 +822,38 @@
         }
       },
       "variants": {
+        "hero": {
+          "display": "flex",
+          "alignItems": "center",
+          "flexDirection": "column",
+          "textAlign": "center",
+          "h1": {
+            "mb": "xxs",
+            "fontSize": ["lg", "xxl", "xxxl"]
+          },
+          "h5": {
+            "fontSize": ["sm", "sm", "md"],
+            "mb": "sm"
+          },
+          ">div": {
+            "&:nth-of-type(2)": {
+              "width": "100%",
+              "div[class*=LeadCaptureForm]:first-of-type": {
+                "margin": "auto"
+              }
+            },
+            "&:nth-of-type(3)": {
+              "pt": 0,
+              "mt": ["sm", "md"],
+              "*": {
+                "fontSize": "base"
+              }
+            },
+            "&:last-of-type": {
+              "mb": ["xxs", "md", "md"]
+            }
+          }
+        },
         "center": {
           "textAlign": "center"
         },


### PR DESCRIPTION
# Description

Hero variant for rich text block

# Screenshots

### Desktop
![image](https://user-images.githubusercontent.com/66306693/105337577-dcc79e80-5bda-11eb-9539-4dfa3510867b.png)

### Mobile
![image](https://user-images.githubusercontent.com/66306693/105337627-e5b87000-5bda-11eb-8a63-27ef92cb6cf3.png)

### Tablet
![image](https://user-images.githubusercontent.com/66306693/105337711-f963d680-5bda-11eb-9489-589234589f0f.png)


# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
