### PR TITLE
fix: don't show info button if hideOnModile is falsy

### DIFF
--- a/src/elements/category/CHANGELOG.md
+++ b/src/elements/category/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.2.0...@uswitch/trustyle.category@2.2.2) (2021-02-02)
+
+
+### Bug Fixes
+
+* don't show info button if hideOnModile is falsy ([a031282](https://github.com/uswitch/trustyle/commit/a031282))
+
+
+
+
+
 ## [2.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.2.0...@uswitch/trustyle.category@2.2.1) (2021-02-02)
 
 

--- a/src/elements/category/CHANGELOG.md
+++ b/src/elements/category/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.2.0...@uswitch/trustyle.category@2.2.1) (2021-02-02)
+
+
+### Bug Fixes
+
+* don't show info button if hideOnModile is falsy ([a031282](https://github.com/uswitch/trustyle/commit/a031282))
+
+
+
+
+
 # [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.category@2.1.0...@uswitch/trustyle.category@2.2.0) (2021-01-29)
 
 

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/category/package.json
+++ b/src/elements/category/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.category",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/category/src/index.tsx
+++ b/src/elements/category/src/index.tsx
@@ -68,7 +68,7 @@ const Category: React.FC<CategoryProps> = ({
                 variant={breadcrumbsVariant}
               />
             )}
-            {icon && (
+            {icon && hideDescriptionMobile && (
               <div
                 sx={{ display: ['block', 'none'] }}
                 onClick={() => setShowDescription(!showDescription)}


### PR DESCRIPTION
# Description

Don't show info button if hideOnModile is falsy in category heading module

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
