### PR TITLE
fix: make the whole btn link the same color inside

### DIFF
--- a/src/compounds/ad-banner/CHANGELOG.md
+++ b/src/compounds/ad-banner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.24](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.ad-banner@2.3.23...@uswitch/trustyle.ad-banner@2.3.24) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.ad-banner
+
+
+
+
+
 ## [2.3.23](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.ad-banner@2.3.22...@uswitch/trustyle.ad-banner@2.3.23) (2021-08-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.ad-banner

--- a/src/compounds/ad-banner/package.json
+++ b/src/compounds/ad-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.ad-banner",
-  "version": "2.3.23",
+  "version": "2.3.24",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@uswitch/trustyle.awards-tag": "^0.2.2",
-    "@uswitch/trustyle.button-link": "^3.2.10",
+    "@uswitch/trustyle.button-link": "^3.2.11",
     "@uswitch/trustyle.imgix-image": "^0.1.42"
   }
 }

--- a/src/compounds/hero-card/CHANGELOG.md
+++ b/src/compounds/hero-card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.30](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-card@2.0.29...@uswitch/trustyle.hero-card@2.0.30) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.hero-card
+
+
+
+
+
 ## [2.0.29](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.hero-card@2.0.28...@uswitch/trustyle.hero-card@2.0.29) (2021-08-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.hero-card

--- a/src/compounds/hero-card/package.json
+++ b/src/compounds/hero-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.hero-card",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.10",
-    "@uswitch/trustyle.button-link": "^3.2.10"
+    "@uswitch/trustyle.button-link": "^3.2.11"
   }
 }

--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.7.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.7.2...@uswitch/trustyle.legacy-product-table@1.7.3) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.legacy-product-table
+
+
+
+
+
 ## [1.7.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.7.1...@uswitch/trustyle.legacy-product-table@1.7.2) (2021-08-27)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@uswitch/trustyle.button": "^3.0.6",
-    "@uswitch/trustyle.button-link": "^3.2.10",
+    "@uswitch/trustyle.button-link": "^3.2.11",
     "@uswitch/trustyle.circular-percentage-bar": "^0.1.4",
     "@uswitch/trustyle.icon": "^1.27.2",
     "@uswitch/trustyle.information-panel": "^0.1.1",

--- a/src/compounds/sponsored-product-rate-table/CHANGELOG.md
+++ b/src/compounds/sponsored-product-rate-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.39](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.38...@uswitch/trustyle.sponsored-product-rate-table@3.3.39) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product-rate-table
+
+
+
+
+
 ## [3.3.38](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product-rate-table@3.3.37...@uswitch/trustyle.sponsored-product-rate-table@3.3.38) (2021-08-27)
 
 

--- a/src/compounds/sponsored-product-rate-table/package.json
+++ b/src/compounds/sponsored-product-rate-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product-rate-table",
-  "version": "3.3.38",
+  "version": "3.3.39",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.arrangement": "^2.0.22",
     "@uswitch/trustyle.awards-tag": "^0.2.2",
     "@uswitch/trustyle.button": "^3.0.6",
-    "@uswitch/trustyle.button-link": "^3.2.10",
+    "@uswitch/trustyle.button-link": "^3.2.11",
     "@uswitch/trustyle.flex-grid": "^1.2.1",
     "@uswitch/trustyle.imgix-image": "^0.1.42",
     "@uswitch/trustyle.primary-info-block": "^1.0.13",

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.40](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.39...@uswitch/trustyle.sponsored-product@3.5.40) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.sponsored-product
+
+
+
+
+
 ## [3.5.39](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.5.38...@uswitch/trustyle.sponsored-product@3.5.39) (2021-08-27)
 
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.5.39",
+  "version": "3.5.40",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -20,7 +20,7 @@
     "@uswitch/trustyle.arrangement": "^2.0.22",
     "@uswitch/trustyle.awards-tag": "^0.2.2",
     "@uswitch/trustyle.badge": "^2.0.6",
-    "@uswitch/trustyle.button-link": "^3.2.10",
+    "@uswitch/trustyle.button-link": "^3.2.11",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.17",
     "@uswitch/trustyle.imgix-image": "^0.1.42",

--- a/src/elements/button-link/CHANGELOG.md
+++ b/src/elements/button-link/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.2.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button-link@3.2.10...@uswitch/trustyle.button-link@3.2.11) (2021-09-07)
+
+
+### Bug Fixes
+
+* make the whole btn link the same color inside ([68a3f2e](https://github.com/uswitch/trustyle/commit/68a3f2e))
+
+
+
+
+
 ## [3.2.10](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.button-link@3.2.9...@uswitch/trustyle.button-link@3.2.10) (2021-08-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.button-link

--- a/src/elements/button-link/package.json
+++ b/src/elements/button-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.button-link",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/button-link/src/index.tsx
+++ b/src/elements/button-link/src/index.tsx
@@ -98,6 +98,7 @@ export const ButtonLink = <
       <div
         sx={{
           display: 'inline',
+          backgroundColor: 'inherit',
           variant: `elements.buttons.variants.${variant}.content`
         }}
       >

--- a/src/elements/card/CHANGELOG.md
+++ b/src/elements/card/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.14.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.card@1.14.2...@uswitch/trustyle.card@1.14.3) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.card
+
+
+
+
+
 ## [1.14.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.card@1.14.1...@uswitch/trustyle.card@1.14.2) (2021-08-27)
 
 

--- a/src/elements/card/package.json
+++ b/src/elements/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.card",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "license": "MIT",
   "main": "lib/index.js",
   "publishConfig": {
@@ -16,7 +16,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
-    "@uswitch/trustyle.button-link": "^3.2.10",
+    "@uswitch/trustyle.button-link": "^3.2.11",
     "@uswitch/trustyle.date": "^0.0.14",
     "@uswitch/trustyle.flex-grid": "^3.5.4",
     "@uswitch/trustyle.imgix-image": "^0.1.42"

--- a/src/elements/cta/CHANGELOG.md
+++ b/src/elements/cta/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.30](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.cta@1.0.29...@uswitch/trustyle.cta@1.0.30) (2021-09-07)
+
+**Note:** Version bump only for package @uswitch/trustyle.cta
+
+
+
+
+
 ## [1.0.29](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.cta@1.0.28...@uswitch/trustyle.cta@1.0.29) (2021-08-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.cta

--- a/src/elements/cta/package.json
+++ b/src/elements/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.cta",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@uswitch/trustyle-utils.get": "^1.0.10",
-    "@uswitch/trustyle.button-link": "^3.2.10"
+    "@uswitch/trustyle.button-link": "^3.2.11"
   }
 }


### PR DESCRIPTION
# Description

make the whole btn link the same color inside

https://www.notion.so/rvu/Button-has-grey-background-applied-to-button-text-when-embedded-onto-greybox-rich-text-variant-746381c5b50c49fba8ff63c75b2a0067

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
