### PR TITLE
fix: add sponsored by centered variant color to theme

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.46.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.46.0...@uswitch/trustyle.money-theme@1.46.1) (2021-03-30)
+
+
+### Bug Fixes
+
+* add centered-light variant ([1324e32](https://github.com/uswitch/trustyle/commit/1324e32))
+* add sponsored by centered variant color to theme ([a44a291](https://github.com/uswitch/trustyle/commit/a44a291))
+
+
+
+
+
 # [1.46.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.45.1...@uswitch/trustyle.money-theme@1.46.0) (2021-03-11)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -392,7 +392,10 @@
         },
         "centered": {
           "display": "inline-block",
-          "align-items": "center"
+          "align-items": "center",
+          "text": {
+            "color": "white"
+          }
         }
       }
     },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -392,7 +392,10 @@
         },
         "centered": {
           "display": "inline-block",
-          "align-items": "center",
+          "align-items": "center"
+        },
+        "centered-light": {
+          "variant": "elements.sponsored-by-tag.variants.centered",
           "text": {
             "color": "white"
           }


### PR DESCRIPTION
# Description

Add sponsored by variant color to money theme

![image](https://user-images.githubusercontent.com/56200818/112860976-45843900-90ac-11eb-80a7-594ecf997e4e.png)

![image](https://user-images.githubusercontent.com/56200818/112861037-5634af00-90ac-11eb-8583-bf55febe4832.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
