### PR TITLE
Feat: add optional rep example copy

### DIFF
--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -87,10 +87,12 @@ export const MoreInformationButton: React.FC<MoreInformationButtonProps> = ({
 interface RepresentativeExampleProps
   extends React.HTMLAttributes<HTMLDivElement> {
   text: string
+  label: boolean
 }
 
 const RepresentativeExample: React.FC<RepresentativeExampleProps> = ({
-  text
+  text,
+  label
 }) => {
   return (
     <div
@@ -105,7 +107,8 @@ const RepresentativeExample: React.FC<RepresentativeExampleProps> = ({
         lineHeight: 'normal'
       }}
     >
-      Representative Example: {text}
+      {label && 'Representative Example: '}
+      {text}
     </div>
   )
 }
@@ -608,6 +611,7 @@ interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   info: string[]
   title: string
   representativeExample?: string
+  representativeExampleLabel?: boolean
   moreInformationPanel?: React.ReactNode[]
   clickableRow?: string
   moreInformationButton?: React.ReactNode
@@ -624,6 +628,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
   info,
   title,
   representativeExample,
+  representativeExampleLabel = true,
   moreInformationPanel,
   moreInformationLabel,
   clickableRow,
@@ -707,7 +712,10 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
         )}
 
         {representativeExample && (
-          <RepresentativeExample text={representativeExample} />
+          <RepresentativeExample
+            text={representativeExample}
+            label={representativeExampleLabel}
+          />
         )}
       </RowWrapper>
 

--- a/src/compounds/legacy-product-table/src/stories.tsx
+++ b/src/compounds/legacy-product-table/src/stories.tsx
@@ -291,6 +291,27 @@ const moreInformationButton = (
   </MoreInformationButton>
 )
 
+export const RepresentativeExampleNoLabel = () => {
+  return (
+    <LegacyProductTable
+      representativeExample={representativeExample}
+      representativeExampleLabel={false}
+      info={info}
+      title={title}
+      clickableRow={clickableRow}
+      moreInformationButton={moreInformationButton}
+    >
+      {productTableContents}
+    </LegacyProductTable>
+  )
+}
+
+RepresentativeExampleNoLabel.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 export const BadgeExample = () => {
   return (
     <LegacyProductTable
@@ -307,6 +328,12 @@ export const BadgeExample = () => {
       {productTableContents}
     </LegacyProductTable>
   )
+}
+
+BadgeExample.story = {
+  parameters: {
+    percy: { skip: true }
+  }
 }
 
 export const EligibilityExample = () => {
@@ -418,6 +445,7 @@ TelephoneExample.story = {
 export const AutomatedTests = () => {
   return (
     <AllThemes>
+      <RepresentativeExampleNoLabel />
       <BadgeExample />
       <DisabledExample />
       <EligibilityExample />


### PR DESCRIPTION
# Description

Adds optional representative example label - instead of always having the 'Representative example' label.

With representative example label:

<img width="1426" alt="Screenshot 2021-05-20 at 09 40 41" src="https://user-images.githubusercontent.com/15983736/118947755-8e8b9780-b94f-11eb-9260-9177447a5c64.png">

Without representative example label:

<img width="1441" alt="Screenshot 2021-05-20 at 09 40 53" src="https://user-images.githubusercontent.com/15983736/118947787-951a0f00-b94f-11eb-9b01-4009bca9e2f1.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
