### PR TITLE
Percentage progress bar min width

### DIFF
--- a/src/elements/funnel-progress/CHANGELOG.md
+++ b/src/elements/funnel-progress/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.funnel-progress@3.0.6...@uswitch/trustyle.funnel-progress@3.0.7) (2021-06-24)
+
+**Note:** Version bump only for package @uswitch/trustyle.funnel-progress
+
+
+
+
+
 ## [3.0.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.funnel-progress@3.0.5...@uswitch/trustyle.funnel-progress@3.0.6) (2021-06-22)
 
 **Note:** Version bump only for package @uswitch/trustyle.funnel-progress

--- a/src/elements/funnel-progress/package.json
+++ b/src/elements/funnel-progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.funnel-progress",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {

--- a/src/elements/funnel-progress/src/index.tsx
+++ b/src/elements/funnel-progress/src/index.tsx
@@ -115,17 +115,16 @@ const FunnelProgress: React.FC<Props> = ({
   )
   const percentageVariant = variant === 'percentage'
 
-  const variantPath = (additionalPath?: string) => {
-    return `elements.funnel-progress.${
+  const variantPath = (additionalPath: string = '') =>
+    `elements.funnel-progress.${
       variant ? `variants.${variant}` : 'base'
-    }${additionalPath && additionalPath}`
-  }
+    }${additionalPath}`
 
   const minWidth = percentageVariant ? '10%' : '0%'
 
   return (
     <Fragment>
-      <div {...rest} sx={{ variant: variantPath('') }}>
+      <div {...rest} sx={{ variant: variantPath() }}>
         {!percentageVariant &&
           phases.map((phase, ind) => (
             <FunnelPhase

--- a/src/elements/funnel-progress/src/index.tsx
+++ b/src/elements/funnel-progress/src/index.tsx
@@ -59,7 +59,12 @@ const PhaseIcon: React.FC<PhaseIconProps> = ({ variant, step }) => (
 const Percentage: React.FC<PercentageProps> = ({ progress }) => {
   const percentage = `${Math.round((progress + 0.1) * 100)}%`
   return (
-    <div sx={{ variant: 'elements.funnel-progress.variants.percentage' }}>
+    <div
+      sx={{
+        variant:
+          'elements.funnel-progress.variants.percentage.displayPercentage'
+      }}
+    >
       {percentage}
     </div>
   )
@@ -110,9 +115,17 @@ const FunnelProgress: React.FC<Props> = ({
   )
   const percentageVariant = variant === 'percentage'
 
+  const variantPath = (additionalPath?: string) => {
+    return `elements.funnel-progress.${
+      variant ? `variants.${variant}` : 'base'
+    }${additionalPath && additionalPath}`
+  }
+
+  const minWidth = percentageVariant ? '10%' : '0%'
+
   return (
     <Fragment>
-      <div {...rest} sx={{ variant: 'elements.funnel-progress.base' }}>
+      <div {...rest} sx={{ variant: variantPath('') }}>
         {!percentageVariant &&
           phases.map((phase, ind) => (
             <FunnelPhase
@@ -129,7 +142,7 @@ const FunnelProgress: React.FC<Props> = ({
       {!hideProgressBar && (
         <div
           sx={{
-            variant: 'elements.funnel-progress.base.progess.back',
+            variant: variantPath('.progess.back'),
             height: '4px',
             width: '100%',
             position: 'relative',
@@ -141,15 +154,15 @@ const FunnelProgress: React.FC<Props> = ({
             sx={{
               variant:
                 progress !== 0
-                  ? 'elements.funnel-progress.base.progress.base'
-                  : 'elements.funnel-progress.base.progress.variants.start'
+                  ? variantPath('.progress.base')
+                  : variantPath('.progress.variants.start')
             }}
             style={{
               width:
                 progress !== 0
                   ? `${STARTING_PROGRESS * 100 +
                       progress * (1 - STARTING_PROGRESS) * 100}%`
-                  : '0%'
+                  : minWidth
             }}
           />
         </div>

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.47.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.47.7...@uswitch/trustyle.uswitch-theme@2.47.8) (2021-06-24)
+
+**Note:** Version bump only for package @uswitch/trustyle.uswitch-theme
+
+
+
+
+
 ## [2.47.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.47.6...@uswitch/trustyle.uswitch-theme@2.47.7) (2021-06-22)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.47.7",
+  "version": "2.47.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1531,7 +1531,6 @@
         "display": "flex",
         "flexFlow": "row",
         "userSelect": "none",
-        "justifyContent": "flex-end",
         "phase": {
           "base": {
             "flex": "auto",
@@ -1640,8 +1639,24 @@
       "variants": {
         "percentage": {
           "variant": "elements.funnel-progress.base",
-          "fontWeight": "600",
-          "lineHeight": "24px"
+          "justifyContent": "flex-end",
+          "displayPercentage": {
+            "fontWeight": "600",
+            "lineHeight": "24px"  
+          },
+          "progress": {
+            "base": {
+              "variant": "elements.funnel-progress.base.progress.base"
+            },
+            "variants": {
+              "start": {
+                "variant": "elements.funnel-progress.base.progress.base"
+              }
+            },
+            "back": {
+              "variant": "elements.funnel-progress.base.progress.back"
+            }
+          }
         }
       }
     },

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1642,7 +1642,7 @@
           "justifyContent": "flex-end",
           "displayPercentage": {
             "fontWeight": "600",
-            "lineHeight": "24px"  
+            "lineHeight": "24px"
           },
           "progress": {
             "base": {


### PR DESCRIPTION
# Description

fix percentage progress bar variant min bar width; display 10% width at start

![image](https://user-images.githubusercontent.com/56200818/123279698-02493300-d500-11eb-9e7c-1f324d37f6a0.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
