### PR TITLE
fix: input alert spacing incorrect

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.64.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.64.1...@uswitch/trustyle.money-theme@1.64.2) (2021-09-27)
+
+
+### Bug Fixes
+
+* input alert spacing incorrect ([07e05fe](https://github.com/uswitch/trustyle/commit/07e05fe))
+
+
+
+
+
 ## [1.64.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.64.0...@uswitch/trustyle.money-theme@1.64.1) (2021-09-27)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.64.1",
+  "version": "1.64.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1081,7 +1081,7 @@
       "fontSize": "base",
       "lineHeight": 1.38,
       "color": "error",
-      "padding": 8,
+      "paddingY": 8,
       "position": "relative",
       "borderRadius": "sm",
       "notificationColor": "none",


### PR DESCRIPTION
# Description

FIx the spacing on input alert

![CleanShot 2021-09-27 at 15 37 57](https://user-images.githubusercontent.com/630034/134930253-5f84a95e-1a59-4b9d-aaf1-0c07b85abf05.png)


# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
