### PR TITLE
Fix product rows so they are always 100%

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.13.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.13.12...@uswitch/trustyle.product-table@2.13.13) (2021-02-24)
+
+
+### Bug Fixes
+
+* product rows so they are always 100% ([f495983](https://github.com/uswitch/trustyle/commit/f495983))
+
+
+
+
+
 ## [2.13.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.13.11...@uswitch/trustyle.product-table@2.13.12) (2021-01-25)
 
 **Note:** Version bump only for package @uswitch/trustyle.product-table

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.13.12",
+  "version": "2.13.13",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -119,7 +119,8 @@ const ProductTableRow: React.FC<RowProps> = ({
           pointerEvents: disabled ? 'none' : null,
           opacity: disabled ? '0.5' : '1',
           pb: card ? '50px' : '0',
-          overflow: card ? 'hidden' : 'visible'
+          overflow: card ? 'hidden' : 'visible',
+          width: '100%'
         }}
       >
         <RowWrapper link={clickableRow} headerImage={image}>


### PR DESCRIPTION
# Description

Ref: https://app.asana.com/0/1199920669936537/1199921369865118

![Screenshot 2021-02-23 at 16 35 31](https://user-images.githubusercontent.com/15983736/108875508-2ac62c80-75f5-11eb-928e-056e4eb5cdbc.png)

Also tested: http://localhost:3000/mortgages, and works as expected 👍 

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
