### PR TITLE
fix: change margin top when there is no badge

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.4.2...@uswitch/trustyle.legacy-product-table@1.4.3) (2021-07-13)
+
+
+### Bug Fixes
+
+* change margin top when there is no badge ([1a879b5](https://github.com/uswitch/trustyle/commit/1a879b5))
+
+
+
+
+
 ## [1.4.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.4.1...@uswitch/trustyle.legacy-product-table@1.4.2) (2021-07-12)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -99,7 +99,7 @@ const PreapprovedBanner: React.FC<PreapprovedBannerProps> = ({
         fontWeight: 'bold'
       }}
     >
-      <span sx={{ marginTop: [badge ? '10px' : '0', '10px'] }}>
+      <span sx={{ marginTop: badge ? '10px' : '0' }}>
         {bannerInfo.text}&nbsp;
         <span
           sx={{

--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.16.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.16.3...@uswitch/trustyle.product-table@2.16.4) (2021-07-13)
+
+
+### Bug Fixes
+
+* change margin top when there is no badge ([1a879b5](https://github.com/uswitch/trustyle/commit/1a879b5))
+
+
+
+
+
 ## [2.16.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.16.2...@uswitch/trustyle.product-table@2.16.3) (2021-07-12)
 
 **Note:** Version bump only for package @uswitch/trustyle.product-table

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/components/header-banner.tsx
+++ b/src/compounds/product-table/src/components/header-banner.tsx
@@ -33,7 +33,7 @@ export const ProductTableHeaderBanner: React.FC<ProductTableHeaderBannerProps> =
         fontWeight: 'bold'
       }}
     >
-      <span sx={{ marginTop: [badge ? '10px' : '0', '10px'] }}>
+      <span sx={{ marginTop: badge ? '10px' : '0' }}>
         {bannerInfo.text}&nbsp;
         <span
           sx={{


### PR DESCRIPTION
# Description

**Before**
<img width="1150" alt="Screenshot 2021-07-13 at 12 06 06" src="https://user-images.githubusercontent.com/20357064/125424907-8fc24995-2c03-49bb-bfb8-77863d22ddde.png">

**After**
<img width="1144" alt="Screenshot 2021-07-13 at 12 06 37" src="https://user-images.githubusercontent.com/20357064/125424919-9cde5055-2ad0-4ae9-ad79-3e3d10cadde2.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
