### PR TITLE
fix: add explicit tabindex to sidenav links

### DIFF
--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.52](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.51...@uswitch/trustyle.side-nav@1.0.52) (2021-03-18)
+
+
+### Bug Fixes
+
+* add explicit tabindex to sidenav links ([6d83702](https://github.com/uswitch/trustyle/commit/6d83702))
+
+
+
+
+
 ## [1.0.51](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.50...@uswitch/trustyle.side-nav@1.0.51) (2021-03-08)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-nav

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/side-nav/src/index.tsx
+++ b/src/compounds/side-nav/src/index.tsx
@@ -54,6 +54,7 @@ const SideNav: React.FC<Props> = ({
                     as={'a'}
                     px={{ color: 'textColor' }}
                     href={url}
+                    tabindex="0"
                     sx={{ borderBottom: 0 }}
                   >
                     {text}


### PR DESCRIPTION
# Description

Explicit `tabindex` attribute (with the default value of 0) has been added to the link in side nav element to help with the way browsers apply default styles to focused elements.

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
