### PR TITLE
feature/app-download-module

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.35.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.35.0...@uswitch/trustyle.uswitch-theme@2.35.1) (2021-02-17)
+
+
+### Bug Fixes
+
+* Removed unused property from theme.json ([297e47a](https://github.com/uswitch/trustyle/commit/297e47a))
+* Run Prettier ([a7ccf2e](https://github.com/uswitch/trustyle/commit/a7ccf2e))
+* typo ([3fe16d8](https://github.com/uswitch/trustyle/commit/3fe16d8))
+* Use named colour rather than string (thanks Phil) ([b311e17](https://github.com/uswitch/trustyle/commit/b311e17))
+
+
+
+
+
 # [2.35.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.34.6...@uswitch/trustyle.uswitch-theme@2.35.0) (2021-02-11)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3999,10 +3999,7 @@
             "mt": [null, 0, 20],
             "px": 0,
             "py": [45, 0],
-            "height": [null, "100%"],
-            "img": {
-              
-            }
+            "height": [null, "100%"]
           },
           "content": {
             "alignSelf": "center",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3949,7 +3949,11 @@
             "mb": [35, 45, 0],
             "pb": [0],
             "borderBottom": ["1px solid", "1px solid", "none"],
-            "borderBottomColor": ["border-medium-grey", "border-medium-grey", null]
+            "borderBottomColor": [
+              "border-medium-grey",
+              "border-medium-grey",
+              null
+            ]
           },
           "content": {
             "alignSelf": "center",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3328,36 +3328,6 @@
             ]
           }
         },
-        "imageCallout": {
-          "display": "flex",
-          "mb": ["md", "md", "xl"],
-          "pb": ["sm", "sm", 0],
-          "heading": {
-            "a": {
-              "borderBottom": "none"
-            },
-            "pb": ["xxs", "xxs", "sm"]
-          },
-          "content": {
-            "p": {
-              "color": "grey-20",
-              "mb": 0,
-              "fontWeight": "bold",
-              "lineHeight": "sm"
-            }
-          },
-          "image": {
-            "mr": ["sm", "sm", "md"],
-            "borderBottom": "none",
-            "color": "white",
-            "img,svg": {
-              "filter": "invert(100%) sepia(0%) saturate(2%) hue-rotate(234deg) brightness(104%) contrast(101%)",
-              "width": "auto",
-              "height": [21, 28, 28],
-              "mt": [4, 3, 3]
-            }
-          }
-        },
         "provider": {
           "display": "flex",
           "position": "relative",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -234,6 +234,7 @@
     "light-grey": "#F2F2F6",
     "light-grey-content": "#202020",
     "border-light-grey": "#E9E9EC",
+    "border-medium-grey": "#C4C4C4",
     "primary-yellow-100": "#FFD555",
     "primary-yellow-75": "#FFDF80",
     "primary-yellow-50": "#FFEAAA",
@@ -3933,7 +3934,8 @@
             "flexDirection": ["column", "column", "row"],
             "alignItems": ["center", "center", "flex-start"],
             "px": 0,
-            "borderBottom": [null, null, "1px solid #C4C4C4"]
+            "borderBottom": [null, null, "1px solid"],
+            "borderBottomColor": [null, null, "border-medium-grey"]
           },
           "colorBlock": {
             "display": "none"
@@ -3946,7 +3948,8 @@
             "height": [null, "100%"],
             "mb": [35, 45, 0],
             "pb": [0],
-            "borderBottom": ["1px solid #C4C4C4", "1px solid #C4C4C4", "none"]
+            "borderBottom": ["1px solid #C4C4C4", "1px solid #C4C4C4", "none"],
+            "borderBottomColor": ["border-medium-grey", "border-medium-grey", null]
           },
           "content": {
             "alignSelf": "center",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3924,6 +3924,60 @@
         }
       },
       "variants": {
+        "borderBottomImageLeft": {
+          "wrapper": {
+            "pb": [74, 100],
+            "px": 0
+          },
+          "inner": {
+            "flexDirection": ["column", "column", "row"],
+            "alignItems": ["center", "center", "flex-start"],
+            "px": 0,
+            "borderBottom": [null, null, "1px solid #C4C4C4"]
+          },
+          "colorBlock": {
+            "display": "none"
+          },
+          "image-container": {
+            "alignSelf": ["auto", "flex-end"],
+            "mt": [-40, 0, 20],
+            "px": 0,
+            "pt": [45, 0],
+            "height": [null, "100%"],
+            "mb": [35, 45, 0],
+            "pb": [0],
+            "borderBottom": ["1px solid #C4C4C4", "1px solid #C4C4C4", "none"]
+          },
+          "content": {
+            "alignSelf": "center",
+            "px": [20, 0, 0],
+            "textAlign": "left",
+            "maxWidth": ["100%", null, "grid.md.8"],
+            "width": "100%",
+            "flexBasis": [null, "45%"],
+            "h4": {
+              "width": "100%"
+            },
+            "h2": {
+              "fontSize": [32, 40],
+              "mb": 72
+            },
+            "span > h3": {
+              "fontSize": [28, 28],
+              "mb": 72
+            },
+            "p": {
+              "color": "grey-60"
+            }
+          },
+          "image": {
+            "mt": [0],
+            "mb": 0,
+            "maxWidth": ["100%", "100%"],
+            "imgixWidth": 768,
+            "height": ["auto, 100%"]
+          }
+        },
         "solidColorImageLeft": {
           "wrapper": {
             "pb": [74, 100],
@@ -3945,7 +3999,10 @@
             "mt": [null, 0, 20],
             "px": 0,
             "py": [45, 0],
-            "height": [null, "100%"]
+            "height": [null, "100%"],
+            "img": {
+              
+            }
           },
           "content": {
             "alignSelf": "center",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3948,7 +3948,7 @@
             "height": [null, "100%"],
             "mb": [35, 45, 0],
             "pb": [0],
-            "borderBottom": ["1px solid #C4C4C4", "1px solid #C4C4C4", "none"],
+            "borderBottom": ["1px solid", "1px solid", "none"],
             "borderBottomColor": ["border-medium-grey", "border-medium-grey", null]
           },
           "content": {


### PR DESCRIPTION
# Image Callout Module: added variant, "borderBottomImageLeft" 

Added a new theme variant to the ImageCalloutModule based on US: https://www.notion.so/Stefan-App-download-module-1dde81b816ff4297b47d61480f4c6a6e

Most of the the desired functionality in the US is handled by existing components. This change is based on the design in https://www.figma.com/file/8VkEBrLfg3i9C0WINkwMUF/homepage-reskin?node-id=236%3A2

<img width="1370" alt="Screenshot 2021-02-17 at 10 04 23" src="https://user-images.githubusercontent.com/7438448/108188521-94cb6700-7107-11eb-8e46-6b63d18e9ee7.png">

<img width="410" alt="Screenshot 2021-02-16 at 17 08 14" src="https://user-images.githubusercontent.com/7438448/108188579-a44ab000-7107-11eb-9d58-eac832045536.png">
<img width="428" alt="Screenshot 2021-02-16 at 17 08 20" src="https://user-images.githubusercontent.com/7438448/108188592-aa409100-7107-11eb-904f-9d73fdf827e1.png">


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [x] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
