### PR TITLE
fix: do not close modal if dragging mouse into or out of content

### DIFF
--- a/src/compounds/phone-number-modal/CHANGELOG.md
+++ b/src/compounds/phone-number-modal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.9](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.phone-number-modal@0.1.8...@uswitch/trustyle.phone-number-modal@0.1.9) (2021-09-30)
+
+**Note:** Version bump only for package @uswitch/trustyle.phone-number-modal
+
+
+
+
+
 ## [0.1.8](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.phone-number-modal@0.1.7...@uswitch/trustyle.phone-number-modal@0.1.8) (2021-08-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.phone-number-modal

--- a/src/compounds/phone-number-modal/package.json
+++ b/src/compounds/phone-number-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.phone-number-modal",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -18,6 +18,6 @@
   "dependencies": {
     "@uswitch/trustyle.icon": "^1.27.2",
     "@uswitch/trustyle.imgix-image": "^0.1.42",
-    "@uswitch/trustyle.modal": "^2.4.21"
+    "@uswitch/trustyle.modal": "^2.4.22"
   }
 }

--- a/src/elements/modal/CHANGELOG.md
+++ b/src/elements/modal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.4.22](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.4.21...@uswitch/trustyle.modal@2.4.22) (2021-09-30)
+
+
+### Bug Fixes
+
+* do not close modal if dragging mouse into or out of content ([04245df](https://github.com/uswitch/trustyle/commit/04245df))
+
+
+
+
+
 ## [2.4.21](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.modal@2.4.20...@uswitch/trustyle.modal@2.4.21) (2021-08-27)
 
 

--- a/src/elements/modal/package.json
+++ b/src/elements/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.modal",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/modal/src/stories.tsx
+++ b/src/elements/modal/src/stories.tsx
@@ -8,7 +8,7 @@ import AllThemes from '../../../utils/all-themes'
 import Modal from './'
 
 export default {
-  title: 'Elements|Modal'
+  title: 'Elements/Modal'
 }
 
 export const PartialHeight = () => (

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.58.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.58.1...@uswitch/trustyle.uswitch-theme@2.58.2) (2021-09-30)
+
+**Note:** Version bump only for package @uswitch/trustyle.uswitch-theme
+
+
+
+
+
 ## [2.58.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.58.0...@uswitch/trustyle.uswitch-theme@2.58.1) (2021-09-29)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.58.1",
+  "version": "2.58.2",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
# Description

The modal currently closes if the user starts to 'click' inside of the modal, and drags their mouse outside. This is easy to do when the modal contains a text input that the user is trying to highlight.

Instead, we keep track of the mousedown and mouseup elements, and do not close if the drag started inside or finished inside of the modal content.

# Checklist

Pull request contains:

- [ ] A new component
- [X] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

~~- [ ] Includes theme changes for both Uswitch and money~~
- [X] Work has been tested in multiple browsers
- [X] PR description includes description of change
~~- [ ] PR description includes screenshot of change~~
~~- [ ] If new component, designer has approved screenshot~~
~~- [ ] If the change will affect other teams, that team knows about this change~~
~~- [ ] If introducing a new component behaviour, added a story to cover that case.~~
