### PR TITLE
Fix: warnings

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.2.7...@uswitch/trustyle.legacy-product-table@1.2.8) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+
+
+
+
+
 ## [1.2.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.2.6...@uswitch/trustyle.legacy-product-table@1.2.7) (2021-05-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.legacy-product-table

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -139,7 +139,7 @@ export const ImageCell: React.FC<React.HTMLAttributes<any>> = ({
         margin: 'auto',
         marginRight: ['auto', '15px'],
         py: ['10px', 0],
-        '>:first-child': {
+        '>:first-of-type': {
           margin: 'auto',
           display: 'block',
           maxWidth: '130px',
@@ -338,7 +338,7 @@ export const MoreInformationTable = ({ rows }: MoreInformationTableProps) => {
     fontFamily: 'Open Sans,Arial,sans-serif',
     padding: 'sm',
     textAlign: 'center',
-    ':first-child': {
+    ':first-of-type': {
       paddingLeft: 0,
       textAlign: 'left'
     },

--- a/src/compounds/side-nav/CHANGELOG.md
+++ b/src/compounds/side-nav/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.57](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.56...@uswitch/trustyle.side-nav@1.0.57) (2021-05-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.side-nav
+
+
+
+
+
 ## [1.0.56](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.side-nav@1.0.55...@uswitch/trustyle.side-nav@1.0.56) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.side-nav

--- a/src/compounds/side-nav/package.json
+++ b/src/compounds/side-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.side-nav",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.palette": "^4.0.3",
-    "@uswitch/trustyle.accordion": "^0.14.9"
+    "@uswitch/trustyle.accordion": "^0.14.10"
   }
 }

--- a/src/elements/accordion/CHANGELOG.md
+++ b/src/elements/accordion/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.14.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.14.9...@uswitch/trustyle.accordion@0.14.10) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+
+
+
+
+
 ## [0.14.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.accordion@0.14.8...@uswitch/trustyle.accordion@0.14.9) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.accordion

--- a/src/elements/accordion/package.json
+++ b/src/elements/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.accordion",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/accordion/src/index.tsx
+++ b/src/elements/accordion/src/index.tsx
@@ -276,7 +276,7 @@ const Accordion: React.FC<Props> & {
           marginBottom: isOpen
             ? accordionTheme?.base?.content?.marginBottom
             : '0',
-          '> *:first-child': {
+          '> *:first-of-type': {
             marginTop: 0
           },
           '> *:last-child': {

--- a/src/elements/embedded-video/CHANGELOG.md
+++ b/src/elements/embedded-video/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.58](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.57...@uswitch/trustyle.embedded-video@0.4.58) (2021-05-13)
+
+**Note:** Version bump only for package @uswitch/trustyle.embedded-video
+
+
+
+
+
 ## [0.4.57](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.embedded-video@0.4.56...@uswitch/trustyle.embedded-video@0.4.57) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.embedded-video

--- a/src/elements/embedded-video/package.json
+++ b/src/elements/embedded-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.embedded-video",
-  "version": "0.4.57",
+  "version": "0.4.58",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -21,6 +21,6 @@
     "theme-ui": "^0.2.52"
   },
   "dependencies": {
-    "@uswitch/trustyle.accordion": "^0.14.9"
+    "@uswitch/trustyle.accordion": "^0.14.10"
   }
 }

--- a/src/themes/bankrate/CHANGELOG.md
+++ b/src/themes/bankrate/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.25.14](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.25.13...@uswitch/trustyle.bankrate-theme@2.25.14) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+
+
+
+
+
 ## [2.25.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.bankrate-theme@2.25.12...@uswitch/trustyle.bankrate-theme@2.25.13) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.bankrate-theme

--- a/src/themes/bankrate/package.json
+++ b/src/themes/bankrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.bankrate-theme",
-  "version": "2.25.13",
+  "version": "2.25.14",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/bankrate/theme.json
+++ b/src/themes/bankrate/theme.json
@@ -275,7 +275,7 @@
         "left": {
           "main": {
             "variant": "elements.author-profile.base",
-            "a:first-child": { "ml": 0 }
+            "a:first-of-type": { "ml": 0 }
           },
           "bio": {
             "variant": "elements.author-profile.base.bio",

--- a/src/themes/journey/CHANGELOG.md
+++ b/src/themes/journey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.12.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.12.3...@uswitch/trustyle.journey-theme@2.12.4) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+
+
+
+
+
 ## [2.12.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.12.2...@uswitch/trustyle.journey-theme@2.12.3) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.journey-theme

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -845,7 +845,7 @@
             "whiteSpace": "nowrap",
             "position": "relative",
             "transition": "flex-grow 0.4s",
-            "&:first-child": {
+            "&:first-of-type": {
               "marginLeft": "0px"
             }
           },
@@ -876,7 +876,7 @@
             "fontWeight": "bold",
             "lineHeight": "24px",
             "color": "black",
-            "&:first-child": {
+            "&:first-of-type": {
               "marginLeft": "0px"
             }
           }
@@ -1170,7 +1170,7 @@
 
     "rich-text-block": {
       "base": {
-        "*:first-child": { "mt": 0 }
+        "*:first-of-type": { "mt": 0 }
       },
       "variants": {
         "panel-primary": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.48.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.48.3...@uswitch/trustyle.money-theme@1.48.4) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+* update kebab case to camel case in money theme ([d1828fa](https://github.com/uswitch/trustyle/commit/d1828fa))
+
+
+
+
+
 ## [1.48.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.48.2...@uswitch/trustyle.money-theme@1.48.3) (2021-05-13)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.48.3",
+  "version": "1.48.4",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -443,7 +443,7 @@
       "variants": {
         "left": {
           "main": {
-            "a:first-child": { "ml": 0 }
+            "a:first-of-type": { "ml": 0 }
           },
           "bio": {
             "width": ["100%", "75%", "60%"],
@@ -1752,7 +1752,7 @@
     },
     "rich-text-block": {
       "base": {
-        "&:first-child": {
+        "&:first-of-type": {
           "mt": 0
         }
       },
@@ -1832,13 +1832,13 @@
           },
           "fields": {
             "display": "none",
-            ">:first-child": {
+            ">:first-of-type": {
               "label": {
                 "mt": 0
               }
             },
             "calculator": {
-              ">:first-child": {
+              ">:first-of-type": {
                 "label": {
                   "mt": 0
                 }
@@ -1890,7 +1890,7 @@
             },
             "fields": {
               "display": "block",
-              ">:first-child": {
+              ">:first-of-type": {
                 "label": {
                   "mt": 0
                 }
@@ -2793,7 +2793,7 @@
             "top": "0",
             "height": "100%"
           },
-          ":first-child::before": {
+          ":first-of-type::before": {
             "top": "50%",
             "height": "50%"
           },

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -394,7 +394,7 @@
         },
         "centered": {
           "display": "inline-block",
-          "align-items": "center"
+          "alignItems": "center"
         },
         "centered-light": {
           "variant": "elements.sponsored-by-tag.variants.centered",
@@ -1366,7 +1366,7 @@
       "variants": {
         "quickLinks": {
           "display": "flex",
-          "flex-direction": "column",
+          "flexDirection": "column",
           "header": {
             "paddingY": ["sm", "md"]
           },
@@ -1545,7 +1545,7 @@
                 "calculator": {
                   "marginTop": "xs",
                   "display": "flex",
-                  "flex-wrap": "wrap",
+                  "flexWrap": "wrap",
                   ">:nth-child(3n+1)": {
                     "marginLeft": 0
                   }
@@ -1567,7 +1567,7 @@
                 "calculator": {
                   "marginTop": "xs",
                   "display": "flex",
-                  "flex-wrap": "wrap",
+                  "flexWrap": "wrap",
                   ">:nth-child(3n+1)": {
                     "marginLeft": 0
                   }
@@ -1798,13 +1798,13 @@
             "fields": {
               "calculator": {
                 "display": "flex",
-                "flex-wrap": "wrap"
+                "flexWrap": "wrap"
               }
             },
             "buttonWrapper": {
               "calculator": {
                 "display": "flex",
-                "justify-content": "center"
+                "justifyContent": "center"
               }
             }
           }
@@ -2047,7 +2047,7 @@
     "eligibility-criteria": {
       "base": {
         "height": "100%",
-        "box-sizing": "border-box",
+        "boxSizing": "border-box",
         "backgroundColor": "grey-0",
         "py": "lg",
         "px": "md"
@@ -2680,7 +2680,7 @@
             "padding": "0 15px",
             "bg": "#eaeced",
             "ul": {
-              "list-style": "none",
+              "listStyle": "none",
               "padding": 0,
               "a": {
                 "textDecoration": "none",
@@ -2701,7 +2701,7 @@
             },
             "p": {
               "color": "#858f95",
-              "padding-top": "10px"
+              "paddingTop": "10px"
             },
             "a": {
               "display": "block"
@@ -2890,7 +2890,7 @@
         "marginRight": "base",
         "meta": {
           "display": "flex",
-          "font-size": 14
+          "fontSize": 14
         },
         "superScript": {
           "mb": "xxs"
@@ -2901,8 +2901,8 @@
           "paddingX": "xs",
           "paddingY": "xxs",
           "mb": "xxs",
-          "font-weight": "bold",
-          "line-height": "150%",
+          "fontWeight": "bold",
+          "lineHeight": "150%",
           "borderRadius": 4
         }
       },
@@ -2938,7 +2938,7 @@
             "fontSize": [16, 18]
           },
           "meta": {
-            "flex-direction": "column",
+            "flexDirection": "column",
             "variant": "compounds.card.base.meta"
           },
           "content": {
@@ -3117,13 +3117,13 @@
     },
     "heroCard": {
       "variants": {
-        "flex-direction": ["column", "row"],
+        "flexDirection": ["column", "row"],
         "background": "linear-gradient(161.42deg, #924A8B 22.95%, #AF4C83 77.05%)",
-        "box-shadow": "0px 9px 19px rgba(92, 36, 87, 0.2)",
+        "boxShadow": "0px 9px 19px rgba(92, 36, 87, 0.2)",
         "paddingX": ["sm", "4xl"],
         "pt": ["md", "xxxl"],
         "pb": ["lg", "xxxl"],
-        "border-radius": ["4px", "8px"],
+        "borderRadius": ["4px", "8px"],
         "h1": {
           "color": "grey-0"
         },
@@ -3134,9 +3134,9 @@
           "width": ["initial", "50%"],
           "mr": [0, "4xl"],
           "display": ["flex"],
-          "flex-direction": "column",
-          "justify-content": "center",
-          "align-items": "flex-start"
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "alignItems": "flex-start"
         },
         "buttonLink": {
           "mt": ["sm", "xs"]

--- a/src/themes/save-on-energy/CHANGELOG.md
+++ b/src/themes/save-on-energy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.13.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.13.11...@uswitch/trustyle.save-on-energy-theme@1.13.12) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+
+
+
+
+
 ## [1.13.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.save-on-energy-theme@1.13.10...@uswitch/trustyle.save-on-energy-theme@1.13.11) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.save-on-energy-theme

--- a/src/themes/save-on-energy/package.json
+++ b/src/themes/save-on-energy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.save-on-energy-theme",
-  "version": "1.13.11",
+  "version": "1.13.12",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/save-on-energy/theme.json
+++ b/src/themes/save-on-energy/theme.json
@@ -762,7 +762,7 @@
 
     "rich-text-block": {
       "base": {
-        "*:first-child": {
+        "*:first-of-type": {
           "mt": 0
         }
       },

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.45.13](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.45.12...@uswitch/trustyle.uswitch-theme@2.45.13) (2021-05-13)
+
+
+### Bug Fixes
+
+* update first-child to first-of-type ([b5f0c8b](https://github.com/uswitch/trustyle/commit/b5f0c8b))
+
+
+
+
+
 ## [2.45.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.45.11...@uswitch/trustyle.uswitch-theme@2.45.12) (2021-05-13)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.45.12",
+  "version": "2.45.13",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -416,7 +416,7 @@
       "variants": {
         "left": {
           "main": {
-            "a:first-child": { "ml": 0 },
+            "a:first-of-type": { "ml": 0 },
             "a": {
               "mb": 0
             }
@@ -1134,7 +1134,7 @@
         "h3": {
           "fontSize": 28
         },
-        ":first-child": {
+        ":first-of-type": {
           ":not(hr)": {
             "mt": 0
           }
@@ -1460,7 +1460,7 @@
             "whiteSpace": "nowrap",
             "position": "relative",
             "transition": "flex-grow 0.4s",
-            "&:first-child": {
+            "&:first-of-type": {
               "marginLeft": "0px"
             }
           },
@@ -1491,7 +1491,7 @@
             "fontWeight": "bold",
             "lineHeight": "24px",
             "color": "dark-1",
-            "&:first-child": {
+            "&:first-of-type": {
               "marginLeft": "0px"
             }
           }
@@ -3478,7 +3478,7 @@
           "p:last-of-type": {
             "mb": 32
           },
-          "& > :first-child": {
+          "& > :first-of-type": {
             "mt": "xs"
           }
         },


### PR DESCRIPTION
# Description

Fixes `first-child` and kebab case not supported warnings for money theme and components.

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
