### PR TITLE
feat: add row clickout callback function for usage in segment tracking

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.14.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.14.0...@uswitch/trustyle.product-table@2.14.1) (2021-03-25)
+
+
+### Bug Fixes
+
+* prettier ([711c018](https://github.com/uswitch/trustyle/commit/711c018))
+
+
+
+
+
 # [2.14.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.13.17...@uswitch/trustyle.product-table@2.14.0) (2021-03-25)
 
 

--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.14.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.13.17...@uswitch/trustyle.product-table@2.14.0) (2021-03-25)
+
+
+### Features
+
+* add row clickout callback function for usage in segment tracking ([7b237a8](https://github.com/uswitch/trustyle/commit/7b237a8))
+
+
+
+
+
 ## [2.13.17](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.13.16...@uswitch/trustyle.product-table@2.13.17) (2021-03-09)
 
 **Note:** Version bump only for package @uswitch/trustyle.product-table

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.13.17",
+  "version": "2.14.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -29,6 +29,7 @@ export interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   card?: boolean
   extraStyles?: {}
   sectionStyles?: {}
+  onRowClick?: () => void
 }
 
 const ProductTableRow: React.FC<RowProps> = ({
@@ -44,7 +45,8 @@ const ProductTableRow: React.FC<RowProps> = ({
   disabled,
   card = false,
   extraStyles = {},
-  sectionStyles = {}
+  sectionStyles = {},
+  onRowClick,
 }) => {
   const forcedMobile = forceMobile(card)
 
@@ -124,7 +126,7 @@ const ProductTableRow: React.FC<RowProps> = ({
           ...sectionStyles
         }}
       >
-        <RowWrapper link={clickableRow} headerImage={image}>
+        <RowWrapper link={clickableRow} headerImage={image} onRowClick={onRowClick}>
           {!!badges.length && (
             <div
               sx={{

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -46,7 +46,7 @@ const ProductTableRow: React.FC<RowProps> = ({
   card = false,
   extraStyles = {},
   sectionStyles = {},
-  onRowClick,
+  onRowClick
 }) => {
   const forcedMobile = forceMobile(card)
 
@@ -126,7 +126,11 @@ const ProductTableRow: React.FC<RowProps> = ({
           ...sectionStyles
         }}
       >
-        <RowWrapper link={clickableRow} headerImage={image} onRowClick={onRowClick}>
+        <RowWrapper
+          link={clickableRow}
+          headerImage={image}
+          onRowClick={onRowClick}
+        >
           {!!badges.length && (
             <div
               sx={{

--- a/src/compounds/product-table/src/components/rowWrapper.tsx
+++ b/src/compounds/product-table/src/components/rowWrapper.tsx
@@ -7,6 +7,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   link?: string
   children?: React.ReactNode
   headerImage?: React.ReactNode
+  onRowClick?: () => void
 }
 
 const checkClickTargetIsAccordion = (n: number, e: any) => {
@@ -28,16 +29,19 @@ const checkClickTargetIsLink = (e: any) => {
   }
 }
 
-const linkWrapper = (
-  link: string,
-  children: React.ReactNode,
+interface LinkWrapperOptions {
+  link: string
+  children: React.ReactNode
   headerImage?: React.ReactNode
-) => {
+  onRowClick?: () => void
+}
+const linkWrapper = (options: LinkWrapperOptions) => {
+  const { link, children, headerImage, onRowClick } = options
   const handleClick = (e: any) => {
     if (checkClickTargetIsAccordion(10, e) && !checkClickTargetIsLink(e)) {
       e.preventDefault()
     }
-
+    if (onRowClick) onRowClick()
     return e
   }
 
@@ -67,10 +71,11 @@ const RowWrapper: React.FC<Props> = ({
   children,
   headerImage,
   sx = {},
-  className
+  className,
+  onRowClick,
 }) => {
   return link ? (
-    linkWrapper(link, children, headerImage)
+    linkWrapper({ link, children, headerImage, onRowClick })
   ) : (
     <div
       sx={{

--- a/src/compounds/product-table/src/components/rowWrapper.tsx
+++ b/src/compounds/product-table/src/components/rowWrapper.tsx
@@ -72,7 +72,7 @@ const RowWrapper: React.FC<Props> = ({
   headerImage,
   sx = {},
   className,
-  onRowClick,
+  onRowClick
 }) => {
   return link ? (
     linkWrapper({ link, children, headerImage, onRowClick })


### PR DESCRIPTION
It's just a callback passed through the row props so it can eventually be called when the link is pressed.