### PR TITLE
flex fix for sponsored by tag

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.30](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.29...@uswitch/trustyle.sponsored-product-rate-table@3.3.30) (2021-04-22)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.3.29](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.28...@uswitch/trustyle.sponsored-product-rate-table@3.3.29) (2021-04-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.3.29",
+  "version": "3.3.30",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.11",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.2.1",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.2.2",
     "@uswitch/trustyle.usp-tag": "^0.1.6"
   },
   "devDependencies": {

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.29](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.28...@uswitch/trustyle.sponsored-product@3.5.29) (2021-04-22)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.5.28](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.27...@uswitch/trustyle.sponsored-product@3.5.28) (2021-04-21)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.5.28",
+  "version": "3.5.29",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,7 +21,7 @@
     "@uswitch/trustyle.grid": "^2.0.13",
     "@uswitch/trustyle.imgix-image": "^0.1.40",
     "@uswitch/trustyle.primary-info-block": "^1.0.11",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.2.1",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.2.2",
     "@uswitch/trustyle.usp-tag": "^0.1.6"
   },
   "devDependencies": {

--- a/src/elements/sponsored-by-tag/CHANGELOG.md
+++ b/src/elements/sponsored-by-tag/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.2.1...@uswitch/trustyle.sponsored-by-tag@2.2.2) (2021-04-22)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-by-tag
+
+
+
+
+
 ## [2.2.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.2.0...@uswitch/trustyle.sponsored-by-tag@2.2.1) (2021-04-21)
 
 

--- a/src/elements/sponsored-by-tag/package.json
+++ b/src/elements/sponsored-by-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-by-tag",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -27,9 +27,9 @@ const SponsoredByTag: React.FC<Props> = ({
   <div
     className={className}
     sx={{
-      variant: `${lookup(variant)}.wrapper`,
-      display: 'inline-flex',
-      alignItems: 'center'
+      display: 'flex',
+      alignItems: 'center',
+      variant: `${lookup(variant)}.wrapper`
     }}
   >
     <span

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -14,7 +14,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   className?: string
   providerText?: string
   providerName: string
-  variant?: 'base' | 'hero' | 'form'
+  variant?: 'base' | 'hero' | 'form' | 'centered-light'
 }
 
 const SponsoredByTag: React.FC<Props> = ({
@@ -28,7 +28,7 @@ const SponsoredByTag: React.FC<Props> = ({
     className={className}
     sx={{
       variant: `${lookup(variant)}.wrapper`,
-      display: 'flex',
+      display: 'inline-flex',
       alignItems: 'center'
     }}
   >

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -139,6 +139,7 @@ export const AutomatedTests = () => {
       <ExampleWithTextProp />
       <ExampleWithHeroVariant />
       <ExampleWithFormVariant />
+      <ExampleWithCentredLightVariant />
     </AllThemes>
   )
 }

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -87,6 +87,28 @@ export const ExampleWithFormVariant = () => {
   )
 }
 
+export const ExampleWithCentredLightVariant = () => {
+  const providerName: string = text('Provider name', 'Three')
+  const providerLogo: string = text(
+    'Provider logo url',
+    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+  )
+
+  const providerText: string = text('Text to display', 'You selected:')
+  return (
+    <React.Fragment>
+      <div sx={{ backgroundColor: 'secondary' }}>
+        <SponsoredByTag
+          providerLogoSrc={providerLogo}
+          providerText={providerText}
+          providerName={providerName}
+          variant="centered-light"
+        />
+      </div>
+    </React.Fragment>
+  )
+}
+
 ExampleWithDefaultText.story = {
   parameters: {
     percy: { skip: true }

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.46.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.46.5...@uswitch/trustyle.money-theme@1.46.6) (2021-04-22)
+
+**Note:** Version bump only for package @uswitch/trustyle.money-theme
+
+
+
+
+
 ## [1.46.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.46.4...@uswitch/trustyle.money-theme@1.46.5) (2021-04-22)
 
 **Note:** Version bump only for package @uswitch/trustyle.money-theme

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.46.5",
+  "version": "1.46.6",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -397,6 +397,13 @@
         },
         "centered-light": {
           "variant": "elements.sponsored-by-tag.variants.centered",
+          "wrapper": {
+            "display": "inline-flex !important",
+            "alignItems": "center",
+            "justifyContent": "flex-end",
+            "paddingY": "xxs",
+            "pt": "md"
+          },
           "text": {
             "color": "white"
           },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -399,6 +399,9 @@
           "variant": "elements.sponsored-by-tag.variants.centered",
           "text": {
             "color": "white"
+          },
+          "image": {
+            "ml": "10px"
           }
         }
       }


### PR DESCRIPTION
# Description

Flex breaks the sponsor hero on fs-core like this: 

<img width="1054" alt="Screenshot 2021-04-22 at 11 38 08" src="https://user-images.githubusercontent.com/350343/115701224-7bd96f00-a35f-11eb-8553-e7c7c7efea64.png">

Changed to inline-flex: 

<img width="440" alt="Screenshot 2021-04-22 at 11 38 28" src="https://user-images.githubusercontent.com/350343/115701260-8267e680-a35f-11eb-8c0e-f053e08b4cd2.png">


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
