### PR TITLE
fix: add align prop to set different alignments

### DIFF
--- a/src/elements/circular-percentage-bar/CHANGELOG.md
+++ b/src/elements/circular-percentage-bar/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.circular-percentage-bar@0.1.0...@uswitch/trustyle.circular-percentage-bar@0.1.1) (2021-06-29)
+
+
+### Bug Fixes
+
+* add align prop to set different alignments ([4a0e64e](https://github.com/uswitch/trustyle/commit/4a0e64e))
+* add story with alignment ([0d813b1](https://github.com/uswitch/trustyle/commit/0d813b1))
+* story spacing ([b059dfb](https://github.com/uswitch/trustyle/commit/b059dfb))
+
+
+
+
+
 # 0.1.0 (2021-06-28)
 
 

--- a/src/elements/circular-percentage-bar/package.json
+++ b/src/elements/circular-percentage-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.circular-percentage-bar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/circular-percentage-bar/src/index.tsx
+++ b/src/elements/circular-percentage-bar/src/index.tsx
@@ -8,6 +8,9 @@ import { CircularPercentageBarStyles } from './percentage-bar-styles'
 const styles = (element?: string) =>
   `elements.circle-percentage-bar.base${element ? `.${element}` : ''}`
 
+const alignCircle = (side: string) =>
+  `${side !== 'center' ? `flex-${side}` : 'center'}`
+
 const drawCircle = (pct: number, isBackground: boolean = false) => {
   const cls = isBackground ? '-full' : ''
   const deg = (360 / 100) * pct
@@ -38,18 +41,20 @@ const drawCircle = (pct: number, isBackground: boolean = false) => {
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   percentage: number
   size?: string
+  align: 'center' | 'start' | 'end'
 }
 
 const CircularPercentageBar: React.FC<Props> = ({
   percentage,
-  size = 'xs'
+  size = 'xs',
+  align = 'center'
 }) => {
   return (
     <div
       css={CircularPercentageBarStyles}
       sx={{
         display: 'flex',
-        justifyContent: 'center'
+        justifyContent: alignCircle(align)
       }}
     >
       <div

--- a/src/elements/circular-percentage-bar/src/index.tsx
+++ b/src/elements/circular-percentage-bar/src/index.tsx
@@ -41,7 +41,7 @@ const drawCircle = (pct: number, isBackground: boolean = false) => {
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   percentage: number
   size?: string
-  align: 'center' | 'start' | 'end'
+  align?: 'center' | 'start' | 'end'
 }
 
 const CircularPercentageBar: React.FC<Props> = ({

--- a/src/elements/circular-percentage-bar/src/percentage-bar-styles.ts
+++ b/src/elements/circular-percentage-bar/src/percentage-bar-styles.ts
@@ -4,7 +4,6 @@ export const CircularPercentageBarStyles = css({
   '.c100': {
     position: 'relative',
     float: 'left',
-    margin: '0 0.1em 0.1em 0',
     width: '1em',
     height: '1em',
     'font-size': '120px',

--- a/src/elements/circular-percentage-bar/src/stories.tsx
+++ b/src/elements/circular-percentage-bar/src/stories.tsx
@@ -60,10 +60,44 @@ ExampleWithPercentages.story = {
   }
 }
 
+export const ExampleWithAlignment = () => {
+  return (
+    <div
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        marginX: 'auto',
+        backgroundColor: '#F5E9EE',
+        width: ['100%', '50%']
+      }}
+    >
+      <div sx={{ width: '100%', marginBottom: '20px' }}>
+        <p>Start</p>
+        <CircularPercentageBar align="start" percentage={50} />
+      </div>
+      <div sx={{ width: '100%', marginBottom: '20px' }}>
+        <p>Center</p>
+        <CircularPercentageBar align="center" percentage={50} />
+      </div>
+      <div sx={{ width: '100%', marginBottom: '20px' }}>
+        <p>End</p>
+        <CircularPercentageBar align="end" percentage={50} />
+      </div>
+    </div>
+  )
+}
+
+ExampleWithAlignment.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 export const AutomatedTests = () => {
   return (
     <AllThemes themes={['uswitch', 'money']}>
       <ExampleWithPercentages />
+      <ExampleWithAlignment />
     </AllThemes>
   )
 }

--- a/src/elements/circular-percentage-bar/src/stories.tsx
+++ b/src/elements/circular-percentage-bar/src/stories.tsx
@@ -14,10 +14,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   bgColor?: string
 }
 
-export const DrawCircles: React.FC<Props> = ({
-  size = 'xs',
-  bgColor = '#ffffff'
-}) => {
+const DrawCircles: React.FC<Props> = ({ size = 'xs', bgColor = '#ffffff' }) => {
   return (
     <div
       sx={{
@@ -28,12 +25,24 @@ export const DrawCircles: React.FC<Props> = ({
         backgroundColor: bgColor
       }}
     >
-      <CircularPercentageBar size={size} percentage={0} />
-      <CircularPercentageBar size={size} percentage={25} />
-      <CircularPercentageBar size={size} percentage={50} />
-      <CircularPercentageBar size={size} percentage={75} />
-      <CircularPercentageBar size={size} percentage={85} />
-      <CircularPercentageBar size={size} percentage={100} />
+      <div sx={{ margin: '5px' }}>
+        <CircularPercentageBar size={size} percentage={0} />
+      </div>
+      <div sx={{ margin: '5px' }}>
+        <CircularPercentageBar size={size} percentage={25} />
+      </div>
+      <div sx={{ margin: '5px' }}>
+        <CircularPercentageBar size={size} percentage={50} />
+      </div>
+      <div sx={{ margin: '5px' }}>
+        <CircularPercentageBar size={size} percentage={75} />
+      </div>
+      <div sx={{ margin: '5px' }}>
+        <CircularPercentageBar size={size} percentage={85} />
+      </div>
+      <div sx={{ margin: '5px' }}>
+        <CircularPercentageBar size={size} percentage={100} />
+      </div>
     </div>
   )
 }

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.53.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.53.0...@uswitch/trustyle.money-theme@1.53.1) (2021-06-29)
+
+**Note:** Version bump only for package @uswitch/trustyle.money-theme
+
+
+
+
+
 # [1.53.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.52.0...@uswitch/trustyle.money-theme@1.53.0) (2021-06-29)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
# Description

Added an alignment prop because of the different requirements of the brands 

<img width="713" alt="Screenshot 2021-06-29 at 15 06 44" src="https://user-images.githubusercontent.com/20357064/123812131-be816f80-d8eb-11eb-9715-908c2b93bb85.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
