### PR TITLE
feat: create circle percentage bar element

### DIFF
--- a/src/elements/circular-percentage-bar/.npmignore
+++ b/src/elements/circular-percentage-bar/.npmignore
@@ -1,0 +1,6 @@
+**/*
+
+!lib/*
+!package.json
+!README.md
+!LICENSE

--- a/src/elements/circular-percentage-bar/.npmrc
+++ b/src/elements/circular-percentage-bar/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/src/elements/circular-percentage-bar/CHANGELOG.md
+++ b/src/elements/circular-percentage-bar/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2021-06-28)
+
+
+### Bug Fixes
+
+* make the example unscrollable ([87c18ee](https://github.com/uswitch/trustyle/commit/87c18ee))
+* prettier error ([551e119](https://github.com/uswitch/trustyle/commit/551e119))
+
+
+### Features
+
+* create circle percentage bar element ([eaf6b07](https://github.com/uswitch/trustyle/commit/eaf6b07))

--- a/src/elements/circular-percentage-bar/package.json
+++ b/src/elements/circular-percentage-bar/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@uswitch/trustyle.circular-percentage-bar",
+  "version": "0.0.0",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "ts:main": "src/index.tsx",
+  "publishConfig": {
+    "access": "public"
+  },
+ "repository": {
+    "type" : "git",
+    "url": "https://github.com/uswitch/trustyle"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.0.27",
+    "react": "^16.7.0"
+  }
+}

--- a/src/elements/circular-percentage-bar/package.json
+++ b/src/elements/circular-percentage-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.circular-percentage-bar",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/circular-percentage-bar/package.json
+++ b/src/elements/circular-percentage-bar/package.json
@@ -7,8 +7,8 @@
   "publishConfig": {
     "access": "public"
   },
- "repository": {
-    "type" : "git",
+  "repository": {
+    "type": "git",
     "url": "https://github.com/uswitch/trustyle"
   },
   "peerDependencies": {

--- a/src/elements/circular-percentage-bar/src/index.tsx
+++ b/src/elements/circular-percentage-bar/src/index.tsx
@@ -1,0 +1,61 @@
+/** @jsx jsx */
+
+import * as React from 'react'
+import { jsx } from 'theme-ui'
+
+import { CircularPercentageBarStyles } from './percentage-bar-styles'
+
+const styles = (element?: string) =>
+  `elements.circle-percentage-bar.base${element ? `.${element}` : ''}`
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  percentage: number
+  size?: string
+}
+
+const drawCircle = (pct: number, isBackground: boolean = false) => {
+  const cls = isBackground ? '-full' : ''
+  const deg = (360 / 100) * pct
+
+  return (
+    <div className={`slice${cls}`}>
+      <div
+        className={`bar${cls}`}
+        sx={{
+          transform: `rotate(${deg}deg)`,
+          variant: styles(`bar${cls}`)
+        }}
+      ></div>
+      <div
+        className={`fill${cls}`}
+        sx={{
+          variant: isBackground
+            ? styles(`fill${cls}`)
+            : deg > 180
+            ? styles('fill')
+            : ''
+        }}
+      ></div>
+    </div>
+  )
+}
+
+const CircularPercentageBar: React.FC<Props> = ({
+  percentage,
+  size = 'xs'
+}) => {
+  return (
+    <div css={CircularPercentageBarStyles}>
+      <div
+        className={`c100 ${size} ${percentage > 50 ? 'gt50' : ''}`}
+        sx={{ variant: styles() }}
+      >
+        <span sx={{ variant: styles('text') }}>{percentage}%</span>
+        {drawCircle(100, true)}
+        {drawCircle(percentage)}
+      </div>
+    </div>
+  )
+}
+
+export default CircularPercentageBar

--- a/src/elements/circular-percentage-bar/src/index.tsx
+++ b/src/elements/circular-percentage-bar/src/index.tsx
@@ -8,11 +8,6 @@ import { CircularPercentageBarStyles } from './percentage-bar-styles'
 const styles = (element?: string) =>
   `elements.circle-percentage-bar.base${element ? `.${element}` : ''}`
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  percentage: number
-  size?: string
-}
-
 const drawCircle = (pct: number, isBackground: boolean = false) => {
   const cls = isBackground ? '-full' : ''
   const deg = (360 / 100) * pct
@@ -40,12 +35,23 @@ const drawCircle = (pct: number, isBackground: boolean = false) => {
   )
 }
 
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  percentage: number
+  size?: string
+}
+
 const CircularPercentageBar: React.FC<Props> = ({
   percentage,
   size = 'xs'
 }) => {
   return (
-    <div css={CircularPercentageBarStyles}>
+    <div
+      css={CircularPercentageBarStyles}
+      sx={{
+        display: 'flex',
+        justifyContent: 'center'
+      }}
+    >
       <div
         className={`c100 ${size} ${percentage > 50 ? 'gt50' : ''}`}
         sx={{ variant: styles() }}

--- a/src/elements/circular-percentage-bar/src/percentage-bar-styles.ts
+++ b/src/elements/circular-percentage-bar/src/percentage-bar-styles.ts
@@ -1,0 +1,91 @@
+import { css } from 'theme-ui'
+
+export const CircularPercentageBarStyles = css({
+  '.c100': {
+    position: 'relative',
+    float: 'left',
+    margin: '0 0.1em 0.1em 0',
+    width: '1em',
+    height: '1em',
+    'font-size': '120px',
+    '-webkit-border-radius': '50%',
+    '-moz-border-radius': '50%',
+    '-ms-border-radius': '50%',
+    '-o-border-radius': '50%',
+    'border-radius': '50%'
+  },
+  '.c100.xs': {
+    'font-size': '64px'
+  },
+  '.c100.sm': {
+    'font-size': '80px'
+  },
+  '.c100.md': {
+    'font-size': '120px'
+  },
+  '.c100.lg': {
+    'font-size': '160px'
+  },
+  '.c100.xl': {
+    'font-size': '200px'
+  },
+  '.c100 .bar, .c100 .bar-full, .c100.gt50 .fill, .c100 .fill-full': {
+    position: 'absolute',
+    border: '0.08em solid #307bbb',
+    width: '0.84em',
+    height: '0.84em',
+    clip: 'rect(0em, 0.5em, 1em, 0em)',
+    '-webkit-border-radius': '50%',
+    '-moz-border-radius': '50%',
+    '-ms-border-radius': '50%',
+    '-o-border-radius': '50%',
+    'border-radius': '50%'
+  },
+  '.c100.gt50 .bar:after, .c100.gt50 .fill, .c100 .bar-full:after, .c100 .fill-full': {
+    '-webkit-transform': 'rotate(180deg)',
+    '-moz-transform': 'rotate(180deg)',
+    '-ms-transform': 'rotate(180deg)',
+    '-o-transform': 'rotate(180deg)',
+    transform: 'rotate(180deg)'
+  },
+  '.c100 *, .c100 *:before, .c100 *:after': {
+    '-webkit-box-sizing': 'content-box',
+    '-moz-box-sizing': 'content-box',
+    'box-sizing': 'content-box'
+  },
+  '.c100 > span': {
+    width: '100%',
+    position: 'absolute',
+    left: '0',
+    top: '0',
+    display: 'block',
+    'z-index': '1',
+    'line-height': '4em',
+    'font-size': '0.25em',
+    'text-align': 'center',
+    'white-space': 'nowrap'
+  },
+  '.c100:after': {
+    position: 'absolute',
+    top: '0.08em',
+    left: '0.08em',
+    display: 'block',
+    content: '" "',
+    width: '0.84em',
+    height: '0.84em',
+    '-webkit-border-radius': '50%',
+    '-moz-border-radius': '50%',
+    '-ms-border-radius': '50%',
+    '-o-border-radius': '50%',
+    'border-radius': '50%'
+  },
+  '.c100 .slice, .c100 .slice-full': {
+    position: 'absolute',
+    width: '1em',
+    height: '1em',
+    clip: 'rect(0em, 1em, 1em, 0.5em)'
+  },
+  '.c100.gt50 .slice, .c100 .slice-full': {
+    clip: 'rect(auto, auto, auto, auto)'
+  }
+})

--- a/src/elements/circular-percentage-bar/src/stories.tsx
+++ b/src/elements/circular-percentage-bar/src/stories.tsx
@@ -1,0 +1,97 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
+import AllThemes from '../../../utils/all-themes'
+
+import CircularPercentageBar from './'
+
+export default {
+  title: 'Elements/CircularPercentageBar'
+}
+
+export const ExampleWithPercentages = () => {
+  return (
+    <div
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        flexWrap: 'wrap'
+      }}
+    >
+      <div
+        sx={{
+          marginBottom: '20px',
+          display: 'flex',
+          flexDirection: 'row',
+          backgroundColor: '#F5E9EE'
+        }}
+      >
+        <CircularPercentageBar size="xs" percentage={100} />
+        <CircularPercentageBar size="xs" percentage={85} />
+        <CircularPercentageBar size="xs" percentage={75} />
+        <CircularPercentageBar size="xs" percentage={50} />
+        <CircularPercentageBar size="xs" percentage={25} />
+        <CircularPercentageBar size="xs" percentage={0} />
+      </div>
+
+      <div
+        sx={{
+          marginBottom: '20px',
+          display: 'flex',
+          flexDirection: 'row'
+        }}
+      >
+        <CircularPercentageBar size="sm" percentage={100} />
+        <CircularPercentageBar size="sm" percentage={85} />
+        <CircularPercentageBar size="sm" percentage={75} />
+        <CircularPercentageBar size="sm" percentage={50} />
+        <CircularPercentageBar size="sm" percentage={25} />
+        <CircularPercentageBar size="sm" percentage={0} />
+      </div>
+
+      <div
+        sx={{
+          marginBottom: '20px',
+          display: 'flex',
+          flexDirection: 'row',
+          background: '#F5E9EE'
+        }}
+      >
+        <CircularPercentageBar size="md" percentage={100} />
+        <CircularPercentageBar size="md" percentage={85} />
+        <CircularPercentageBar size="md" percentage={75} />
+        <CircularPercentageBar size="md" percentage={50} />
+        <CircularPercentageBar size="md" percentage={25} />
+        <CircularPercentageBar size="md" percentage={0} />
+      </div>
+
+      <div
+        sx={{
+          display: 'flex',
+          flexDirection: 'row'
+        }}
+      >
+        <CircularPercentageBar size="lg" percentage={100} />
+        <CircularPercentageBar size="lg" percentage={85} />
+        <CircularPercentageBar size="lg" percentage={75} />
+        <CircularPercentageBar size="lg" percentage={50} />
+        <CircularPercentageBar size="lg" percentage={25} />
+        <CircularPercentageBar size="lg" percentage={0} />
+      </div>
+    </div>
+  )
+}
+
+ExampleWithPercentages.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+export const AutomatedTests = () => {
+  return (
+    <AllThemes themes={['uswitch', 'money']}>
+      <ExampleWithPercentages />
+    </AllThemes>
+  )
+}

--- a/src/elements/circular-percentage-bar/src/stories.tsx
+++ b/src/elements/circular-percentage-bar/src/stories.tsx
@@ -9,75 +9,47 @@ export default {
   title: 'Elements/CircularPercentageBar'
 }
 
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  size: string
+  bgColor?: string
+}
+
+export const DrawCircles: React.FC<Props> = ({
+  size = 'xs',
+  bgColor = '#ffffff'
+}) => {
+  return (
+    <div
+      sx={{
+        marginBottom: '20px',
+        display: 'flex',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        backgroundColor: bgColor
+      }}
+    >
+      <CircularPercentageBar size={size} percentage={0} />
+      <CircularPercentageBar size={size} percentage={25} />
+      <CircularPercentageBar size={size} percentage={50} />
+      <CircularPercentageBar size={size} percentage={75} />
+      <CircularPercentageBar size={size} percentage={85} />
+      <CircularPercentageBar size={size} percentage={100} />
+    </div>
+  )
+}
+
 export const ExampleWithPercentages = () => {
   return (
     <div
       sx={{
         display: 'flex',
-        flexDirection: 'column',
-        flexWrap: 'wrap'
+        flexDirection: 'column'
       }}
     >
-      <div
-        sx={{
-          marginBottom: '20px',
-          display: 'flex',
-          flexDirection: 'row',
-          backgroundColor: '#F5E9EE'
-        }}
-      >
-        <CircularPercentageBar size="xs" percentage={100} />
-        <CircularPercentageBar size="xs" percentage={85} />
-        <CircularPercentageBar size="xs" percentage={75} />
-        <CircularPercentageBar size="xs" percentage={50} />
-        <CircularPercentageBar size="xs" percentage={25} />
-        <CircularPercentageBar size="xs" percentage={0} />
-      </div>
-
-      <div
-        sx={{
-          marginBottom: '20px',
-          display: 'flex',
-          flexDirection: 'row'
-        }}
-      >
-        <CircularPercentageBar size="sm" percentage={100} />
-        <CircularPercentageBar size="sm" percentage={85} />
-        <CircularPercentageBar size="sm" percentage={75} />
-        <CircularPercentageBar size="sm" percentage={50} />
-        <CircularPercentageBar size="sm" percentage={25} />
-        <CircularPercentageBar size="sm" percentage={0} />
-      </div>
-
-      <div
-        sx={{
-          marginBottom: '20px',
-          display: 'flex',
-          flexDirection: 'row',
-          background: '#F5E9EE'
-        }}
-      >
-        <CircularPercentageBar size="md" percentage={100} />
-        <CircularPercentageBar size="md" percentage={85} />
-        <CircularPercentageBar size="md" percentage={75} />
-        <CircularPercentageBar size="md" percentage={50} />
-        <CircularPercentageBar size="md" percentage={25} />
-        <CircularPercentageBar size="md" percentage={0} />
-      </div>
-
-      <div
-        sx={{
-          display: 'flex',
-          flexDirection: 'row'
-        }}
-      >
-        <CircularPercentageBar size="lg" percentage={100} />
-        <CircularPercentageBar size="lg" percentage={85} />
-        <CircularPercentageBar size="lg" percentage={75} />
-        <CircularPercentageBar size="lg" percentage={50} />
-        <CircularPercentageBar size="lg" percentage={25} />
-        <CircularPercentageBar size="lg" percentage={0} />
-      </div>
+      <DrawCircles size="xs" bgColor="#F5E9EE" />
+      <DrawCircles size="sm" />
+      <DrawCircles size="md" bgColor="#F5E9EE" />
+      <DrawCircles size="lg" />
     </div>
   )
 }

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.50.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.49.9...@uswitch/trustyle.money-theme@1.50.0) (2021-06-28)
+
+
+### Features
+
+* create circle percentage bar element ([eaf6b07](https://github.com/uswitch/trustyle/commit/eaf6b07))
+
+
+
+
+
 ## [1.49.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.49.8...@uswitch/trustyle.money-theme@1.49.9) (2021-06-16)
 
 **Note:** Version bump only for package @uswitch/trustyle.money-theme

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.49.9",
+  "version": "1.50.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -2205,6 +2205,27 @@
           }
         }
       }
+    },
+    "circle-percentage-bar": {
+      "base": {
+        "text": {
+          "fontFamily": "heading",
+          "fontWeight": "bolder",
+          "color": "grey-100"
+        },
+        "bar": {
+          "border": "0.08em solid #A64470 !important"
+        },
+        "fill": {
+          "border": "0.08em solid #A64470 !important"
+        },
+        "bar-full": {
+          "border": "0.08em solid #DFDFE1 !important"
+        },
+        "fill-full": {
+          "border": "0.08em solid #DFDFE1 !important"
+        }
+      }
     }
   },
   "compounds": {

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.48.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.47.8...@uswitch/trustyle.uswitch-theme@2.48.0) (2021-06-28)
+
+
+### Features
+
+* create circle percentage bar element ([eaf6b07](https://github.com/uswitch/trustyle/commit/eaf6b07))
+
+
+
+
+
 ## [2.47.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.47.7...@uswitch/trustyle.uswitch-theme@2.47.8) (2021-06-24)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.47.8",
+  "version": "2.48.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3019,6 +3019,27 @@
       "small": {
         "fontSize": ["sm", "md"]
       }
+    },
+    "circle-percentage-bar": {
+      "base": {
+        "text": {
+          "fontFamily": "heading",
+          "fontWeight": "xxbold",
+          "color": "primary"
+        },
+        "bar": {
+          "border": "0.08em solid #141424 !important"
+        },
+        "fill": {
+          "border": "0.08em solid #141424 !important"
+        },
+        "bar-full": {
+          "border": "0.08em solid #F3F3F4 !important"
+        },
+        "fill-full": {
+          "border": "0.08em solid #F3F3F4 !important"
+        }
+      }
     }
   },
   "compounds": {


### PR DESCRIPTION
# Description
Created circle percentage bar that can have different sizes

**Money**
<img width="1236" alt="Screenshot 2021-06-24 at 17 01 42" src="https://user-images.githubusercontent.com/20357064/123296508-9de1a000-d50e-11eb-9d4c-78d304932347.png">

**Uswitch**
<img width="1264" alt="Screenshot 2021-06-24 at 17 01 54" src="https://user-images.githubusercontent.com/20357064/123296514-9f12cd00-d50e-11eb-9376-6b662058eb9d.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
