### PR TITLE
feat: allow hiding of description on mobile

### DIFF
--- a/src/elements/category/CHANGELOG.md
+++ b/src/elements/category/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.0.30...@uswitch/trustyle.category@2.1.0) (2021-01-22)
+
+
+### Bug Fixes
+
+* types ([94e888b](https://github.com/uswitch/trustyle/commit/94e888b))
+
+
+### Features
+
+* allow hiding of description on mobile ([73d2362](https://github.com/uswitch/trustyle/commit/73d2362))
+
+
+
+
+
 ## [2.0.30](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.0.29...@uswitch/trustyle.category@2.0.30) (2021-01-20)
 
 **Note:** Version bump only for package @uswitch/trustyle.category

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "2.0.30",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/category/src/index.tsx
+++ b/src/elements/category/src/index.tsx
@@ -8,22 +8,24 @@ import {
   Row
 } from '@uswitch/trustyle.flex-grid'
 
-interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
+interface CategoryProps extends React.HTMLAttributes<HTMLDivElement> {
   title: string
   text?: string
   container?: React.FC
   breadcrumbs?: React.ReactElement
   image?: React.ReactElement
   className?: string
+  hideDescriptionMobile: boolean
 }
 
-const Category: React.FC<ListProps> = ({
+const Category: React.FC<CategoryProps> = ({
   title,
   text,
   container: Container = DefaultContainer,
   breadcrumbs: Breadcrumbs,
   image: Image,
-  className
+  className,
+  hideDescriptionMobile = false
 }) => {
   const { theme }: any = useThemeUI()
   const breadcrumbsVariant = theme.elements?.category?.breadcrumbs?.variant
@@ -70,7 +72,11 @@ const Category: React.FC<ListProps> = ({
             </Styled.h1>
             {text && (
               <Styled.p
-                sx={{ marginBottom: 0, variant: 'elements.category.text' }}
+                sx={{
+                  marginBottom: 0,
+                  variant: 'elements.category.text',
+                  display: hideDescriptionMobile ? ['none', 'block'] : 'block'
+                }}
               >
                 {text}
               </Styled.p>

--- a/src/elements/category/src/index.tsx
+++ b/src/elements/category/src/index.tsx
@@ -15,7 +15,7 @@ interface CategoryProps extends React.HTMLAttributes<HTMLDivElement> {
   breadcrumbs?: React.ReactElement
   image?: React.ReactElement
   className?: string
-  hideDescriptionMobile: boolean
+  hideDescriptionMobile?: boolean
 }
 
 const Category: React.FC<CategoryProps> = ({


### PR DESCRIPTION
# Description

This will allow hiding on mobile without removing from desktop

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
