### PR TITLE
Feat: add centered sponsored-by variant

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.46.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.45.1...@uswitch/trustyle.money-theme@1.46.0) (2021-03-11)
+
+
+### Features
+
+* add centered sponsored-by variant ([c4a1a13](https://github.com/uswitch/trustyle/commit/c4a1a13))
+
+
+
+
+
 ## [1.45.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.45.0...@uswitch/trustyle.money-theme@1.45.1) (2021-03-10)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -389,6 +389,10 @@
             "width": "149px",
             "height": "auto"
           }
+        },
+        "centered": {
+          "display": "inline-block",
+          "align-items": "center"
         }
       }
     },


### PR DESCRIPTION
# Description

Styling for `centered` sponsored-by variant.

![Screenshot 2021-03-11 at 14 29 00](https://user-images.githubusercontent.com/15983736/110802475-2301bb80-8276-11eb-8bb1-957c4d998c56.png)

![Screenshot 2021-03-11 at 14 28 51](https://user-images.githubusercontent.com/15983736/110802492-25641580-8276-11eb-8f7b-8f525241b2e5.png)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
