### PR TITLE
Add option to blur backdrop to modal

### DIFF
--- a/src/compounds/phone-number-modal/CHANGELOG.md
+++ b/src/compounds/phone-number-modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.phone-number-modal@0.1.1...@uswitch/trustyle.phone-number-modal@0.1.2) (2021-05-10)
+
+**Note:** Version bump only for package @uswitch/trustyle.phone-number-modal
+
+
+
+
+
 ## [0.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.phone-number-modal@0.1.0...@uswitch/trustyle.phone-number-modal@0.1.1) (2021-05-10)
 
 

--- a/src/compounds/phone-number-modal/package.json
+++ b/src/compounds/phone-number-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.phone-number-modal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -18,6 +18,6 @@
   "dependencies": {
     "@uswitch/trustyle.icon": "^1.26.3",
     "@uswitch/trustyle.imgix-image": "^0.1.41",
-    "@uswitch/trustyle.modal": "^2.4.16"
+    "@uswitch/trustyle.modal": "^2.4.17"
   }
 }

--- a/src/elements/modal/CHANGELOG.md
+++ b/src/elements/modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.4.17](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.4.16...@uswitch/trustyle.modal@2.4.17) (2021-05-10)
+
+**Note:** Version bump only for package @uswitch/trustyle.modal
+
+
+
+
+
 ## [2.4.16](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.4.15...@uswitch/trustyle.modal@2.4.16) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.modal

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.modal",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/modal/src/index.tsx
+++ b/src/elements/modal/src/index.tsx
@@ -26,6 +26,7 @@ interface Props {
   onClose?: OnCloseFn
   role?: ModalRole
   focusLockProps?: FocusLockProps
+  backdropBlur?: boolean
 }
 
 interface OverlayProps {
@@ -36,6 +37,7 @@ interface OverlayProps {
   onClose?: OnCloseFn
   role: ModalRole
   focusLockProps: FocusLockProps
+  backdropBlur: boolean
 }
 
 interface OverlayIndexingContext {
@@ -58,7 +60,8 @@ const Overlay: React.FC<OverlayProps> = ({
   closeButtonProps,
   height,
   onClose,
-  role
+  role,
+  backdropBlur
 }) => {
   const holdingRef = useRef<HTMLDivElement>()
   const closeButtonRef = useRef<HTMLButtonElement>()
@@ -132,6 +135,7 @@ const Overlay: React.FC<OverlayProps> = ({
         transform: 'translateZ(0)',
         width: '100%',
         zIndex: 10000,
+        backdropFilter: backdropBlur ? 'blur(6px)' : 'none', // currently unsupported by Firefox & IE
         variant: 'elements.overlay'
       }}
       style={{
@@ -232,12 +236,14 @@ const Modal: React.FC<Props> = ({
   height = 'partial',
   role = 'dialog',
   focusLockProps = {},
+  backdropBlur = false,
   ...props
 }) => (
   <Overlay
     height={height}
     role={role}
     focusLockProps={focusLockProps}
+    backdropBlur={backdropBlur}
     {...props}
   >
     {children}

--- a/src/elements/modal/src/stories.tsx
+++ b/src/elements/modal/src/stories.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { Fragment } from 'react'
 import { action } from '@storybook/addon-actions'
 
 import AllThemes from '../../../utils/all-themes'
@@ -109,6 +110,31 @@ export const NestedModals = () => (
 )
 
 NestedModals.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+export const WithBlurredBackdrop = () => (
+  <Fragment>
+    {[...Array(10)].map((_, i) => (
+      <p key={i}>test</p>
+    ))}
+    <Modal
+      backdropBlur
+      ariaLabel="An example modal element"
+      onClose={action('Clicked close')}
+      focusLockProps={{
+        whiteList: node =>
+          document.getElementById('app')?.contains(node) ?? false
+      }}
+    >
+      Modal content
+    </Modal>
+  </Fragment>
+)
+
+WithBlurredBackdrop.story = {
   parameters: {
     percy: { skip: true }
   }


### PR DESCRIPTION
# Description

Allow `backdropBlur` prop to be passed to Modal for blurred background effect. Uses `backdrop-filter` which is currently unsupported by Firefox (planned) & IE

# Checklist

Pull request contains:

- [ ] A new component
- [X ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

![Screenshot 2021-05-10 at 11 41 02](https://user-images.githubusercontent.com/21021507/117648965-d445a480-b186-11eb-9a6f-ba8faf06e1bb.png)

