### PR TITLE
fix: Adds missing repository key to social-sharing packag.json

### DIFF
--- a/src/compounds/social-sharing/CHANGELOG.md
+++ b/src/compounds/social-sharing/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.social-sharing@0.0.2...@uswitch/trustyle.social-sharing@0.0.3) (2021-06-18)
+
+
+### Bug Fixes
+
+* Adds missing repository key to social-sharing packag.json ([881d071](https://github.com/uswitch/trustyle/commit/881d071))
+
+
+
+
+
 ## 0.0.2 (2021-06-16)
 
 **Note:** Version bump only for package @uswitch/trustyle.social-sharing

--- a/src/compounds/social-sharing/package.json
+++ b/src/compounds/social-sharing/package.json
@@ -7,6 +7,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uswitch/trustyle"
+  },
   "peerDependencies": {
     "@emotion/core": "^10.0.27",
     "react": "^16.7.0"

--- a/src/compounds/social-sharing/package.json
+++ b/src/compounds/social-sharing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.social-sharing",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",


### PR DESCRIPTION
# Description

The publish github action isn't working because the social-sharing package.json is missing the repository key.

This PR solves this. 

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
