### PR TITLE
Fix: max-width for wide sponsored by logos

### DIFF
--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.36](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.35...@uswitch/trustyle.sponsored-product-rate-table@3.3.36) (2021-08-04)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.3.35](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.34...@uswitch/trustyle.sponsored-product-rate-table@3.3.35) (2021-06-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.3.35",
+  "version": "3.3.36",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -24,7 +24,7 @@
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.41",
     "@uswitch/trustyle.primary-info-block": "^1.0.12",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.2.3",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.2.4",
     "@uswitch/trustyle.usp-tag": "^0.2.0"
   },
   "devDependencies": {

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.36](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.35...@uswitch/trustyle.sponsored-product@3.5.36) (2021-08-04)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.5.35](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.34...@uswitch/trustyle.sponsored-product@3.5.35) (2021-06-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.5.35",
+  "version": "3.5.36",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -25,7 +25,7 @@
     "@uswitch/trustyle.grid": "^2.0.15",
     "@uswitch/trustyle.imgix-image": "^0.1.41",
     "@uswitch/trustyle.primary-info-block": "^1.0.12",
-    "@uswitch/trustyle.sponsored-by-tag": "^2.2.3",
+    "@uswitch/trustyle.sponsored-by-tag": "^2.2.4",
     "@uswitch/trustyle.usp-tag": "^0.2.0"
   },
   "devDependencies": {

--- a/src/elements/sponsored-by-tag/CHANGELOG.md
+++ b/src/elements/sponsored-by-tag/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.4](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.2.3...@uswitch/trustyle.sponsored-by-tag@2.2.4) (2021-08-04)
+
+
+### Bug Fixes
+
+* max-width for wide sponsored by logos ([3e71c31](https://github.com/uswitch/trustyle/commit/3e71c31))
+
+
+
+
+
 ## [2.2.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-by-tag@2.2.2...@uswitch/trustyle.sponsored-by-tag@2.2.3) (2021-04-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-by-tag

--- a/src/elements/sponsored-by-tag/package.json
+++ b/src/elements/sponsored-by-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-by-tag",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/sponsored-by-tag/src/index.tsx
+++ b/src/elements/sponsored-by-tag/src/index.tsx
@@ -45,12 +45,10 @@ const SponsoredByTag: React.FC<Props> = ({
       alt={providerName}
       imgixParams={{
         fit: 'fill',
-        w: 92,
         h: 45,
         bg: '00FFFFFF' // weirdly, fixes size issues
       }}
       critical
-      width={92}
       height={46}
       sx={{
         variant: `${lookup(variant)}.image`

--- a/src/elements/sponsored-by-tag/src/stories.tsx
+++ b/src/elements/sponsored-by-tag/src/stories.tsx
@@ -11,12 +11,38 @@ export default {
   title: 'Elements/Sponsored by tag'
 }
 
-export const ExampleWithDefaultText = () => {
-  const providerName: string = text('Provider name', 'Three')
-  const providerLogo: string = text(
-    'Provider logo url',
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+const defaultProviderName = 'Three'
+const defaultProviderLogo =
+  'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+const wideProviderLogo =
+  'https://user-images.githubusercontent.com/15983736/127509419-d54cbc11-3d5b-42ed-9902-6e5a178cd2bc.png'
+const defaultProviderText = 'This is example text'
+
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+  children: React.ReactNode
+}
+
+const Wrapper: React.FC<Props> = ({ children, sx = {} }) => {
+  return <div sx={{ backgroundColor: 'secondary', ...sx }}>{children}</div>
+}
+
+export const WideExampleWithDefaultText = () => {
+  const providerName = text('Provider name', defaultProviderName)
+  const providerLogo = text('Provider logo url', wideProviderLogo)
+
+  return (
+    <Wrapper>
+      <SponsoredByTag
+        providerLogoSrc={providerLogo}
+        providerName={providerName}
+      />
+    </Wrapper>
   )
+}
+
+export const ExampleWithDefaultText = () => {
+  const providerName = text('Provider name', defaultProviderName)
+  const providerLogo = text('Provider logo url', defaultProviderLogo)
 
   return (
     <SponsoredByTag
@@ -27,85 +53,69 @@ export const ExampleWithDefaultText = () => {
 }
 
 export const ExampleWithTextProp = () => {
-  const providerName: string = text('Provider name', 'Three')
-  const providerLogo: string = text(
-    'Provider logo url',
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
-  )
+  const providerName = text('Provider name', defaultProviderName)
+  const providerLogo = text('Provider logo url', defaultProviderLogo)
+  const providerText = text('Text to display', defaultProviderText)
 
-  const providerText: string = text('Text to display', 'This is example text')
   return (
-    <React.Fragment>
+    <Wrapper>
       <SponsoredByTag
         providerLogoSrc={providerLogo}
         providerText={providerText}
         providerName={providerName}
       />
-    </React.Fragment>
+    </Wrapper>
   )
 }
 
 export const ExampleWithHeroVariant = () => {
-  const providerName: string = text('Provider name', 'Three')
-  const providerLogo: string = text(
-    'Provider logo url',
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
-  )
+  const providerName = text('Provider name', defaultProviderName)
+  const providerLogo = text('Provider logo url', defaultProviderLogo)
+  const providerText = text('Text to display', defaultProviderText)
 
-  const providerText: string = text('Text to display', 'This is example text')
   return (
-    <React.Fragment>
+    <Wrapper>
       <SponsoredByTag
         providerLogoSrc={providerLogo}
         providerText={providerText}
         providerName={providerName}
         variant="hero"
       />
-    </React.Fragment>
+    </Wrapper>
   )
 }
 
 export const ExampleWithFormVariant = () => {
-  const providerName: string = text('Provider name', 'Three')
-  const providerLogo: string = text(
-    'Provider logo url',
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
-  )
+  const providerName = text('Provider name', defaultProviderName)
+  const providerLogo = text('Provider logo url', defaultProviderLogo)
+  const providerText = text('Text to display', 'You selected:')
 
-  const providerText: string = text('Text to display', 'You selected:')
   return (
-    <React.Fragment>
-      <div sx={{ backgroundColor: 'secondary', padding: 'sm', width: '500px' }}>
-        <SponsoredByTag
-          providerLogoSrc={providerLogo}
-          providerText={providerText}
-          providerName={providerName}
-          variant="form"
-        />
-      </div>
-    </React.Fragment>
+    <Wrapper sx={{ padding: 'sm', width: '500px' }}>
+      <SponsoredByTag
+        providerLogoSrc={providerLogo}
+        providerText={providerText}
+        providerName={providerName}
+        variant="form"
+      />
+    </Wrapper>
   )
 }
 
 export const ExampleWithCentredLightVariant = () => {
-  const providerName: string = text('Provider name', 'Three')
-  const providerLogo: string = text(
-    'Provider logo url',
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
-  )
+  const providerName = text('Provider name', defaultProviderName)
+  const providerLogo = text('Provider logo url', defaultProviderLogo)
+  const providerText = text('Text to display', 'You selected:')
 
-  const providerText: string = text('Text to display', 'You selected:')
   return (
-    <React.Fragment>
-      <div sx={{ backgroundColor: 'secondary' }}>
-        <SponsoredByTag
-          providerLogoSrc={providerLogo}
-          providerText={providerText}
-          providerName={providerName}
-          variant="centered-light"
-        />
-      </div>
-    </React.Fragment>
+    <Wrapper>
+      <SponsoredByTag
+        providerLogoSrc={providerLogo}
+        providerText={providerText}
+        providerName={providerName}
+        variant="centered-light"
+      />
+    </Wrapper>
   )
 }
 

--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.56.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.56.0...@uswitch/trustyle.money-theme@1.56.1) (2021-08-04)
+
+
+### Bug Fixes
+
+* max-width for wide sponsored by logos ([3e71c31](https://github.com/uswitch/trustyle/commit/3e71c31))
+
+
+
+
+
 # [1.56.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.55.1...@uswitch/trustyle.money-theme@1.56.0) (2021-07-30)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -372,7 +372,7 @@
         },
         "image": {
           "maxHeight": "32px",
-          "maxWidth": ["88px", "104px"],
+          "maxWidth": ["88px", "150px"],
           "ml": "xs"
         }
       },
@@ -404,7 +404,9 @@
             "alignItems": "center",
             "justifyContent": "flex-end",
             "paddingY": "xxs",
-            "pt": "md"
+            "pt": "md",
+            "textAlign": "right",
+            "width": "100%"
           },
           "text": {
             "color": "white"

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.49.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.49.0...@uswitch/trustyle.uswitch-theme@2.49.1) (2021-08-04)
+
+**Note:** Version bump only for package @uswitch/trustyle.uswitch-theme
+
+
+
+
+
 # [2.49.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.48.10...@uswitch/trustyle.uswitch-theme@2.49.0) (2021-07-30)
 
 

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.49.0",
+  "version": "2.49.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1481,6 +1481,13 @@
         "backgroundColor": "blue"
       }
     },
+    "sponsored-by-tag": {
+      "base": {
+        "image": {
+          "width": "92px"
+        }
+      }
+    },
     "breadcrumbs": {
       "base": {
         "main": {


### PR DESCRIPTION
# Description

Ref: https://rvu.atlassian.net/browse/MONEY-91

Adjust size of sponsored by logo.

Before:

<img width="549" alt="Screenshot 2021-07-29 at 17 37 18" src="https://user-images.githubusercontent.com/15983736/127530943-67575a45-5c31-4606-b8e3-6362a2ce217e.png">
<img width="502" alt="Screenshot 2021-07-29 at 17 38 42" src="https://user-images.githubusercontent.com/15983736/127531091-b5c01193-65e7-46a8-9009-e384e9c1dc1d.png">

After:

<img width="507" alt="Screenshot 2021-07-29 at 17 41 27" src="https://user-images.githubusercontent.com/15983736/127531514-918a85c6-112d-4b8a-bb2a-8a1d67827d4b.png">
<img width="515" alt="Screenshot 2021-07-29 at 17 38 14" src="https://user-images.githubusercontent.com/15983736/127531032-3fc2bfe3-7215-4568-856d-0a1c894639e6.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
