### PR TITLE
Add phone number modal to legacy product table

### DIFF
--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@uswitch/trustyle.button": "^3.0.5",
     "@uswitch/trustyle.button-link": "^3.2.5",
-    "@uswitch/trustyle.icon": "^1.26.3"
+    "@uswitch/trustyle.icon": "^1.26.3",
+    "@uswitch/trustyle.phone-number-modal": "^0.1.1"
   }
 }

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -1,10 +1,12 @@
 /** @jsx jsx */
 
-import * as React from 'react'
+import React, { useState } from 'react'
 import { jsx, Styled, useThemeUI } from 'theme-ui'
 import { ButtonLink } from '@uswitch/trustyle.button-link'
 import { Button } from '@uswitch/trustyle.button'
 import { Icon } from '@uswitch/trustyle.icon'
+
+import PhoneNumberModal from '../../phone-number-modal/src'
 
 import RowWrapper from './row-wrapper'
 
@@ -603,6 +605,17 @@ const TelephoneInfo: React.FC<TelephoneInfoProps> = ({ telephone }) => {
   )
 }
 
+// Shared type with phone-number-modal
+interface PhoneNumber {
+  phoneNumber: string
+  logoUrl: string
+  logoDescription: string
+  termsAndConditions: string
+  openingTimes?: string[]
+  url?: string
+  complianceText: string[]
+}
+
 interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   info: string[]
   title: string
@@ -614,7 +627,7 @@ interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   onRowClick?: () => void
   disabled?: boolean
   badges?: string[]
-  telephone?: string
+  phoneNumber?: PhoneNumber
 }
 
 const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
@@ -629,10 +642,12 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
   onRowClick,
   disabled,
   badges = [],
-  telephone,
+  phoneNumber,
   ...props
 }) => {
   const badge = badges[0]
+  const [isModalOpen, setPhoneModalOpen] = useState(false)
+
   return (
     <article
       sx={{
@@ -651,9 +666,24 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
       }}
       {...props}
     >
+      {phoneNumber && (
+        <PhoneNumberModal
+          phoneNumber={phoneNumber}
+          isOpen={isModalOpen}
+          setStateClosed={() => setPhoneModalOpen(false)}
+        />
+      )}
       <RowWrapper
+        hasModal={!!phoneNumber}
         link={clickableRow}
-        onRowClick={onRowClick}
+        onRowClick={() => {
+          if ((!!phoneNumber || clickableRow) && onRowClick) {
+            onRowClick()
+          }
+          if (phoneNumber) {
+            setPhoneModalOpen(true)
+          }
+        }}
         disabled={disabled}
       >
         {badge && <Badge text={badge} />}
@@ -680,7 +710,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
           >
             {title}
           </Styled.h5>
-          {telephone && <TelephoneInfo telephone={telephone} />}
+          {phoneNumber && <TelephoneInfo telephone={phoneNumber.phoneNumber} />}
         </header>
 
         <div

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -5,8 +5,7 @@ import { jsx, Styled, useThemeUI } from 'theme-ui'
 import { ButtonLink } from '@uswitch/trustyle.button-link'
 import { Button } from '@uswitch/trustyle.button'
 import { Icon } from '@uswitch/trustyle.icon'
-
-import PhoneNumberModal from '../../phone-number-modal/src'
+import PhoneNumberModal from '@uswitch/trustyle.phone-number-modal'
 
 import RowWrapper from './row-wrapper'
 
@@ -606,7 +605,7 @@ const TelephoneInfo: React.FC<TelephoneInfoProps> = ({ telephone }) => {
 }
 
 // Shared type with phone-number-modal
-interface PhoneNumber {
+interface PhoneNumberModalInfo {
   phoneNumber: string
   logoUrl: string
   logoDescription: string
@@ -627,7 +626,7 @@ interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   onRowClick?: () => void
   disabled?: boolean
   badges?: string[]
-  phoneNumber?: PhoneNumber
+  phoneNumber?: PhoneNumberModalInfo
 }
 
 const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
@@ -668,7 +667,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
     >
       {phoneNumber && (
         <PhoneNumberModal
-          phoneNumber={phoneNumber}
+          phoneNumberModalInfo={phoneNumber}
           isOpen={isModalOpen}
           setStateClosed={() => setPhoneModalOpen(false)}
         />

--- a/src/compounds/legacy-product-table/src/row-wrapper.tsx
+++ b/src/compounds/legacy-product-table/src/row-wrapper.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { jsx } from 'theme-ui'
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  hasModal: boolean
   link?: string
   children?: React.ReactNode
   onRowClick?: () => void
@@ -42,6 +43,7 @@ const linkWrapper = (
 }
 
 const RowWrapper: React.FC<Props> = ({
+  hasModal,
   link,
   children,
   onRowClick,
@@ -50,7 +52,16 @@ const RowWrapper: React.FC<Props> = ({
   if (disabled) {
     return <div>{children}</div>
   }
-  return link ? linkWrapper(link, children, onRowClick) : <div>{children}</div>
+
+  if (hasModal) {
+    return <div onClick={onRowClick}>{children}</div>
+  }
+
+  if (link) {
+    return linkWrapper(link, children, onRowClick)
+  }
+
+  return <div>{children}</div>
 }
 
 export default RowWrapper

--- a/src/compounds/legacy-product-table/src/stories.tsx
+++ b/src/compounds/legacy-product-table/src/stories.tsx
@@ -395,6 +395,24 @@ DisabledExample.story = {
 }
 
 export const TelephoneExample = () => {
+  const phoneNumber = {
+    phoneNumber: '0808 296 6568',
+    logoUrl: 'https://placekitten.com/200/200?image=9',
+    logoDescription: 'kitten',
+    url: 'https://www.money.co.uk/',
+    termsAndConditions:
+      'Your calls may be recorded for monitoring purposes. You must be a UK resident aged 18+. Terms & Conditions apply. Please see our General Lending Criteria.',
+    complianceText: [
+      'An early repayment charge applies during any fixed or discount rate period.',
+      'Your home may be repossessed if you do not keep up repayments on your mortgage.'
+    ],
+    openingTimes: [
+      'Lines are open:',
+      'Monday to Saturday: 8am-8pm',
+      'Sunday: 9am-8pm'
+    ]
+  }
+
   return (
     <LegacyProductTable
       representativeExample={representativeExample}
@@ -402,7 +420,7 @@ export const TelephoneExample = () => {
       title={title}
       moreInformationPanel={[eligibilityContent, ratesContent]}
       clickableRow={clickableRow}
-      telephone="0808 296 6568"
+      phoneNumber={phoneNumber}
     >
       {productTableContents}
     </LegacyProductTable>


### PR DESCRIPTION
# Description
Screenshots are with uswitch theme because of the modal element's bug on Storybook.

<img width="1225" alt="Screenshot 2021-05-10 at 13 33 03" src="https://user-images.githubusercontent.com/20357064/117659907-6acc9280-b194-11eb-91b7-f421adfb8be2.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
