### PR TITLE
Fix: mobile table overflow

### DIFF
--- a/src/elements/table/CHANGELOG.md
+++ b/src/elements/table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.table@0.0.10...@uswitch/trustyle.table@0.0.11) (2021-06-03)
+
+
+### Bug Fixes
+
+* mobile styling overflow ([8a9c159](https://github.com/uswitch/trustyle/commit/8a9c159))
+
+
+
+
+
 ## [0.0.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.table@0.0.9...@uswitch/trustyle.table@0.0.10) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.table

--- a/src/elements/table/package.json
+++ b/src/elements/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.table",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/table/src/index.tsx
+++ b/src/elements/table/src/index.tsx
@@ -4,7 +4,17 @@ import * as React from 'react'
 import { jsx, Styled } from 'theme-ui'
 
 const Table: React.FC = ({ children, ...props }) => {
-  return <Styled.table {...props}>{children}</Styled.table>
+  return (
+    <div
+      sx={{
+        overflowX: ['scroll', 'visible', 'visible'],
+        '&::-webkit-scrollbar': { display: 'none' },
+        '&::-ms-overflow-style': { display: 'none' }
+      }}
+    >
+      <Styled.table {...props}>{children}</Styled.table>
+    </div>
+  )
 }
 
 const TableRow: React.FC = ({ children, ...props }) => {


### PR DESCRIPTION
# Description

Ensure table overflows on mobile.

<img width="318" alt="Screenshot 2021-06-02 at 13 46 38" src="https://user-images.githubusercontent.com/15983736/120482490-1b4f4000-c3a9-11eb-8433-f775f045b154.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
