### PR TITLE
Add save for later component and icon

### DIFF
--- a/src/elements/icon/CHANGELOG.md
+++ b/src/elements/icon/CHANGELOG.md
@@ -19,6 +19,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
+* add bookmark icons to the library
+
 * hide description and image in category heading module on mobile ([3af7477](https://github.com/uswitch/trustyle/commit/3af7477))
 
 

--- a/src/elements/icon/src/bookmark-filled.tsx
+++ b/src/elements/icon/src/bookmark-filled.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+import * as st from './styles'
+
+interface Props {
+  color: string
+  size?: number
+}
+
+export const BookmarkFilled: React.FC<Props> = ({ color, size }) => (
+  <svg
+    sx={{
+      display: 'block',
+      ...st.size(size),
+      fill: color,
+      stroke: color
+    }}
+    viewBox="0 0 22 22"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M10.6807 14.534L4.625 19.5602V4.125C4.625 2.88864 5.63864 1.875 6.875 1.875H15.125C16.3614 1.875 17.375 2.88864 17.375 4.125V19.5602L11.3193 14.534L11 14.269L10.6807 14.534Z" />
+  </svg>
+)

--- a/src/elements/icon/src/bookmark.tsx
+++ b/src/elements/icon/src/bookmark.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+import * as st from './styles'
+
+interface Props {
+  color: string
+  size?: number
+}
+
+export const Bookmark: React.FC<Props> = ({ color, size }) => (
+  <svg
+    sx={{
+      display: 'block',
+      ...st.size(size),
+      fill: color,
+      stroke: color
+    }}
+    viewBox="0 0 18 26"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M15.6793 21.8712L16.5 22.5571V21.4875V4.25C16.5 3.01136 15.4886 2 14.25 2H3.75C2.51136 2 1.5 3.01136 1.5 4.25V21.4875V22.5571L2.32065 21.8712L8.18317 16.9712L8.18548 16.9692L9 16.28L9.81451 16.9692L9.81683 16.9711L15.6793 21.8712ZM9.31933 17.6028L9 17.3377L8.68067 17.6028L0.75 24.1852V4.25C0.75 2.60114 2.10114 1.25 3.75 1.25H14.25C15.8989 1.25 17.25 2.60114 17.25 4.25V24.1852L9.31933 17.6028Z" />
+  </svg>
+)

--- a/src/elements/icon/src/index.tsx
+++ b/src/elements/icon/src/index.tsx
@@ -8,6 +8,8 @@ import { ArrowCircle } from './arrow-circle'
 import { Bill } from './bill'
 import { Book } from './book'
 import { BookClosed } from './book-closed'
+import { Bookmark } from './bookmark'
+import { BookmarkFilled } from './bookmark-filled'
 import { Calendar } from './calendar'
 import { Caret } from './caret'
 import { Car } from './car'
@@ -66,6 +68,8 @@ export type Glyph =
   | 'bill'
   | 'book'
   | 'book-closed'
+  | 'bookmark'
+  | 'bookmark-filled'
   | 'calendar'
   | 'car'
   | 'caret'
@@ -151,6 +155,10 @@ export const Icon: React.FC<Props> = ({
       return <Book color={color} size={size} />
     case 'book-closed':
       return <BookClosed color={color} size={size} />
+    case 'bookmark':
+      return <Bookmark color={color} size={size} />
+    case 'bookmark-filled':
+      return <BookmarkFilled color={color} size={size} />
 
     case 'calendar':
       return <Calendar color={color} size={size} />

--- a/src/elements/icon/src/stories.tsx
+++ b/src/elements/icon/src/stories.tsx
@@ -12,6 +12,8 @@ const glyphChoices: Glyph[] = [
   'bill',
   'book',
   'book-closed',
+  'bookmark',
+  'bookmark-filled',
   'calendar',
   'car',
   'caret',

--- a/src/elements/save-for-later/CHANGELOG.md
+++ b/src/elements/save-for-later/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.icon-tile@2.0.2...@uswitch/trustyle.icon-tile@2.1.0) (2020-09-21)
+
+### Bug Fixes
+
+### Features
+

--- a/src/elements/save-for-later/package.json
+++ b/src/elements/save-for-later/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@uswitch/trustyle.save-for-later",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "ts:main": "src/index.tsx",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.0.27",
+    "react": "^16.7.0"
+  },
+  "dependencies": {
+    "@uswitch/trustyle.icon": "^1.21.0"
+  }
+}

--- a/src/elements/save-for-later/src/index.tsx
+++ b/src/elements/save-for-later/src/index.tsx
@@ -1,0 +1,40 @@
+/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+import { Icon } from '@uswitch/trustyle.icon'
+
+interface Props extends React.HTMLAttributes<any> {
+  checked: boolean
+  size?: number
+  className?: string
+}
+
+const SaveForLater: React.FC<Props> = ({
+  checked,
+  onClick,
+  className,
+  size = 40
+}) => {
+  return (
+    <button
+      sx={{ backgroundColor: 'transparent', outline: '0', border: '0' }}
+      className={className}
+      onClick={onClick}
+    >
+      <div
+        sx={{
+          position: 'absolute',
+          width: '50px'
+        }}
+      >
+        {checked ? (
+          <Icon glyph="bookmark-filled" color="#91CA50" size={size} />
+        ) : (
+          <Icon glyph="bookmark" color="#575761" size={size} />
+        )}
+      </div>
+    </button>
+  )
+}
+
+export default SaveForLater

--- a/src/elements/save-for-later/src/index.tsx
+++ b/src/elements/save-for-later/src/index.tsx
@@ -11,7 +11,7 @@ interface Props extends React.HTMLAttributes<any> {
 
 const SaveForLater: React.FC<Props> = ({
   checked,
-  onClick,
+  onChange,
   className,
   size = 40
 }) => {
@@ -23,19 +23,20 @@ const SaveForLater: React.FC<Props> = ({
           appearance: 'none',
           position: 'absolute'
         }}
+        checked={checked}
+        onChange={onChange}
         type="checkbox"
       />
-      <span
+      <div
         sx={{ backgroundColor: 'transparent', outline: '0', border: '0' }}
         className={className}
-        onClick={onClick}
       >
         {checked ? (
           <Icon glyph="bookmark-filled" color="#91CA50" size={size} />
         ) : (
           <Icon glyph="bookmark" color="#575761" size={size} />
         )}
-      </span>
+      </div>
     </label>
   )
 }

--- a/src/elements/save-for-later/src/index.tsx
+++ b/src/elements/save-for-later/src/index.tsx
@@ -16,24 +16,27 @@ const SaveForLater: React.FC<Props> = ({
   size = 40
 }) => {
   return (
-    <button
-      sx={{ backgroundColor: 'transparent', outline: '0', border: '0' }}
-      className={className}
-      onClick={onClick}
-    >
-      <div
+    <label sx={{ display: 'block' }}>
+      <input
         sx={{
-          position: 'absolute',
-          width: '50px'
+          marginLeft: '-9000px',
+          appearance: 'none',
+          position: 'absolute'
         }}
+        type="checkbox"
+      />
+      <span
+        sx={{ backgroundColor: 'transparent', outline: '0', border: '0' }}
+        className={className}
+        onClick={onClick}
       >
         {checked ? (
           <Icon glyph="bookmark-filled" color="#91CA50" size={size} />
         ) : (
           <Icon glyph="bookmark" color="#575761" size={size} />
         )}
-      </div>
-    </button>
+      </span>
+    </label>
   )
 }
 

--- a/src/elements/save-for-later/src/stories.tsx
+++ b/src/elements/save-for-later/src/stories.tsx
@@ -13,7 +13,12 @@ export const ExampleWithKnobs = () => {
 
   return (
     <div>
-      <SaveForLater checked={checked} onClick={() => setChecked(!checked)} />
+      <SaveForLater
+        checked={checked}
+        onChange={() => {
+          setChecked(!checked)
+        }}
+      />
     </div>
   )
 }

--- a/src/elements/save-for-later/src/stories.tsx
+++ b/src/elements/save-for-later/src/stories.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+import SaveForLater from './'
+
+export default {
+  title: 'Elements/Save for later'
+}
+
+export const ExampleWithKnobs = () => {
+  const [checked, setChecked] = React.useState(false)
+
+  return (
+    <div>
+      <SaveForLater checked={checked} onClick={() => setChecked(!checked)} />
+    </div>
+  )
+}


### PR DESCRIPTION
# Description

Small component for implementing as save for later component on a product table.

# Checklist

Pull request contains:

- [X] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [ ] PR description includes screenshot of change
- [X] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
