### PR TITLE
feat: add styling for money consent capture

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.70.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.69.0...@uswitch/trustyle.money-theme@1.70.0) (2021-11-25)
+
+
+### Features
+
+* add styling for money consent capture ([5e9f8bc](https://github.com/uswitch/trustyle/commit/5e9f8bc))
+
+
+
+
+
 # [1.69.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.68.2...@uswitch/trustyle.money-theme@1.69.0) (2021-11-10)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1011,6 +1011,24 @@
           }
         }
       },
+      "consent": {
+        "wrapper": {
+          "bg": "grey-10",
+          "&:hover": {
+            "bg": "white"
+          }
+        },
+        "question": {
+          "color": "grey-80",
+          "fontWeight": "bold",
+          "pt": "sm",
+          "ml": "sm",
+          "textAlign": "left !important"
+        },
+        "text": {
+          "textAlign": "left !important"
+        }
+      },
       "checkbox": {
         "base": {
           "variant": "elements.input.radioish.base",


### PR DESCRIPTION
# Description

This is styling for the Credit Cards Result email sprint, figma here: https://www.figma.com/file/e3hYU0JEKGT9PvfzNGVrD2/Credit-Card-Results-Email?node-id=133%3A728

<img width="730" alt="Screenshot 2021-11-25 at 14 50 23" src="https://user-images.githubusercontent.com/350343/143462448-961e6dd3-68fd-4463-9d19-b19beaa2dc91.png">

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
