### PR TITLE
Assurance bar styling for money

### DIFF
--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -3302,20 +3302,20 @@
           "py": 0,
           "mb": "md",
           "h3": {
-            "color": "#000",
-            "paddingLeft": "0px",
-            "fontFamily": "Nunito, sans-serif",
-            "fontWeight": 600,
-            "fontSize": 30,
-            "lineHeight": "120%"
+            "color": "grey-100",
+            "paddingLeft": 0,
+            "fontFamily": "heading",
+            "fontWeight": "bold",
+            "fontSize": "xxl",
+            "lineHeight": "heading"
           },
           "p": {
-            "color": "#000",
+            "color": "grey-100",
             "mx": 0,
-            "fontFamily": "SF Pro Text",
+            "fontFamily": "base",
             "fontWeight": "normal",
-            "fontSize": 16,
-            "lineHeight": "150%"
+            "fontSize": "base",
+            "lineHeight": "base"
           },
           "heading": {
             "a": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -3292,6 +3292,59 @@
               "compounds.card.variants.horizontal.headerChildren"
             ]
           }
+        },
+        "assuranceBar": {
+          "display": "flex",
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+          "alignItems": "flex-start",
+          "textAlign": "left",
+          "py": 0,
+          "mb": "md",
+          "h3": {
+            "color": "#000",
+            "paddingLeft": "0px",
+            "fontFamily": "Nunito, sans-serif",
+            "fontWeight": 600,
+            "fontSize": 30,
+            "lineHeight": "120%"
+          },
+          "p": {
+            "color": "#000",
+            "mx": 0,
+            "fontFamily": "SF Pro Text",
+            "fontWeight": "normal",
+            "fontSize": 16,
+            "lineHeight": "150%"
+          },
+          "heading": {
+            "a": {
+              "fontWeight": "700"
+            },
+            "pb": ["8px", "16px"]
+          },
+          "image": {
+            "box-sizing": "border-box",
+            "img": {
+              "width": 32
+            }
+          },
+          "link": {
+            "variant": "compounds.card.base.link"
+          },
+          "a": {
+            "textDecoration": "none",
+            "borderBottom": "initial",
+            "mb": 0,
+            "width": 32,
+            "height": 32,
+            "mr": "md"
+          },
+          "& a:hover": {
+            "color": "inherit",
+            "stroke": "initial",
+            "opacity": "initial"
+          }
         }
       }
     },


### PR DESCRIPTION
# Description

Adding Assurance Bar Card variation styling to money theme

![image](https://user-images.githubusercontent.com/55379739/127976814-d79614c8-dd43-434c-8d60-92ebcfd1882d.png)

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
