### PR TITLE
fix: overide specificity for card info component

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3874,14 +3874,14 @@
           "py": "xxs",
           "a": {
             "borderBottom": "none",
-            "mb": 0
+            "mb": 0,
+            "img": {
+              "width": 14,
+              "mt": 0,
+              "mr": "xxs"
+            }
           },
-          "img": {
-            "width": 14,
-            "mt": 0,
-            "mr": "xxs"
-          },
-          "h3": {
+          "h3[class*='Card']": {
             "fontSize": "xxs",
             "fontWeight": "bold",
             "lineHeight": "base",


### PR DESCRIPTION
# Description

Adds more css specificity to override the one set for the rich-text-block.

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
