### PR TITLE
fix: more information text does not render ul

### DIFF
--- a/src/compounds/information-panel/CHANGELOG.md
+++ b/src/compounds/information-panel/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.information-panel@0.1.1...@uswitch/trustyle.information-panel@0.1.2) (2021-10-05)
+
+
+### Bug Fixes
+
+* more information text does not render ul ([5e9b62e](https://github.com/uswitch/trustyle/commit/5e9b62e))
+
+
+
+
+
 ## [0.1.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.information-panel@0.1.0...@uswitch/trustyle.information-panel@0.1.1) (2021-08-27)
 
 **Note:** Version bump only for package @uswitch/trustyle.information-panel

--- a/src/compounds/information-panel/package.json
+++ b/src/compounds/information-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.information-panel",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/information-panel/src/index.tsx
+++ b/src/compounds/information-panel/src/index.tsx
@@ -17,6 +17,16 @@ export const MoreInformationText: React.FC<MoreInformationTextProps> = ({
         return
       }
 
+      if (chunk.includes('<ul>')) {
+        return (
+          <div
+            key={i}
+            sx={{ variant: 'compounds.information-panel.text' }}
+            dangerouslySetInnerHTML={{ __html: chunk }}
+          ></div>
+        )
+      }
+
       return (
         <React.Fragment key={i}>
           {chunk

--- a/src/compounds/information-panel/src/stories.tsx
+++ b/src/compounds/information-panel/src/stories.tsx
@@ -200,6 +200,14 @@ const infoText = (
   />
 )
 
+const infoTextWithList = (
+  <MoreInformationText
+    content={[
+      '<ul><li>Earn 0.25% cashback on the first £4,000 of purchases per calendar year. Earn 0.5% cashback on further purchases once you have made over £4,000 of purchases per calendar year</li><li>There is no limit to the amount of cashback you can earn in a year</li><li>Cashback will be paid automatically into the credit card account every January</li><li>New Customers : £20 cashback bonus on your balance, if you make £1,000 of purchases within 90 days of the account opening</li></ul>'
+    ]}
+  />
+)
+
 const eligibilityContent = (
   <MoreInformationBlock title="Eligibility" key="key-1">
     {list}
@@ -215,6 +223,12 @@ const ratesContent = (
 const textContent = (
   <MoreInformationBlock title="Repayment" key="key-3">
     {infoText}
+  </MoreInformationBlock>
+)
+
+const textContentWithBulletPoints = (
+  <MoreInformationBlock title="Repayment" key="key-3">
+    {infoTextWithList}
   </MoreInformationBlock>
 )
 
@@ -234,7 +248,7 @@ const moreInformationButton = (
   </ButtonLink>
 )
 
-const eligibity = (
+const eligibility = (
   <Eligibility
     moreInformationPanel={[eligibilityContent, ratesContent]}
     moreInformationLabel={moreInfoLabel}
@@ -242,7 +256,7 @@ const eligibity = (
   />
 )
 
-const eligibityWithText = (
+const eligibilityWithText = (
   <Eligibility
     moreInformationPanel={[eligibilityContent, textContent]}
     moreInformationLabel={moreInfoLabel}
@@ -250,15 +264,32 @@ const eligibityWithText = (
   />
 )
 
+const eligibilityWithBulletPoints = (
+  <Eligibility
+    moreInformationPanel={[textContentWithBulletPoints, textContent]}
+    moreInformationLabel={moreInfoLabel}
+  />
+)
+
 export const ExampleWithEligibility = () => (
-  <React.Fragment>{eligibity}</React.Fragment>
+  <React.Fragment>{eligibility}</React.Fragment>
 )
 
 export const ExampleWithText = () => (
-  <React.Fragment>{eligibityWithText}</React.Fragment>
+  <React.Fragment>{eligibilityWithText}</React.Fragment>
 )
 
 ExampleWithText.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
+export const ExampleWithBulletPoints = () => (
+  <React.Fragment>{eligibilityWithBulletPoints}</React.Fragment>
+)
+
+ExampleWithBulletPoints.story = {
   parameters: {
     percy: { skip: true }
   }
@@ -269,6 +300,7 @@ export const AutomatedTests = () => {
     <AllThemes>
       <ExampleWithEligibility />
       <ExampleWithText />
+      <ExampleWithBulletPoints />
     </AllThemes>
   )
 }

--- a/src/compounds/legacy-product-table/CHANGELOG.md
+++ b/src/compounds/legacy-product-table/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.7.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.7.6...@uswitch/trustyle.legacy-product-table@1.7.7) (2021-10-05)
+
+**Note:** Version bump only for package @uswitch/trustyle.legacy-product-table
+
+
+
+
+
 ## [1.7.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.legacy-product-table@1.7.3...@uswitch/trustyle.legacy-product-table@1.7.6) (2021-10-04)
 
 

--- a/src/compounds/legacy-product-table/package.json
+++ b/src/compounds/legacy-product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.legacy-product-table",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",
@@ -27,7 +27,7 @@
     "@uswitch/trustyle.button-link": "^3.2.11",
     "@uswitch/trustyle.circular-percentage-bar": "^0.1.4",
     "@uswitch/trustyle.icon": "^1.27.2",
-    "@uswitch/trustyle.information-panel": "^0.1.1",
+    "@uswitch/trustyle.information-panel": "^0.1.2",
     "@uswitch/trustyle.wireframe-cell": "^0.0.3"
   }
 }


### PR DESCRIPTION
# Description
Ticket: https://rvu.atlassian.net/browse/MONEY-376

Here is the two different types of more information text:

<img width="1558" alt="Screenshot 2021-10-05 at 15 11 58" src="https://user-images.githubusercontent.com/20357064/136042260-91dcbcf0-8a33-4a86-951b-4ab79142ca4a.png">

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
