### PR TITLE
feat: add custom more info label

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.1.2...@uswitch/trustyle.legacy-product-table@1.2.0) (2021-04-15)
+
+
+### Features
+
+* add custom more info label ([b444668](https://github.com/uswitch/trustyle/commit/b444668))
+
+
+
+
+
 ## [1.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.1.1...@uswitch/trustyle.legacy-product-table@1.1.2) (2021-04-14)
 
 **Note:** Version bump only for package @uswitch/trustyle.legacy-product-table

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -489,11 +489,13 @@ export const MoreInformationList: React.FC<MoreInformationListProps> = ({
 interface EligibilityProps extends React.HTMLAttributes<HTMLDivElement> {
   moreInformationPanel: React.ReactNode[]
   moreInformationButton?: React.ReactNode
+  moreInformationLabel?: string
 }
 
 const Eligibility: React.FC<EligibilityProps> = ({
   moreInformationPanel,
-  moreInformationButton
+  moreInformationButton,
+  moreInformationLabel = 'More information'
 }) => {
   const [open, setOpen] = React.useState(false)
 
@@ -550,7 +552,7 @@ const Eligibility: React.FC<EligibilityProps> = ({
         }}
         onClick={() => setOpen(!open)}
       >
-        <div sx={{ pr: '15px' }}>More information</div>
+        <div sx={{ pr: '15px' }}>{moreInformationLabel}</div>
         <Icon
           color="#34454E"
           glyph={'caret'}
@@ -606,6 +608,7 @@ interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   moreInformationPanel?: React.ReactNode[]
   clickableRow?: string
   moreInformationButton?: React.ReactNode
+  moreInformationLabel?: string
   onRowClick?: () => void
   disabled?: boolean
   badges?: string[]
@@ -618,6 +621,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
   title,
   representativeExample,
   moreInformationPanel,
+  moreInformationLabel,
   clickableRow,
   moreInformationButton,
   onRowClick,
@@ -705,6 +709,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
         <Eligibility
           moreInformationPanel={moreInformationPanel}
           moreInformationButton={moreInformationButton}
+          moreInformationLabel={moreInformationLabel}
         />
       )}
     </article>

--- a/src/compounds/legacy-product-table/src/stories.tsx
+++ b/src/compounds/legacy-product-table/src/stories.tsx
@@ -29,6 +29,8 @@ const info = [
 ]
 const title = 'Lowest representative APR'
 
+const moreInfoLabel = 'Custom More Info Label'
+
 const clickableRow = 'https://www.money.co.uk'
 
 const baseTableContents = [
@@ -316,6 +318,7 @@ export const EligibilityExample = () => {
       clickableRow={clickableRow}
       moreInformationPanel={[eligibilityContent, ratesContent]}
       moreInformationButton={moreInformationButton}
+      moreInformationLabel={moreInfoLabel}
     >
       {productTableContents}
     </LegacyProductTable>


### PR DESCRIPTION
# Description

This adds support for customising the more info label

![image](https://user-images.githubusercontent.com/630034/114880877-606be280-9dfa-11eb-996d-ac8aa2f78077.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
