### PR TITLE
fix: be more specic for simple drop down border

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.46.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.46.2...@uswitch/trustyle.money-theme@1.46.3) (2021-04-08)
+
+
+### Bug Fixes
+
+* be more specic for simple drop down border ([bc919d6](https://github.com/uswitch/trustyle/commit/bc919d6))
+
+
+
+
+
 ## [1.46.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.46.1...@uswitch/trustyle.money-theme@1.46.2) (2021-03-30)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.46.2",
+  "version": "1.46.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1401,7 +1401,10 @@
         "error": {
           "variant": "elements.simple-drop-down.select.base",
           "border": "2px solid",
-          "borderColor": "error",
+          "borderTopColor": "error",
+          "borderBottomColor": "error",
+          "borderRightColor": "error",
+          "borderLeftColor": "error",
           "outlineColor": "error"
         },
         "focus": {


### PR DESCRIPTION
# Description

In https://money.co.uk/pensions/pension-enquiry.htm?tracking=false the dropdown borders aren't behaving as expected for an error state.

<img width="459" alt="Screenshot 2021-04-08 at 12 02 02" src="https://user-images.githubusercontent.com/15983736/114016411-b2dd5a00-9862-11eb-8237-9da293ab008b.png">

The border is being overwritten by `initial`.

<img width="286" alt="Screenshot 2021-04-08 at 12 08 42" src="https://user-images.githubusercontent.com/15983736/114016840-2e3f0b80-9863-11eb-8e6e-5edfcd6f69a3.png">

This can be fixed by being more specific for each of the borders.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
