### PR TITLE
fix: desktop eligiblity through css

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.8.2...@uswitch/trustyle.legacy-product-table@0.8.3) (2021-01-22)
+
+
+### Bug Fixes
+
+* desktop eligiblity through css ([49e875d](https://github.com/uswitch/trustyle/commit/49e875d))
+
+
+
+
+
 ## [0.8.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.8.1...@uswitch/trustyle.legacy-product-table@0.8.2) (2021-01-08)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -317,18 +317,14 @@ const MobileEligibility: React.FC<MobileEligibilityProps> = ({
   )
 }
 
-interface DesktopEligibilityProps extends React.HTMLAttributes<HTMLDivElement> {
-  hover: boolean
-}
-
-const DesktopEligibility: React.FC<DesktopEligibilityProps> = ({
-  children,
-  hover
+const DesktopEligibility: React.FC<React.HTMLAttributes<HTMLElement>> = ({
+  className,
+  children
 }) => {
   return (
     <div
+      className={className}
       sx={{
-        display: ['none', hover ? 'block' : 'none'],
         position: 'absolute',
         top: '100%',
         width: '400px',
@@ -473,7 +469,6 @@ export const EligibilityContentRow: React.FC<EligibilityContentRowProps> = ({
 }
 
 interface EligibilityProps extends React.HTMLAttributes<HTMLDivElement> {
-  hover: boolean
   eligibilityContent: React.ReactNode[]
   clickableRow?: string
   onClickEligibility?: (addon?: object) => void
@@ -481,7 +476,6 @@ interface EligibilityProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Eligibility: React.FC<EligibilityProps> = ({
-  hover,
   eligibilityContent,
   clickableRow,
   onClickEligibility,
@@ -499,7 +493,7 @@ const Eligibility: React.FC<EligibilityProps> = ({
           return item
         })}
       </MobileEligibility>
-      <DesktopEligibility sx={{ display: ['none', 'block'] }} hover={hover}>
+      <DesktopEligibility className="desktop-eligibility">
         {eligibilityContent.map(item => {
           return item
         })}
@@ -534,8 +528,6 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
   disabled,
   ...props
 }) => {
-  const [hover, setHover] = React.useState(false)
-
   return (
     <article
       sx={{
@@ -546,13 +538,13 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
         ':first-of-type': {
           marginTop: '10px'
         },
-        opacity: disabled ? '0.4' : 1
-      }}
-      onMouseEnter={() => {
-        setHover(true)
-      }}
-      onMouseLeave={() => {
-        setHover(false)
+        opacity: disabled ? '0.4' : 1,
+        '.desktop-eligibility': {
+          display: 'none'
+        },
+        ':hover .desktop-eligibility': {
+          display: ['none', 'block']
+        }
       }}
       {...props}
     >
@@ -589,7 +581,6 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
 
       {eligibilityContent.length > 0 && !disabled && (
         <Eligibility
-          hover={hover}
           eligibilityContent={eligibilityContent}
           clickableRow={clickableRow}
           onClickEligibility={onClickEligibility}


### PR DESCRIPTION
# Description

Show desktop eligibility on legacy product table even when there is no hydration

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
