### PR TITLE
feat: adds formatter for pounds with commas

### DIFF
--- a/src/compounds/product-table/CHANGELOG.md
+++ b/src/compounds/product-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.18.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.17.7...@uswitch/trustyle.product-table@2.18.0) (2021-11-30)
+
+
+### Features
+
+* adds formatter for pounds with commas ([6e3b6ab](https://github.com/uswitch/trustyle/commit/6e3b6ab))
+
+
+
+
+
 ## [2.17.7](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.product-table@2.17.6...@uswitch/trustyle.product-table@2.17.7) (2021-11-23)
 
 **Note:** Version bump only for package @uswitch/trustyle.product-table

--- a/src/compounds/product-table/package.json
+++ b/src/compounds/product-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.product-table",
-  "version": "2.17.7",
+  "version": "2.18.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/product-table/src/generics.ts
+++ b/src/compounds/product-table/src/generics.ts
@@ -57,6 +57,11 @@ const formatters: {
   // Alternative version of the pounds formatter that takes care of adding 0 as needed
   'full-pounds': value => `£${value.toFixed(2)}`,
 
+  'pounds-with-commas': value =>
+    Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(
+      value
+    ),
+
   percent: value => `${value}%`,
 
   /**


### PR DESCRIPTION
# Description

Adds formatter for adding commas to pound values, eg. £100,000

# Checklist

Pull request contains:

- [ ] A new component
- [ ] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
