### PR TITLE
feat: add postcode-secondary styles

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -5223,6 +5223,66 @@
             "padding": "base",
             "backgroundColor": "success-mint"
           }
+        },
+        "postcodeSecondary": {
+          "container": {
+            "mt": "md",
+            "mb": "xl",
+            "ml": 0,
+            "mr": 0,
+
+            "form": {
+              "mx": 0,
+              "ml": 0,
+              "maxWidth": ["100%", 555, 555],
+              "background": "white",
+
+              "> div": {
+                "boxShadow": "none",
+                "padding": 0
+              },
+
+              "input": {
+                "border": "1px solid",
+                "borderColor": "grey-40",
+                "mr": [0, "sm"],
+                "mb": ["sm", 0],
+                "py": "sm",
+                "pr": 20,
+                "pl": 48,
+                "height": 56,
+
+                "&:not(:placeholder-shown)": {
+                  "backgroundColor": "grey-05",
+                  "borderWidth": 2,
+                  "borderColor": "primary"
+                }
+              },
+
+              "svg": {
+                "fill": "primary",
+                "stroke": "primary",
+                "ml": [-5, 20],
+                "mt": [-5, 2]
+              },
+
+              "button": {
+                "border": "2px solid",
+                "borderColor": "primary",
+                "px": 42,
+                "margin": 0,
+                "justifyContent": "center",
+
+                ":hover": {
+                  "borderColor": "grey-70"
+                },
+
+                "svg": {
+                  "display": "none"
+                }
+              }
+            }
+          }
         }
       },
       "form": {


### PR DESCRIPTION
# Description

Adds styles for lead-capture-form "postcode-secondary" variant.
"postcode-secondary" variant is just styling over postcode-capture-form to be used on guide pages and where necessary.

## Desktop

![image](https://user-images.githubusercontent.com/55379739/132322170-d9adfcf7-5e0c-4751-bbfa-f60ef152a033.png)


## Mobile

![image](https://user-images.githubusercontent.com/55379739/132322294-42892aaa-86b3-417c-95d4-d6cf97fb1e54.png)


