### PR TITLE
feat: fix styling on sponsored by on form

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.58.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.57.0...@uswitch/trustyle.money-theme@1.58.0) (2021-08-05)
+
+
+### Features
+
+* fix styling on sponsored by on form ([ef5394e](https://github.com/uswitch/trustyle/commit/ef5394e))
+
+
+
+
+
 # [1.57.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.56.1...@uswitch/trustyle.money-theme@1.57.0) (2021-08-04)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -379,16 +379,22 @@
       "variants": {
         "form": {
           "wrapper": {
-            "backgroundColor": "grey-05",
+            "backgroundColor": "grey-0",
             "borderRadius": "4px",
             "display": "flex",
             "alignItems": "center",
             "justifyContent": "center",
             "paddingY": "md",
-            "paddingX": "xl"
+            "paddingX": "xl",
+            "img": {
+              "ml": "md",
+              "mr": "0"
+            }
+          },
+          "text": {
+            "color": "black"
           },
           "image": {
-            "ml": "md",
             "width": "149px",
             "height": "auto"
           }


### PR DESCRIPTION
# Description

This resolves styling issues on pensions and mortgages form

before: 
![CleanShot 2021-08-05 at 15 38 11](https://user-images.githubusercontent.com/630034/128368864-5a0df41e-0735-4421-8b0a-36753e7ad788.png)

after:
![CleanShot 2021-08-05 at 15 37 49](https://user-images.githubusercontent.com/630034/128368810-d5e75f5c-a492-48cc-8fe6-b515476b6f89.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
