### PR TITLE
feat: grey-box rich text block on money

### DIFF
--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1899,6 +1899,13 @@
           "display": "flex",
           "alignItems": "center"
         },
+        "grey-box": {
+          "variant": "elements.rich-text-block.base",
+          "bg": "grey-10",
+          "py": "md",
+          "px": ["md", "lg"],
+          "boxSizing": "border-box"
+        },
         "assurance-text": {
           "boxSizing": "border-box",
           "px": ["lg", "56px"],


### PR DESCRIPTION
# Description

Grey-box variant for Rich Text Block for the Money theme

![grey](https://user-images.githubusercontent.com/78726823/127236222-a259c48d-c0d3-4b3d-94e0-686b2fab63a9.JPG)

https://www.notion.so/rvu/Grey-box-rich-text-block-variant-on-Money-9be630b1a85946579513d867dba12662

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
