### PR TITLE
Fix/completed steps fully visible

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.44.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.44.0...@uswitch/trustyle.money-theme@1.44.1) (2021-03-08)
+
+
+### Bug Fixes
+
+* make completed steps fully visible ([e9cd4fc](https://github.com/uswitch/trustyle/commit/e9cd4fc))
+
+
+
+
+
 # [1.44.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.43.9...@uswitch/trustyle.money-theme@1.44.0) (2021-03-05)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1518,6 +1518,7 @@
             "color": "plum",
             "paddingX": "lg",
             "paddingY": 0,
+            "opacity": 0.8,
             "submit": {
               "backgroundColor": "white",
               "borderRadius": "4px",
@@ -1609,7 +1610,8 @@
           },
           "isComplete": {
             "wrapper": {
-              "variant": "elements.form-section.default.elements.wrapper"
+              "variant": "elements.form-section.default.elements.wrapper",
+              "opacity": 1
             },
             "heading": {
               "variant": "elements.form-section.default.elements.heading",


### PR DESCRIPTION
# Description

Ref: https://app.asana.com/0/1183943778484274/1199956404467233
Page: https://money-core-preview.external.usw.co/pensions/pension-enquiry.htm

Make completed and active form steps fully visible. Give incomplete steps 0.8 opacity.

![Screenshot 2021-03-05 at 16 05 21](https://user-images.githubusercontent.com/15983736/110141003-9ca82e00-7dcc-11eb-9868-2981ae055935.png)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
