### PR TITLE
fix: Left align email capture form, use grid value instead of per cent, add margin bottom

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.38.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.38.2...@uswitch/trustyle.uswitch-theme@2.38.3) (2021-03-03)
+
+
+### Bug Fixes
+
+* Left align email capture form, use grid value instead of per cent, add margin bottom ([ce347f1](https://github.com/uswitch/trustyle/commit/ce347f1))
+
+
+
+
+
 ## [2.38.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.38.1...@uswitch/trustyle.uswitch-theme@2.38.2) (2021-02-26)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.38.2",
+  "version": "2.38.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -4215,7 +4215,8 @@
           "container": {
             "mt": [16, 24, 32],
             "ml": [0],
-            "mr": [0]
+            "mr": [0],
+            "mb": [16, 24, 32]
           },
           "copy": {
             "textAlign": "left",
@@ -4236,8 +4237,8 @@
           "innerContainer": {
             "border": "1px #000 solid",
             "padding": ["base", "md", 32],
-            "width": ["100%", "555px", "66%"],
-            "mx": "auto",
+            "width": ["100%", "555px", "grid.lg.8"],
+            "mx": ["auto", "auto", 0],
             "max-width": ["555px", "100%"],
             "boxShadow": "box"
           },


### PR DESCRIPTION
# Description

Styles for leadCaptureForm email-capture variant to align left on desktop, add padding, plus make us of grid size value rather than per cent

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
