### PR TITLE
align sponsored by logo with text

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.29](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.28...@uswitch/trustyle.sponsored-product-rate-table@3.3.29) (2021-04-21)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.3.28](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.27...@uswitch/trustyle.sponsored-product-rate-table@3.3.28) (2021-04-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.3.28",
+  "version": "3.3.29",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.11",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.2.0",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.2.1",
     "@uswitch/trustyle.usp-tag": "^0.1.6"
   },
   "devDependencies": {

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.28](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.27...@uswitch/trustyle.sponsored-product@3.5.28) (2021-04-21)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.5.27](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.26...@uswitch/trustyle.sponsored-product@3.5.27) (2021-04-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.5.27",
+  "version": "3.5.28",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,7 +21,7 @@
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.11",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.2.0",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.2.1",
     "@uswitch/trustyle.usp-tag": "^0.1.6"
   },
   "devDependencies": {

--- a/src/elements/sponsored-by-tag/CHANGELOG.md
+++ b/src/elements/sponsored-by-tag/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.2.0...@uswitch/trustyle.sponsored-by-tag@2.2.1) (2021-04-21)
+
+
+### Bug Fixes
+
+* align sponsored by logo with text ([6bf13c3](https://github.com/uswitch/trustyle/commit/6bf13c3))
+* form story ([e8daab3](https://github.com/uswitch/trustyle/commit/e8daab3))
+
+
+
+
+
 # [2.2.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.1.2...@uswitch/trustyle.sponsored-by-tag@2.2.0) (2020-12-15)
 
 

--- a/src/elements/sponsored-by-tag/package.json
+++ b/src/elements/sponsored-by-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-by-tag",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -27,7 +27,9 @@ const SponsoredByTag: React.FC<Props> = ({
   <div
     className={className}
     sx={{
-      variant: `${lookup(variant)}.wrapper`
+      variant: `${lookup(variant)}.wrapper`,
+      display: 'flex',
+      alignItems: 'center'
     }}
   >
     <span


### PR DESCRIPTION
# Description

Fixes the alignment of text and logo in sponsored by component

broken version from: 
<img width="362" alt="Screenshot 2021-04-21 at 12 34 40" src="https://user-images.githubusercontent.com/350343/115547501-3b65ec80-a29e-11eb-9be4-e65addc5c75a.png">

fixed to: 
<img width="376" alt="Screenshot 2021-04-21 at 12 34 04" src="https://user-images.githubusercontent.com/350343/115547535-4587eb00-a29e-11eb-9a61-640d32f7de26.png">


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
