### PR TITLE
fix: uswitch theme mods for image module

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -5788,6 +5788,13 @@
           }
         }
       }
+    },
+    "imageModule": {
+      "imageLabel": {
+        "paddingTop": "xxs",
+        "fontSize": "xxxs",
+        "lineHeight": "sm"
+      }
     }
   },
   "layout": {


### PR DESCRIPTION
# Description

Uswitch theme modifications to allow using Image Modules v2 (with image caption) on Uswitch

https://www.notion.so/rvu/Image-captions-on-Uswitch-742019e4e1cc4eef91cf5ffc76c185bc

![imageModule](https://user-images.githubusercontent.com/78726823/132033055-22a04da4-a3f1-46bf-b460-1df5874bddf7.JPG)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
