### PR TITLE
Feat: add optional before and after icons to button-link

### DIFF
--- a/src/compounds/ad-banner/CHANGELOG.md
+++ b/src/compounds/ad-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.ad-banner@2.3.9...@uswitch/trustyle.ad-banner@2.3.10) (2021-02-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.ad-banner
+
+
+
+
+
 ## [2.3.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.ad-banner@2.3.7...@uswitch/trustyle.ad-banner@2.3.9) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.ad-banner

--- a/src/compounds/ad-banner/package.json
+++ b/src/compounds/ad-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.ad-banner",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle.awards-tag": "^0.2.0",
-    "@uswitch/trustyle.button-link": "^3.0.4",
+    "@uswitch/trustyle.button-link": "^3.1.0",
     "@uswitch/trustyle.imgix-image": "^0.1.40"
   }
 }

--- a/src/compounds/hero-card/CHANGELOG.md
+++ b/src/compounds/hero-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.16](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-card@2.0.15...@uswitch/trustyle.hero-card@2.0.16) (2021-02-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.hero-card
+
+
+
+
+
 ## [2.0.15](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-card@2.0.13...@uswitch/trustyle.hero-card@2.0.15) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.hero-card

--- a/src/compounds/hero-card/package.json
+++ b/src/compounds/hero-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero-card",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.button-link": "^3.0.4"
+    "@uswitch/trustyle.button-link": "^3.1.0"
   }
 }

--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.8.8...@uswitch/trustyle.legacy-product-table@0.8.9) (2021-02-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.legacy-product-table
+
+
+
+
+
 ## [0.8.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@0.8.7...@uswitch/trustyle.legacy-product-table@0.8.8) (2021-02-18)
 
 **Note:** Version bump only for package @uswitch/trustyle.legacy-product-table

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@uswitch/trustyle.button": "^3.0.4",
-    "@uswitch/trustyle.button-link": "^3.0.4",
+    "@uswitch/trustyle.button-link": "^3.1.0",
     "@uswitch/trustyle.icon": "^1.22.0"
   }
 }

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.21](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.20...@uswitch/trustyle.sponsored-product-rate-table@3.3.21) (2021-02-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.3.20](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.19...@uswitch/trustyle.sponsored-product-rate-table@3.3.20) (2021-02-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,7 +16,7 @@
     "@uswitch/trustyle.arrangement": "^2.0.20",
     "@uswitch/trustyle.awards-tag": "^0.2.0",
     "@uswitch/trustyle.button": "^3.0.4",
-    "@uswitch/trustyle.button-link": "^3.0.4",
+    "@uswitch/trustyle.button-link": "^3.1.0",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.11",

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.20](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.19...@uswitch/trustyle.sponsored-product@3.5.20) (2021-02-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.5.19](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.18...@uswitch/trustyle.sponsored-product@3.5.19) (2021-02-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.5.19",
+  "version": "3.5.20",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -16,7 +16,7 @@
     "@uswitch/trustyle.arrangement": "^2.0.20",
     "@uswitch/trustyle.awards-tag": "^0.2.0",
     "@uswitch/trustyle.badge": "^2.0.4",
-    "@uswitch/trustyle.button-link": "^3.0.4",
+    "@uswitch/trustyle.button-link": "^3.1.0",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.imgix-image": "^0.1.40",

--- a/src/elements/button-link/CHANGELOG.md
+++ b/src/elements/button-link/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.1.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button-link@3.0.4...@uswitch/trustyle.button-link@3.1.0) (2021-02-23)
+
+
+### Bug Fixes
+
+* stories ([ecb0f7a](https://github.com/uswitch/trustyle/commit/ecb0f7a))
+
+
+### Features
+
+* add before and after icons to button-link ([479850a](https://github.com/uswitch/trustyle/commit/479850a))
+
+
+
+
+
 ## [3.0.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button-link@3.0.2...@uswitch/trustyle.button-link@3.0.4) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.button-link

--- a/src/elements/button-link/package.json
+++ b/src/elements/button-link/package.json
@@ -17,6 +17,7 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle-utils.get": "^1.0.9"
+    "@uswitch/trustyle-utils.get": "^1.0.9",
+    "@uswitch/trustyle.icon": "^1.22.0"
   }
 }

--- a/src/elements/button-link/package.json
+++ b/src/elements/button-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button-link",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button-link/src/index.tsx
+++ b/src/elements/button-link/src/index.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { jsx, Styled, useThemeUI } from 'theme-ui'
 import get from '@uswitch/trustyle-utils.get'
+import { Glyph, Icon } from '@uswitch/trustyle.icon'
 
 type Overwrite<T, U> = Omit<T, keyof U> & U
 type Props<T extends React.ComponentType<any>> = Overwrite<
@@ -12,8 +13,8 @@ type Props<T extends React.ComponentType<any>> = Overwrite<
     variant: string
     children: React.ReactNode
     size?: string
-    beforeIcon?: string
-    afterIcon?: string
+    beforeIcon?: Glyph
+    afterIcon?: Glyph
   }
 >
 
@@ -25,9 +26,28 @@ export const ButtonLink = <
   children,
   variant,
   size = 'large',
+  beforeIcon,
+  afterIcon,
   ...props
 }: Props<T>) => {
   const { theme }: any = useThemeUI()
+
+  const displayIcon = (type: string, icon: Glyph) => {
+    return (
+      <div sx={{ display: 'inline', variant: `elements.buttons.${type}` }}>
+        <Icon
+          glyph={icon}
+          color={get(
+            theme,
+            `elements.buttons.variants.${variant}.color`,
+            'base'
+          )}
+          direction="right"
+          size={22}
+        />
+      </div>
+    )
+  }
 
   return (
     <Styled.a
@@ -61,7 +81,9 @@ export const ButtonLink = <
       }}
       {...props}
     >
+      {beforeIcon && displayIcon('beforeIcon', beforeIcon)}
       {children}
+      {afterIcon && displayIcon('afterIcon', afterIcon)}
     </Styled.a>
   )
 }

--- a/src/elements/button-link/src/stories.tsx
+++ b/src/elements/button-link/src/stories.tsx
@@ -24,6 +24,7 @@ export const AllVariants = () => (
             variant={key}
             href="https://www.uswitch.com"
             target="_blank"
+            afterIcon="arrow"
           >
             {text(`${key} label`, `${key} link button`)}
           </ButtonLink>
@@ -54,6 +55,34 @@ export const StyledComponentAsProp = () => (
 )
 
 StyledComponentAsProp.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+export const WithIcons = () => (
+  <React.Fragment>
+    <ButtonLink
+      variant="primary"
+      href="https://www.uswitch.com"
+      target="_blank"
+      beforeIcon="arrow"
+    >
+      Before icon
+    </ButtonLink>
+    <Spacer />
+    <ButtonLink
+      variant="primary"
+      href="https://www.uswitch.com"
+      target="_blank"
+      afterIcon="arrow"
+    >
+      After icon
+    </ButtonLink>
+  </React.Fragment>
+)
+
+WithIcons.story = {
   parameters: {
     percy: { skip: true }
   }

--- a/src/elements/button-link/src/stories.tsx
+++ b/src/elements/button-link/src/stories.tsx
@@ -24,7 +24,6 @@ export const AllVariants = () => (
             variant={key}
             href="https://www.uswitch.com"
             target="_blank"
-            afterIcon="arrow"
           >
             {text(`${key} label`, `${key} link button`)}
           </ButtonLink>

--- a/src/elements/cta/CHANGELOG.md
+++ b/src/elements/cta/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.16](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.cta@1.0.15...@uswitch/trustyle.cta@1.0.16) (2021-02-23)
+
+**Note:** Version bump only for package @uswitch/trustyle.cta
+
+
+
+
+
 ## [1.0.15](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.cta@1.0.13...@uswitch/trustyle.cta@1.0.15) (2021-01-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.cta

--- a/src/elements/cta/package.json
+++ b/src/elements/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.cta",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.9",
-    "@uswitch/trustyle.button-link": "^3.0.4"
+    "@uswitch/trustyle.button-link": "^3.1.0"
   }
 }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1119,6 +1119,20 @@
       }
     },
     "buttons": {
+      "beforeIcon": {
+        "svg": {
+          "display": "inline",
+          "verticalAlign": "text-bottom",
+          "mr": "xs"
+        }
+      },
+      "afterIcon": {
+        "svg": {
+          "display": "inline",
+          "verticalAlign": "text-bottom",
+          "ml": "xs"
+        }
+      },
       "base": {
         "boxSizing": "border-box",
         "fontWeight": "bold",
@@ -1189,6 +1203,9 @@
           "borderColor": "grey-20",
           "borderRadius": 4,
           "backgroundColor": "white"
+        },
+        "buttonLinkIcons": {
+          
         }
       }
     },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1119,20 +1119,6 @@
       }
     },
     "buttons": {
-      "beforeIcon": {
-        "svg": {
-          "display": "inline",
-          "verticalAlign": "text-bottom",
-          "mr": "xs"
-        }
-      },
-      "afterIcon": {
-        "svg": {
-          "display": "inline",
-          "verticalAlign": "text-bottom",
-          "ml": "xs"
-        }
-      },
       "base": {
         "boxSizing": "border-box",
         "fontWeight": "bold",
@@ -1203,9 +1189,6 @@
           "borderColor": "grey-20",
           "borderRadius": 4,
           "backgroundColor": "white"
-        },
-        "buttonLinkIcons": {
-          
         }
       }
     },


### PR DESCRIPTION
# Description

Add optional before and after icons to button-link

![image](https://user-images.githubusercontent.com/56200818/108836222-7f06e780-75c8-11eb-8b8a-10db98e4ab26.png)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
