### PR TITLE
billboard component image position and image mobile options

### DIFF
--- a/src/compounds/billboard/CHANGELOG.md
+++ b/src/compounds/billboard/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.12](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.billboard@0.2.11...@uswitch/trustyle.billboard@0.2.12) (2021-12-01)
+
+**Note:** Version bump only for package @uswitch/trustyle.billboard
+
+
+
+
+
 ## [0.2.11](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.billboard@0.2.10...@uswitch/trustyle.billboard@0.2.11) (2021-11-05)
 
 **Note:** Version bump only for package @uswitch/trustyle.billboard

--- a/src/compounds/billboard/package.json
+++ b/src/compounds/billboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.billboard",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/billboard/src/index.tsx
+++ b/src/compounds/billboard/src/index.tsx
@@ -129,9 +129,10 @@ const Billboard: React.FC<Props> = ({
                       'block'
                     ],
                     background: `url(${bgImage}) no-repeat ${imagePosition} / contain`,
-                    variant: !imagePosition
-                      ? 'compounds.billboard.bgImagePosition'
-                      : ''
+                    variant:
+                      imagePosition === undefined
+                        ? 'compounds.billboard.bgImagePosition'
+                        : ''
                   }}
                 ></div>
               )}

--- a/src/compounds/billboard/src/index.tsx
+++ b/src/compounds/billboard/src/index.tsx
@@ -10,6 +10,8 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   primarySlot?: React.ReactElement
   fullWidthSlot?: React.ReactElement
   bgImage?: string
+  showImageOnMobile?: boolean
+  imagePosition?: string
 }
 
 const Billboard: React.FC<Props> = ({
@@ -17,7 +19,9 @@ const Billboard: React.FC<Props> = ({
   primaryContent,
   primarySlot,
   fullWidthSlot,
-  bgImage
+  bgImage,
+  showImageOnMobile = false,
+  imagePosition = 'right bottom'
 }) => {
   const styles = () => {
     if (primarySlot) {
@@ -112,15 +116,22 @@ const Billboard: React.FC<Props> = ({
                   {React.cloneElement(primarySlot, { variant: 'billboard' })}
                 </div>
               )}
-
               {!primarySlot && bgImage && (
                 <div
                   sx={{
-                    width: '404px',
-                    height: '416px',
-                    display: ['none', 'none', 'block'],
-                    background: `url(${bgImage}) no-repeat right bottom / contain`,
-                    variant: 'compounds.billboard.bgImagePosition'
+                    width: ['90%', '404px', '404px'],
+                    height: ['0', '255px', '416px'],
+                    margin: ['30px auto 0', '30px auto 0', '0'],
+                    paddingTop: ['60%', '0', '0'],
+                    display: [
+                      showImageOnMobile ? 'block' : 'none',
+                      showImageOnMobile ? 'block' : 'none',
+                      'block'
+                    ],
+                    background: `url(${bgImage}) no-repeat ${imagePosition} / contain`,
+                    variant: !imagePosition
+                      ? 'compounds.billboard.bgImagePosition'
+                      : ''
                   }}
                 ></div>
               )}

--- a/src/compounds/billboard/src/index.tsx
+++ b/src/compounds/billboard/src/index.tsx
@@ -21,7 +21,7 @@ const Billboard: React.FC<Props> = ({
   fullWidthSlot,
   bgImage,
   showImageOnMobile = false,
-  imagePosition = 'right bottom'
+  imagePosition
 }) => {
   const styles = () => {
     if (primarySlot) {
@@ -128,7 +128,10 @@ const Billboard: React.FC<Props> = ({
                       showImageOnMobile ? 'block' : 'none',
                       'block'
                     ],
-                    background: `url(${bgImage}) no-repeat ${imagePosition} / contain`,
+                    backgroundImage: `url(${bgImage})`,
+                    backgroundRepeat: 'no-repeat',
+                    backgroundSize: 'contain',
+                    backgroundPosition: imagePosition || 'right bottom',
                     variant:
                       imagePosition === undefined
                         ? 'compounds.billboard.bgImagePosition'

--- a/src/compounds/billboard/src/stories.tsx
+++ b/src/compounds/billboard/src/stories.tsx
@@ -10,6 +10,7 @@ import AllThemes from '../../../utils/all-themes'
 import IconTile, { DisplayVariant } from '../../../elements/icon-tile/src'
 import { Col, Row } from '../../../layout/flex-grid/src'
 import CTA from '../../../elements/cta/src'
+import { ButtonLink } from '../../../elements/button-link/src'
 
 import Billboard from './'
 
@@ -211,6 +212,39 @@ ExampleWithBgImage.story = {
   }
 }
 
+const primaryPromoContent = (
+  <div>
+    <h3>Compare 10 year fixed rate mortgages</h3>
+    <p>
+      You could find a low fixed rate mortgage deal that offers you peace of
+      mind by fixing your repayments for 10 years.
+    </p>
+    <ButtonLink variant={'primary'} href="https://www.uswitch.com">
+      See more
+    </ButtonLink>
+  </div>
+)
+
+export const ExamplePromoBanner = () => {
+  return (
+    <Billboard
+      breadcrumbs={breadcrumbs}
+      primaryContent={primaryPromoContent}
+      bgImage={
+        'https://money.imgix.net/uswitch-assets-eu/amp/images/product/credit-cards/barclaycard_platinum_2021.png'
+      }
+      showImageOnMobile
+      imagePosition={'center center'}
+    />
+  )
+}
+
+ExamplePromoBanner.story = {
+  parameters: {
+    percy: { skip: true }
+  }
+}
+
 export const AutomatedTests = () => {
   return (
     <AllThemes>
@@ -220,6 +254,7 @@ export const AutomatedTests = () => {
       <ExampleWithoutPrimarySlot />
       <ExampleWithPalette />
       <ExampleWithBgImage />
+      <ExamplePromoBanner />
     </AllThemes>
   )
 }


### PR DESCRIPTION
# Description
Added variables to be able to control the image positioning and display on mobile.

Related to PR: https://github.com/uswitch/contentful-components/pull/512
Related to ticket: https://rvu.atlassian.net/browse/MONEY-839

<!-- Explain the purpose of this Pull Request. -->
Desktop:
![image](https://user-images.githubusercontent.com/12720094/144230656-50f3757a-9b4b-4b5c-a282-a0ed10c40c1a.png)

Mobile:
![image](https://user-images.githubusercontent.com/12720094/144230778-fc773a6f-38b6-45cf-8838-37fbd04359d5.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [x] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [x] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
