### PR TITLE
feat: styled postcode/registraion with email variant for all breakpoints

### DIFF
--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.42.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.41.7...@uswitch/trustyle.uswitch-theme@2.42.0) (2021-03-10)
+
+
+### Bug Fixes
+
+* prettier ([c5f1ebd](https://github.com/uswitch/trustyle/commit/c5f1ebd))
+
+
+### Features
+
+* styled postcode/registraion with email variant for all breakpoints ([fa2c2b1](https://github.com/uswitch/trustyle/commit/fa2c2b1))
+
+
+
+
+
 ## [2.41.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.41.6...@uswitch/trustyle.uswitch-theme@2.41.7) (2021-03-10)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.41.7",
+  "version": "2.42.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -4277,13 +4277,13 @@
             "justifyContent": "space-between",
             "padding": ["sm", 0]
           },
-          "consent-text": { 
-            "textAlign": "left", 
+          "consent-text": {
+            "textAlign": "left",
             "my": 0,
             "mx": 0,
             "display": "flex",
             "alignItems": "baseline",
-            "p" : {
+            "p": {
               "my": 0
             },
             "a": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -4186,7 +4186,10 @@
     "lead-capture-form": {
       "base": {
         "container": {
-          "mx": [-15, 0],
+          "mt": [16, 24, 32],
+          "ml": [0],
+          "mr": [0],
+          "mb": [16, 24, 32],
           ".sticky": {
             "minHeight": ["105px", "172px"]
           }
@@ -4255,6 +4258,39 @@
         }
       },
       "variants": {
+        "postRegWithEmail": {
+          "innerContainer": {
+            "width": ["100%"],
+            "maxWidth": ["555px", "100%"],
+            "mx": ["auto", 0],
+            "backgroundColor": "white"
+          },
+          "submit": {
+            "marginTop": "sm",
+            "mx": [0, "md"],
+            "marginBottom": [0, "md"],
+            "width": ["100%", "100%", "260px"]
+          },
+          "postCodeLead": {
+            "height": [null, "86px"],
+            "display": "flex",
+            "justifyContent": "space-between",
+            "padding": ["sm", 0]
+          },
+          "consent-text": { 
+            "textAlign": "left", 
+            "my": 0,
+            "mx": 0,
+            "display": "flex",
+            "alignItems": "baseline",
+            "p" : {
+              "my": 0
+            },
+            "a": {
+              "marginBottom": 0
+            }
+          }
+        },
         "emailCapture": {
           "container": {
             "mt": [16, 24, 32],
@@ -4283,7 +4319,7 @@
             "padding": ["base", "md", 32],
             "width": ["100%", "555px", "grid.lg.8"],
             "mx": ["auto", "auto", 0],
-            "max-width": ["555px", "100%"],
+            "maxWidth": ["555px", "100%"],
             "boxShadow": "box"
           },
           "errorAlert": {


### PR DESCRIPTION
# Description

Added styles for hero versions of posctode and care registration capture that also feature email capture.

Once eevee is also updated, this will allow contenful users to add email capture to lead-capture forms 

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
