### PR TITLE
fix: styling for fiels that are on one line

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.65.3](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.65.2...@uswitch/trustyle.money-theme@1.65.3) (2021-10-08)
+
+
+### Bug Fixes
+
+* styling for fiels that are on one line ([743f9ed](https://github.com/uswitch/trustyle/commit/743f9ed))
+
+
+
+
+
 ## [1.65.2](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.65.1...@uswitch/trustyle.money-theme@1.65.2) (2021-10-04)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.65.2",
+  "version": "1.65.3",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1717,6 +1717,29 @@
         "right": 16,
         "top": "calc(50% - 15px / 2)",
         "variant": "elements.drop-down.icon"
+      },
+      "singleRow": {
+        "select": {
+          "base": {
+            "variant": "elements.simple-drop-down.select.base",
+            "paddingX": 12
+          },
+          "error": {
+            "variant": "elements.simple-drop-down.select.error",
+            "paddingX": 12
+          },
+          "focus": {
+            "variant": "elements.simple-drop-down.select.focus",
+            "paddingX": 12
+          }
+        },
+        "span": {
+          "variant": "elements.simple-drop-down.span",
+          "top": "calc(50% - 12px / 2)",
+          "height": 12,
+          "width": 12,
+          "right": 12
+        }
       }
     },
     "form": {
@@ -1751,13 +1774,11 @@
                 "flex": ["1 0 100%", "1 0 100%"]
               }
             },
-
             "dropdown": {
               "wrapper": {
                 "variant": "elements.form.variants.field-section.input.wrapper"
               }
             },
-
             "wrapper": {
               "flex": ["1 0 100%", "1 0 25%"],
               "justifyContent": "space-between",
@@ -1877,6 +1898,9 @@
               ":last-child": {
                 "mb": 36
               }
+            },
+            "singleRow": {
+              "mb": [0, 56]
             },
             "error": {
               "color": "error",

--- a/src/themes/uswitch/CHANGELOG.md
+++ b/src/themes/uswitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.59.6](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.59.5...@uswitch/trustyle.uswitch-theme@2.59.6) (2021-10-08)
+
+
+### Bug Fixes
+
+* styling for fiels that are on one line ([743f9ed](https://github.com/uswitch/trustyle/commit/743f9ed))
+
+
+
+
+
 ## [2.59.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.uswitch-theme@2.59.4...@uswitch/trustyle.uswitch-theme@2.59.5) (2021-10-07)
 
 **Note:** Version bump only for package @uswitch/trustyle.uswitch-theme

--- a/src/themes/uswitch/package.json
+++ b/src/themes/uswitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.uswitch-theme",
-  "version": "2.59.5",
+  "version": "2.59.6",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -870,6 +870,10 @@
                 "pb": ["xs", 0]
               }
             },
+            "singleRow": {
+              "variant": "elements.form.variants.default.input.wrapper",
+              "mb": 0
+            },
             "error": {
               "position": "absolute",
               "margin": "0"
@@ -1266,13 +1270,11 @@
                 "flex": ["1 0 100%", "1 0 100%"]
               }
             },
-
             "dropdown": {
               "wrapper": {
                 "variant": "elements.form.variants.slide.input.wrapper"
               }
             },
-
             "wrapper": {
               "flex": ["1 0 100%", "1 0 25%"],
               "justifyContent": "space-between",
@@ -3162,6 +3164,29 @@
         "right": 16,
         "top": "calc(50% - 15px / 2)",
         "variant": "elements.drop-down.icon"
+      },
+      "singleRow": {
+        "select": {
+          "base": {
+            "variant": "elements.simple-drop-down.select.base",
+            "paddingX": 12
+          },
+          "error": {
+            "variant": "elements.simple-drop-down.select.error",
+            "paddingX": 12
+          },
+          "focus": {
+            "variant": "elements.simple-drop-down.select.focus",
+            "paddingX": 12
+          }
+        },
+        "span": {
+          "variant": "elements.simple-drop-down.span",
+          "top": "calc(50% - 12px / 2)",
+          "height": 12,
+          "width": 12,
+          "right": 12
+        }
       }
     },
     "form-section": {


### PR DESCRIPTION
# Description

Ticket: https://rvu.atlassian.net/browse/MONEY-369
Related pr: https://github.com/uswitch/recharge-eevee/pull/1081

<img width="457" alt="Screenshot 2021-10-07 at 16 30 18" src="https://user-images.githubusercontent.com/20357064/136426803-52d722d4-5e3c-4abd-a086-c77fd4025c4c.png">

<img width="457" alt="Screenshot 2021-10-07 at 16 29 51" src="https://user-images.githubusercontent.com/20357064/136426845-bc18effe-3213-48e1-95c2-48107c0b3eff.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
