### PR TITLE
fix: issue where the call out doesnt appear to be bold enough

### DIFF
--- a/src/elements/call-out/CHANGELOG.md
+++ b/src/elements/call-out/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.18](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.1.17...@uswitch/trustyle.call-out@2.1.18) (2021-03-29)
+
+
+### Bug Fixes
+
+* issue where the call out doesnt appear to be bold enough ([abadf64](https://github.com/uswitch/trustyle/commit/abadf64))
+
+
+
+
+
 ## [2.1.17](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.call-out@2.1.16...@uswitch/trustyle.call-out@2.1.17) (2021-03-08)
 
 **Note:** Version bump only for package @uswitch/trustyle.call-out

--- a/src/elements/call-out/package.json
+++ b/src/elements/call-out/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.call-out",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/call-out/src/index.tsx
+++ b/src/elements/call-out/src/index.tsx
@@ -42,7 +42,7 @@ const CallOut: React.FC<Props> = ({
         sx={{
           marginY: 0,
           variant: 'elements.call-out.text',
-          fontWeight: bold ? 'bold' : 'normal'
+          fontWeight: bold ? '700' : 'normal'
         }}
         px={{
           color: 'accentColorText'


### PR DESCRIPTION
# Description

Change this so it overrides bold on uswitch being set to 500

![image](https://user-images.githubusercontent.com/630034/112841127-077d1a00-9098-11eb-9f72-4d8cde6a1122.png)


# Checklist

Pull request contains:

- [x] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [x] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
