### PR TITLE
fix: removed billboard variant prop. added theme variant that defines…

### DIFF
--- a/src/compounds/billboard/src/index.tsx
+++ b/src/compounds/billboard/src/index.tsx
@@ -10,7 +10,6 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   primarySlot?: React.ReactElement
   fullWidthSlot?: React.ReactElement
   bgImage?: string
-  verticalAlign?: string
 }
 
 const Billboard: React.FC<Props> = ({
@@ -18,8 +17,7 @@ const Billboard: React.FC<Props> = ({
   primaryContent,
   primarySlot,
   fullWidthSlot,
-  bgImage,
-  verticalAlign = 'bottom'
+  bgImage
 }) => {
   const styles = () => {
     if (primarySlot) {
@@ -122,7 +120,8 @@ const Billboard: React.FC<Props> = ({
                     width: '404px',
                     height: '416px',
                     display: ['none', 'none', 'block'],
-                    background: `url(${bgImage}) no-repeat right ${verticalAlign.toLowerCase()} / contain`
+                    background: `url(${bgImage}) no-repeat right bottom / contain`,
+                    variant: 'compounds.billboard.bgImagePosition'
                   }}
                 ></div>
               )}

--- a/src/compounds/billboard/src/stories.tsx
+++ b/src/compounds/billboard/src/stories.tsx
@@ -201,7 +201,6 @@ export const ExampleWithBgImage = () => {
       breadcrumbs={breadcrumbs}
       primaryContent={primaryContent}
       bgImage={bgImage}
-      verticalAlign={'bottom'}
     />
   )
 }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -2586,6 +2586,9 @@
       },
       "fullWidthSlot": {
         "mb": "lg"
+      },
+      "bgImagePosition": {
+        "backgroundPosition": "right center"
       }
     },
     "phone-number-modal": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2618,6 +2618,9 @@
         "width": ["100%", "70%", "100%"],
         "marginX": ["0", "auto", "0"],
         "mb": ["md", "lg"]
+      },
+      "bgImagePosition": {
+        "backgroundPosition": "right bottom"
       }
     },
     "navigation-dropdown": {


### PR DESCRIPTION
# Description

removed billboard variant prop from contentful. added theme variant that defines background-position for both money and uswitch

[link to jira](https://rvu.atlassian.net/jira/software/c/projects/MONEY/boards/80?modal=detail&selectedIssue=MONEY-681&quickFilter=148)

In both themes now exists billboard variant named `billboard.bgImagePosition`.

reverting from [this](https://github.com/uswitch/fs-core/pull/1049) change

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
