### PR TITLE
Feat: add modal to preapproved banner

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.4.1...@uswitch/trustyle.legacy-product-table@1.4.2) (2021-07-12)
+
+
+### Bug Fixes
+
+* color value of banner text ([feb7117](https://github.com/uswitch/trustyle/commit/feb7117))
+
+
+
+
+
 ## [1.4.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.4.0...@uswitch/trustyle.legacy-product-table@1.4.1) (2021-07-09)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -105,7 +105,7 @@ const PreapprovedBanner: React.FC<PreapprovedBannerProps> = ({
           sx={{
             variant: 'styles.a',
             fontWeight: 'semiBold',
-            color: 'experimentspanl-text',
+            color: 'experimental-text',
             cursor: 'pointer'
           }}
           onClick={() => onClick()}

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -71,18 +71,19 @@ const Badge: React.FC<BadgeProps> = ({ text }) => {
 
 interface BannerInfo {
   text: string
-  link: string
   linkText: string
 }
 
 interface PreapprovedBannerProps extends React.HTMLAttributes<HTMLDivElement> {
   bannerInfo: BannerInfo
   badge?: string
+  onClick: () => void
 }
 
 const PreapprovedBanner: React.FC<PreapprovedBannerProps> = ({
   bannerInfo,
-  badge
+  badge,
+  onClick
 }) => {
   return (
     <div
@@ -100,17 +101,17 @@ const PreapprovedBanner: React.FC<PreapprovedBannerProps> = ({
     >
       <span sx={{ marginTop: [badge ? '10px' : '0', '10px'] }}>
         {bannerInfo.text}&nbsp;
-        <a
-          href={bannerInfo.link}
-          target="_blank"
-          rel="noopener noreferrer"
+        <span
           sx={{
+            variant: 'styles.a',
             fontWeight: 'semiBold',
-            color: 'experimental-text'
+            color: 'experimentspanl-text',
+            cursor: 'pointer'
           }}
+          onClick={() => onClick()}
         >
           {bannerInfo.linkText}
-        </a>
+        </span>
       </span>
     </div>
   )
@@ -702,6 +703,7 @@ interface LegacyProductTableProps extends React.HTMLAttributes<HTMLDivElement> {
   badges?: string[]
   preapproved?: boolean
   bannerInfo?: BannerInfo
+  onBannerClick?: () => void
   telephone?: string
 }
 
@@ -720,6 +722,7 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
   badges = [],
   preapproved = false,
   bannerInfo,
+  onBannerClick,
   telephone,
   ...props
 }) => {
@@ -743,7 +746,11 @@ const LegacyProductTable: React.FC<LegacyProductTableProps> = ({
       {...props}
     >
       {preapproved && bannerInfo && (
-        <PreapprovedBanner bannerInfo={bannerInfo} badge={badge} />
+        <PreapprovedBanner
+          bannerInfo={bannerInfo}
+          badge={badge}
+          onClick={() => onBannerClick && onBannerClick()}
+        />
       )}
       <RowWrapper
         link={clickableRow}

--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.16.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.16.2...@uswitch/trustyle.product-table@2.16.3) (2021-07-12)
+
+**Note:** Version bump only for package @uswitch/trustyle.product-table
+
+
+
+
+
 ## [2.16.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.16.0...@uswitch/trustyle.product-table@2.16.2) (2021-07-07)
 
 

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/header-banner.tsx
+++ b/src/compounds/product-table/src/components/header-banner.tsx
@@ -4,7 +4,6 @@ import { jsx } from 'theme-ui'
 
 export interface BannerInfo {
   text: string
-  link: string
   linkText: string
 }
 
@@ -12,11 +11,13 @@ interface ProductTableHeaderBannerProps
   extends React.HTMLAttributes<HTMLDivElement> {
   bannerInfo: BannerInfo
   badge?: boolean
+  onClick: () => void
 }
 
 export const ProductTableHeaderBanner: React.FC<ProductTableHeaderBannerProps> = ({
   bannerInfo,
-  badge = false
+  badge = false,
+  onClick
 }) => {
   return (
     <div
@@ -34,14 +35,16 @@ export const ProductTableHeaderBanner: React.FC<ProductTableHeaderBannerProps> =
     >
       <span sx={{ marginTop: [badge ? '10px' : '0', '10px'] }}>
         {bannerInfo.text}&nbsp;
-        <a
-          href={bannerInfo.link}
-          target="_blank"
-          rel="noopener noreferrer"
-          sx={{ fontWeight: 'base' }}
+        <span
+          sx={{
+            variant: 'styles.a',
+            fontWeight: 'base',
+            cursor: 'pointer'
+          }}
+          onClick={() => onClick()}
         >
           {bannerInfo.linkText}
-        </a>
+        </span>
       </span>
     </div>
   )

--- a/src/compounds/product-table/src/components/row.tsx
+++ b/src/compounds/product-table/src/components/row.tsx
@@ -30,6 +30,7 @@ export interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   card?: boolean
   preApproved?: boolean
   bannerInfo?: BannerInfo
+  onBannerClick?: () => void
   extraStyles?: {}
   sectionStyles?: {}
   onRowClick?: () => void
@@ -49,6 +50,7 @@ const ProductTableRow: React.FC<RowProps> = ({
   card = false,
   preApproved = false,
   bannerInfo,
+  onBannerClick,
   extraStyles = {},
   sectionStyles = {},
   onRowClick
@@ -135,6 +137,7 @@ const ProductTableRow: React.FC<RowProps> = ({
           <ProductTableHeaderBanner
             bannerInfo={bannerInfo}
             badge={!!badges.length}
+            onClick={() => onBannerClick && onBannerClick()}
           />
         )}
         <RowWrapper

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.54.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.54.1...@uswitch/trustyle.money-theme@1.54.2) (2021-07-12)
+
+**Note:** Version bump only for package @uswitch/trustyle.money-theme
+
+
+
+
+
 ## [1.54.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.54.0...@uswitch/trustyle.money-theme@1.54.1) (2021-07-07)
 
 **Note:** Version bump only for package @uswitch/trustyle.money-theme

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -945,6 +945,17 @@
       "base": {
         "backgroundColor": "grey-0"
       },
+      "bannerText": {
+        "paddingBottom": "40px",
+        "paddingX": ["sm", "xl"],
+        "marginTop": "0",
+        "textAlign": "center",
+        "fontFamily": "base",
+        "lineHeight": "base",
+        "fontSize": "sm",
+        "fontWeight": "base",
+        "color": "grey-80"
+      },
       "variants": {
         "full": {
           "variant": "elements.modal.base",

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.48.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.48.6...@uswitch/trustyle.uswitch-theme@2.48.7) (2021-07-12)
+
+**Note:** Version bump only for package @uswitch/trustyle.uswitch-theme
+
+
+
+
+
 ## [2.48.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.48.4...@uswitch/trustyle.uswitch-theme@2.48.6) (2021-07-07)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.48.6",
+  "version": "2.48.7",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -801,6 +801,17 @@
       "base": {
         "backgroundColor": "#FFFFFF"
       },
+      "bannerText": {
+        "paddingBottom": "40px",
+        "paddingX": ["sm", "lg"],
+        "marginX": "xs",
+        "marginTop": "0",
+        "textAlign": "center",
+        "fontFamily": "base",
+        "lineHeight": "sm",
+        "fontSize": "xs",
+        "fontWeight": "base"
+      },
       "variants": {
         "full": {
           "variant": "elements.modal.base",
@@ -825,7 +836,10 @@
         "border": 0,
         "cursor": "pointer",
         "lineHeight": 0,
-        "padding": "xs"
+        "padding": "xs",
+        ":focus-visible": {
+          "outline": "none"
+        }
       }
     },
     "form": {


### PR DESCRIPTION
# Description

**Uswitch**
<img width="1190" alt="Screenshot 2021-07-12 at 15 09 14" src="https://user-images.githubusercontent.com/20357064/125285371-42434f00-e323-11eb-8869-7a01419c69dc.png">
<img width="443" alt="Screenshot 2021-07-12 at 15 09 24" src="https://user-images.githubusercontent.com/20357064/125285383-44a5a900-e323-11eb-86f0-0d0ceb97e52f.png">

**Money**
<img width="1404" alt="Screenshot 2021-07-12 at 15 10 52" src="https://user-images.githubusercontent.com/20357064/125285519-69018580-e323-11eb-915a-644d76970cf5.png">
<img width="446" alt="Screenshot 2021-07-12 at 15 11 02" src="https://user-images.githubusercontent.com/20357064/125285531-6a32b280-e323-11eb-92f9-6d2bab281b3d.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
