### PR TITLE
fix: revert uswitch horizontal card changes

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -3855,7 +3855,10 @@
         }
       },
       "aspectRatioBox": {
-        "position": "relative"
+        "position": "relative",
+        "overflow": "hidden",
+        "width": "100%",
+        "height": "0"
       },
       "cardImage": {
         "position": "absolute",
@@ -4019,10 +4022,6 @@
           "variant": "compounds.card.base",
           "display": "flex",
           "alignItems": "start",
-          "image": {
-            "width": [132, 384, 474],
-            "mr": 32
-          },
           "content": {
             "width": [132, 544, 670],
             "variant": "compounds.card.base.content"
@@ -4043,7 +4042,7 @@
           },
           "aspectRatioBox": {
             "variant": "compounds.card.aspectRatioBox",
-            "paddingTop": ["xs", "sm"]
+            "paddingTop": "56.287%"
           },
           "cardImage": {
             "variant": "compounds.card.cardImage"


### PR DESCRIPTION
# Description
Since we created a new header component for Uswitch and it's not a horizontal card anymore, we can revert the changes made to the horizontal card.

**Before**
<img width="1318" alt="Screenshot 2021-06-28 at 12 19 02" src="https://user-images.githubusercontent.com/20357064/123628545-1f854680-d80b-11eb-8a23-0923493a5424.png">

**After**
<img width="1466" alt="Screenshot 2021-06-28 at 12 16 20" src="https://user-images.githubusercontent.com/20357064/123629020-ac300480-d80b-11eb-8337-26f8e7d9ac1b.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
