### PR TITLE
fix: rich text block center-shrink variant styling

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.34.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.34.2...@uswitch/trustyle.uswitch-theme@2.34.3) (2021-02-05)
+
+
+### Bug Fixes
+
+* rich text block center-shrink variant styling ([71991ba](https://github.com/uswitch/trustyle/commit/71991ba))
+
+
+
+
+
 ## [2.34.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.34.1...@uswitch/trustyle.uswitch-theme@2.34.2) (2021-01-29)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.34.2",
+  "version": "2.34.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -865,6 +865,13 @@
         "center": {
           "textAlign": "center"
         },
+        "center-shrink": {
+          "variant": "elements.rich-text-block.variants.center",
+          "*": {
+            "width": "fit-content",
+            "margin": "auto"
+          }
+        },
         "heading": {
           "mx": "auto",
           "maxWidth": ["100%", 900, 900],
@@ -2995,6 +3002,7 @@
       "column": {
         "flexDirection": "column",
         "flex": 1,
+        "pr": [0, "lg"],
         "& p": {
           "display": ["none", "block"],
           "fontSize": "xxs",


### PR DESCRIPTION
# Description

Add center shrink variant to rich text block. This variant centres content and also shrink the width of it.

# Screenshot
![image](https://user-images.githubusercontent.com/66306693/106761764-73617a00-6635-11eb-945a-70e6702fc1d6.png)


# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
