### PR TITLE
Sticky sidenav CLS

### DIFF
--- a/src/themes/broadband-deals/CHANGELOG.md
+++ b/src/themes/broadband-deals/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.16.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.broadband-deals-theme@1.16.4...@uswitch/trustyle.broadband-deals-theme@1.16.5) (2021-07-13)
+
+
+### Bug Fixes
+
+* sidenav-fix ([1003a50](https://github.com/uswitch/trustyle/commit/1003a50))
+
+
+
+
+
 ## [1.16.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.broadband-deals-theme@1.16.3...@uswitch/trustyle.broadband-deals-theme@1.16.4) (2021-06-15)
 
 

--- a/src/themes/broadband-deals/package.json
+++ b/src/themes/broadband-deals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.broadband-deals-theme",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "Theme file for broadband deals",
   "main": "index.js",
   "scripts": {

--- a/src/themes/broadband-deals/theme.json
+++ b/src/themes/broadband-deals/theme.json
@@ -286,6 +286,28 @@
             "color": "primary"
           }
         }
+      },
+      "&.active-sidenav-item": {
+        "color": "primary",
+        "bg": "rgb(247, 247, 248)",
+        "::after": {
+          "content": "\"\"",
+          "position": "absolute",
+          "top": "0",
+          "left": "0",
+          "display": "block",
+          "width": 4,
+          "height": "100%",
+          "backgroundColor": "primary"
+        },
+        ">a": {
+          "color": "primary",
+          "fontWeight": "bold",
+          "transform": "translateX(8px)",
+          ":visited": {
+            "color": "primary"
+          }
+        }
       }
     },
     "additionalLink": {

--- a/src/themes/journey/CHANGELOG.md
+++ b/src/themes/journey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.12.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.12.4...@uswitch/trustyle.journey-theme@2.12.5) (2021-07-13)
+
+
+### Bug Fixes
+
+* sidenav-fix ([1003a50](https://github.com/uswitch/trustyle/commit/1003a50))
+
+
+
+
+
 ## [2.12.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.journey-theme@2.12.3...@uswitch/trustyle.journey-theme@2.12.4) (2021-05-13)
 
 

--- a/src/themes/journey/package.json
+++ b/src/themes/journey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.journey-theme",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/journey/theme.json
+++ b/src/themes/journey/theme.json
@@ -1306,6 +1306,25 @@
               "color": "uswitch-navy"
             }
           }
+        },
+        "&.active-sidenav-item": {
+          "color": "uswitch-navy",
+          "::after": {
+            "content": "\"\"",
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "display": "block",
+            "width": 4,
+            "height": "100%",
+            "backgroundColor": "uswitch-navy"
+          },
+          ">a": {
+            "color": "uswitch-navy",
+            ":visited": {
+              "color": "uswitch-navy"
+            }
+          }
         }
       },
       "additionalLink": {

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.54.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.54.2...@uswitch/trustyle.money-theme@1.54.3) (2021-07-13)
+
+
+### Bug Fixes
+
+* sidenav-fix ([1003a50](https://github.com/uswitch/trustyle/commit/1003a50))
+
+
+
+
+
 ## [1.54.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.54.1...@uswitch/trustyle.money-theme@1.54.2) (2021-07-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.money-theme

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.54.2",
+  "version": "1.54.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -2942,6 +2942,19 @@
             ":visited": {
               "color": "grey-60"
             }
+          },
+          "&.active-sidenav-item": {
+            "color": "experimental-text",
+            "::after": {
+              "borderColor": "fuschia"
+            },
+            ">a": {
+              "color": "experimental-text",
+              "fontWeight": "bold",
+              ":visited": {
+                "color": "experimental-text"
+              }
+            }
           }
         },
         "isActive": {

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.48.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.48.7...@uswitch/trustyle.uswitch-theme@2.48.8) (2021-07-13)
+
+
+### Bug Fixes
+
+* sidenav-fix ([1003a50](https://github.com/uswitch/trustyle/commit/1003a50))
+
+
+
+
+
 ## [2.48.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.48.6...@uswitch/trustyle.uswitch-theme@2.48.7) (2021-07-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.48.7",
+  "version": "2.48.8",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -4635,6 +4635,25 @@
             ":focus": {
               "variant": "compounds.side-nav.isActive"
             }
+          },
+          "&.active-sidenav-item": {
+            "color": "primary",
+            "::after": {
+              "content": "\"\"",
+              "position": "absolute",
+              "top": "0",
+              "left": "0",
+              "display": "block",
+              "width": 4,
+              "height": "100%",
+              "backgroundColor": "primary"
+            },
+            ">a": {
+              "color": "primary",
+              ":visited": {
+                "color": "primary"
+              }
+            }
           }
         },
         "isActive": {


### PR DESCRIPTION
# Description

The article used to sometimes "jump" to the first heading after navigating to it.
 
![money](https://user-images.githubusercontent.com/78726823/124907819-e27a3a80-dfe8-11eb-8b57-9169536d4a06.JPG)
![uswitch](https://user-images.githubusercontent.com/78726823/124907824-e443fe00-dfe8-11eb-81ce-6fca22df509f.JPG)

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [X] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
