### PR TITLE
feat: add address-lookup styling - taken from eevee-components

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.60.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.59.1...@uswitch/trustyle.money-theme@1.60.0) (2021-08-11)
+
+
+### Features
+
+* add address-lookup styling - taken from eevee-components ([f2e3db1](https://github.com/uswitch/trustyle/commit/f2e3db1))
+
+
+
+
+
 ## [1.59.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.59.0...@uswitch/trustyle.money-theme@1.59.1) (2021-08-10)
 
 **Note:** Version bump only for package @uswitch/trustyle.money-theme

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.59.1",
+  "version": "1.60.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1849,6 +1849,50 @@
           }
         }
       },
+      "address-lookup": {
+        "postcode-row": {
+          "marginBottom": "sm",
+          "alignItems": "center"
+        },
+        "display": {
+          "color": "grey-80",
+          "backgroundColor": "#eaeced",
+          "padding": "sm",
+          "borderRadius": "4px"
+        },
+        "container": {
+          "marginBottom": ["sm", "lg", "xl"]
+        },
+        "edit-container": {
+          "backgroundColor": "#eaeced",
+          "padding": "sm"
+        },
+        "input-container": {
+          "marginBottom": "sm"
+        },
+        "label": {
+          "marginRight": "sm",
+          "fontSize": "sm",
+          "color": "#2f353a",
+          "display": "block",
+          "marginBottom": "xxs",
+          "fontFamily": "legacy",
+          "fontWeight": "base",
+          "textAlign": "left"
+        },
+        "button": {
+          "color": "grey-80",
+          "fontSize": "sm",
+          "fontStyle": "normal",
+          "fontWeight": "base",
+          "textAlign": "left",
+          "border": "none",
+          "background": "none",
+          "textDecoration": "underline",
+          "padding": "8px 0 0",
+          "cursor": "pointer"
+        }
+      },
       "button": {
         "variants": {
           "calculator": {


### PR DESCRIPTION
# Description

Move styles from eevee-components to trustyle (see this commit: https://github.com/uswitch/eevee-components/pull/292/commits/12dc47ae00ff974e0a335212df00d32884ee2c97)

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
