### PR TITLE
fix: rich-text-module spacing

### DIFF
--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -1271,17 +1271,6 @@
         },
         "h3": {
           "fontSize": 28
-        },
-        ">div>span>*:first-of-type": {
-          "mt": 0
-        },
-        ">div>*:not(span)": {
-          "mt": 0
-        },
-        "h1,h2,h3,h4,h5,h6,p": {
-          "&:first-of-type": {
-            "mt": 0
-          }
         }
       },
       "variants": {
@@ -5979,6 +5968,15 @@
         "paddingTop": "xxs",
         "fontSize": "xxxs",
         "lineHeight": "sm"
+      }
+    },
+    "rich-text": {
+      "variants": {
+        "withSidebar": {
+          "> :first-child": {
+            "mt": 0
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
# Description

Fixes spacing issues for RichTextModule

## Before

![image](https://user-images.githubusercontent.com/55379739/134322955-e0603563-ca8d-4e52-8aac-9a5096afafa0.png)

## After

![image](https://user-images.githubusercontent.com/55379739/134323022-812aab47-86ec-44a4-9c20-2666d883d030.png)


Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
- [X] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
