### PR TITLE
Include system fonts in uswitch font family

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -16,10 +16,10 @@
     "errorInput": "inset 0 0 0 1px #DB1818"
   },
   "fonts": {
-    "base": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,sans-serif",
-    "link": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,sans-serif",
-    "body": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,sans-serif",
-    "heading": "Helvetica Now Display,Helvetica Neue,Helvetica,Arial,sans-serif",
+    "base": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,sans-serif",
+    "link": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,sans-serif",
+    "body": "Helvetica Now Text,Helvetica Neue,Helvetica,Arial,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,sans-serif",
+    "heading": "Helvetica Now Display,Helvetica Neue,Helvetica,Arial,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Fira Sans,Droid Sans,sans-serif",
     "monospace": "Menlo, monospace"
   },
   "lineHeights": {


### PR DESCRIPTION
We previously used system fonts on uswitch, and now we are moving to
helvetica now, however we dont yet have a licence for helvetica now.

This commit adds the system fonts back into the font family in the
uswitch theme, it shouldnt make much difference, but it fixes an issue
where some characters were not being rendered correctly as they were
in none of the availble fonts

# Description

<!-- Explain the purpose of this Pull Request. -->

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
