### PR TITLE
Consent question bg checked easy fix

### DIFF
--- a/src/themes/money/CHANGELOG.md
+++ b/src/themes/money/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.70.1](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.70.0...@uswitch/trustyle.money-theme@1.70.1) (2021-11-26)
+
+
+### Bug Fixes
+
+* remove background from wrapper for consent checkbox ([b046a46](https://github.com/uswitch/trustyle/commit/b046a46))
+* stop spark checkbox from changing styling ([e54f5ca](https://github.com/uswitch/trustyle/commit/e54f5ca))
+
+
+
+
+
 # [1.70.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.money-theme@1.69.0...@uswitch/trustyle.money-theme@1.70.0) (2021-11-25)
 
 

--- a/src/themes/money/package.json
+++ b/src/themes/money/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.money-theme",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1012,6 +1012,13 @@
         }
       },
       "consent": {
+        "wrapper": {
+          "bg": "grey-10",
+          "label:focus-visible": {
+            "outline-color": "transparent !important",
+            "outline-width": "0px"
+          }
+        },
         "question": {
           "color": "grey-80",
           "fontWeight": "bold",
@@ -1046,8 +1053,9 @@
         },
         "variants": {
           "consent": {
-            "bg": "transparent",
-            "border": "none"
+            "bg": "transparent !important",
+            "border": "none !important",
+            "box-shadow": "none !important"
           },
           "normal": {
             "variant": "elements.input.checkbox.base"

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1012,12 +1012,6 @@
         }
       },
       "consent": {
-        "wrapper": {
-          "bg": "grey-10",
-          "&:hover": {
-            "bg": "white"
-          }
-        },
         "question": {
           "color": "grey-80",
           "fontWeight": "bold",


### PR DESCRIPTION
# Description

So that it will not change style during 

checked: 
<img width="456" alt="Screenshot 2021-11-26 at 15 29 35" src="https://user-images.githubusercontent.com/350343/143603194-ad92f62f-b10d-47fe-b430-58e53aa68e73.png">

focus + hover 

<img width="505" alt="Screenshot 2021-11-26 at 15 38 11" src="https://user-images.githubusercontent.com/350343/143604133-9fc39da0-0e51-4646-9259-a09c76bab1c6.png">



# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
