### PR TITLE
fix: show text if the percantage is not a number

### DIFF
--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.4.5...@uswitch/trustyle.legacy-product-table@1.4.6) (2021-07-15)
+
+
+### Bug Fixes
+
+* show text if the percantage is not a number ([b3d83ba](https://github.com/uswitch/trustyle/commit/b3d83ba))
+
+
+
+
+
 ## [1.4.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.4.4...@uswitch/trustyle.legacy-product-table@1.4.5) (2021-07-14)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/legacy-product-table/src/index.tsx
+++ b/src/compounds/legacy-product-table/src/index.tsx
@@ -323,6 +323,7 @@ export const CtaCell: React.FC<CtaCellProps> = ({
 
 interface PercentageCellProps extends DataCellProps {
   percentage: number
+  alternativeText: string
   size?: string
 }
 
@@ -332,6 +333,7 @@ export const PercentageCell: React.FC<PercentageCellProps> = ({
   color,
   label,
   percentage,
+  alternativeText,
   size
 }) => {
   return (
@@ -341,7 +343,14 @@ export const PercentageCell: React.FC<PercentageCellProps> = ({
       label={label}
       color={color}
     >
-      <CirclePercentageBar percentage={percentage} size={size} align="center" />
+      {!isNaN(percentage) && (
+        <CirclePercentageBar
+          percentage={percentage}
+          size={size}
+          align="center"
+        />
+      )}
+      {isNaN(percentage) && <span>{alternativeText}</span>}
     </DataCell>
   )
 }

--- a/src/compounds/legacy-product-table/src/stories.tsx
+++ b/src/compounds/legacy-product-table/src/stories.tsx
@@ -90,6 +90,7 @@ const percentageTableContents = [
     label="Chance of acceptance"
     key="4"
     percentage={70}
+    alternativeText={'No results found for this'}
     size="xs"
   />,
   <ImageCell key="3">


### PR DESCRIPTION
# Description
Show `No results found for this` text if the percentage is not a number
related change: https://github.com/uswitch/fs-core/pull/708

<img width="1143" alt="Screenshot 2021-07-15 at 14 35 21" src="https://user-images.githubusercontent.com/20357064/125782769-0e080721-0768-4af5-be02-a5582101312b.png">
<img width="1193" alt="Screenshot 2021-07-15 at 14 40 18" src="https://user-images.githubusercontent.com/20357064/125782774-295ce681-2270-428a-a8c7-8b16a1b9f79b.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
