### PR TITLE
fix: rich bio field for author profile on bankrate

### DIFF
--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.25.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.25.2...@uswitch/trustyle.bankrate-theme@2.25.3) (2021-02-24)
+
+
+### Bug Fixes
+
+* rich bio field for author profile on bankrate ([c047906](https://github.com/uswitch/trustyle/commit/c047906))
+
+
+
+
+
 ## [2.25.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.25.1...@uswitch/trustyle.bankrate-theme@2.25.2) (2021-02-24)
 
 

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.25.2",
+  "version": "2.25.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -240,7 +240,13 @@
           "a": { "mx": "sm" }
         },
         "bio": {
-          "mt": "xs"
+          "mt": "xs",
+          "span:first-of-type>*": {
+            "mt": 0
+          },
+          "span>*": {
+            "mb": 0
+          }
         },
         "name": {
           "mb": "md",


### PR DESCRIPTION
# Description

Fixed Bankrate theme to allow rich text elements as author profile biography.

<img width="504" alt="bankrate-desktop-centered" src="https://user-images.githubusercontent.com/78726823/108837368-6b607e80-75d2-11eb-8642-c9ca0868db75.PNG">
<img width="494" alt="bankrate-desktop-left" src="https://user-images.githubusercontent.com/78726823/108837373-6d2a4200-75d2-11eb-8c86-c88d150c78e9.PNG">
<img width="353" alt="bankrate-phone-centered" src="https://user-images.githubusercontent.com/78726823/108837377-6f8c9c00-75d2-11eb-9eef-8195c333c3ae.PNG">
<img width="339" alt="bankrate-phone-left" src="https://user-images.githubusercontent.com/78726823/108837380-71565f80-75d2-11eb-9cc2-ced8ea158161.PNG">


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
