### PR TITLE
Fix: radio spacing

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.49.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.49.3...@uswitch/trustyle.money-theme@1.49.4) (2021-06-03)
+
+
+### Bug Fixes
+
+* radio spacing ([6401751](https://github.com/uswitch/trustyle/commit/6401751))
+
+
+
+
+
 ## [1.49.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.49.1...@uswitch/trustyle.money-theme@1.49.3) (2021-06-03)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.49.3",
+  "version": "1.49.4",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1604,6 +1604,7 @@
         "default": {
           "simple-radio": {
             "radioWrapper": {
+              "marginBottom": "lg",
               "display": "flex",
               "flexDirection": ["column", "row"],
               "div": {


### PR DESCRIPTION
# Description

Fixes spacing issues with form radio buttons.

Before:

<img width="725" alt="Screenshot 2021-06-03 at 16 42 16" src="https://user-images.githubusercontent.com/15983736/120673282-f0d5b380-c48a-11eb-8c99-b26267fa5013.png">

<img width="563" alt="Screenshot 2021-06-03 at 16 44 42" src="https://user-images.githubusercontent.com/15983736/120673373-04811a00-c48b-11eb-9a8b-391a412c4334.png">

After:

<img width="645" alt="Screenshot 2021-06-03 at 16 43 24" src="https://user-images.githubusercontent.com/15983736/120673775-6477c080-c48b-11eb-925c-a11a93aa2e6d.png">

<img width="580" alt="Screenshot 2021-06-03 at 16 46 51" src="https://user-images.githubusercontent.com/15983736/120673685-4dd16980-c48b-11eb-9e0d-f2a2c3f80ae5.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
