### PR TITLE
fix: link blocks having fixed widths, resulting in overlap

### DIFF
--- a/src/elements/link-list/src/index.tsx
+++ b/src/elements/link-list/src/index.tsx
@@ -67,9 +67,7 @@ export const LinkList: React.FC<ListLinkProps> = ({
               {title &&
                 (variant === 'linkBlock' ? (
                   // @ts-ignore - ts does not seem to recognize "as" when in object form
-                  <Themed.h6 {...titleProps}>
-                    <strong>{title}</strong>
-                  </Themed.h6>
+                  <Themed.h6 {...titleProps}>{title}</Themed.h6>
                 ) : (
                   // @ts-ignore
                   <Themed.h3 {...titleProps}>{title}</Themed.h3>

--- a/src/elements/link-list/src/index.tsx
+++ b/src/elements/link-list/src/index.tsx
@@ -32,6 +32,16 @@ export const LinkList: React.FC<ListLinkProps> = ({
   const IconComponent =
     typeof icon === 'string' ? <Icon glyph={icon as Glyph} color="" /> : icon
 
+  const titleProps = {
+    as: 'h2',
+    sx: {
+      paddingTop: 'xs',
+      paddingBottom: 'xs',
+      margin: 0,
+      variant: styles(variant, 'h3')
+    }
+  }
+
   return (
     <VariantContext.Provider value={variant}>
       <div className={className} sx={{ variant: styles(variant) }}>
@@ -54,19 +64,16 @@ export const LinkList: React.FC<ListLinkProps> = ({
                 </div>
               )}
               {variant !== 'linkBlock' && IconComponent}
-              {title && (
-                <Themed.h3
-                  as="h2"
-                  sx={{
-                    paddingTop: 'xs',
-                    paddingBottom: 'xs',
-                    margin: 0,
-                    variant: styles(variant, 'h3')
-                  }}
-                >
-                  {title}
-                </Themed.h3>
-              )}
+              {title &&
+                (variant === 'linkBlock' ? (
+                  // @ts-ignore - ts does not seem to recognize "as" when in object form
+                  <Themed.h6 {...titleProps}>
+                    <strong>{title}</strong>
+                  </Themed.h6>
+                ) : (
+                  // @ts-ignore
+                  <Themed.h3 {...titleProps}>{title}</Themed.h3>
+                ))}
             </header>
             {subtitle && subtitleUrl && (
               <LinkListItem href={subtitleUrl}>

--- a/src/elements/link-list/src/stories.tsx
+++ b/src/elements/link-list/src/stories.tsx
@@ -115,6 +115,71 @@ export const LinkBlock = () => {
   )
 }
 
+export const LinkBlockGroup = () => {
+  const LinkListWrapper = () => (
+    <div
+      css={css({
+        boxSizing: 'border-box',
+        marginRight: '7.5px',
+        marginBottom: '24px',
+        flex: '0 0 auto',
+        marginLeft: '7.5px',
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'flex-start',
+        width: 'calc(25% - 15px)'
+      })}
+    >
+      <LinkList
+        title="Credit Cards"
+        icon={<Icon glyph="travel-money" color="000" />}
+        variant="linkBlock"
+        subtitle="Compare all cards"
+        subtitleUrl="https://money.co.uk"
+      >
+        <LinkListItem href="https://money.co.uk">
+          0% balance transfer
+        </LinkListItem>
+        <LinkListItem href="https://money.co.uk">
+          0% purchase cards
+        </LinkListItem>
+        <LinkListItem href="https://money.co.uk">
+          Cards for bad credit
+        </LinkListItem>
+      </LinkList>
+    </div>
+  )
+
+  return (
+    <div
+      css={css({
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        boxSizing: 'border-box',
+        paddingLeft: '15px',
+        paddingRight: '15px',
+        maxWidth: '1200px',
+        display: 'flex',
+        flexDirection: 'column'
+      })}
+    >
+      <div
+        css={css({
+          marginLeft: '-7.5px',
+          marginRight: '-7.5px',
+          display: 'flex',
+          flexFlow: 'row wrap'
+        })}
+      >
+        <LinkListWrapper />
+        <LinkListWrapper />
+        <LinkListWrapper />
+        <LinkListWrapper />
+      </div>
+    </div>
+  )
+}
+
 LinkBlock.story = {
   parameters: {
     percy: { skip: true }
@@ -127,6 +192,7 @@ export const AutomatedTests = () => {
       <PrimaryVariant />
       <QuickLinks />
       <LinkBlock />
+      <LinkBlockGroup />
     </AllThemes>
   )
 }

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1618,6 +1618,7 @@
           "boxSizing": "border-box",
           "display": "inline-block",
           "padding": "md",
+          "paddingBottom": "6px",
           "maxWidth": ["220px", "296px", "296px"],
           "width": "100%",
           "header": {
@@ -1625,14 +1626,22 @@
             "alignItems": "start"
           },
           "h3": {
-            "color": "text"
+            "color": "text",
+            "fontSize": "sm"
           },
           "a": {
             "marginBottom": 0,
             "textDecoration": "underline"
           },
           "li": {
-            "borderTop": "none"
+            ":first-of-type": {
+              "marginTop": "4px"
+            },
+            "borderTop": "none",
+            "paddingTop": "0px",
+            "paddingBottom": "0px",
+            "marginTop": "12px",
+            "marginBottom": "12px"
           },
           "icon": {
             "backgroundColor": "transparent",

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1627,7 +1627,7 @@
           },
           "h3": {
             "color": "text",
-            "fontSize": "sm"
+            "fontSize": "md"
           },
           "a": {
             "marginBottom": 0,

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1626,7 +1626,8 @@
           },
           "h3": {
             "color": "text",
-            "fontSize": "md"
+            "fontSize": "md",
+            "fontWeight": "xbold"
           },
           "a": {
             "marginBottom": 0,

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1618,7 +1618,8 @@
           "boxSizing": "border-box",
           "display": "inline-block",
           "padding": "md",
-          "width": ["220px", "296px", "296px"],
+          "maxWidth": ["220px", "296px", "296px"],
+          "width": "100%",
           "header": {
             "flexDirection": "column",
             "alignItems": "start"

--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1619,7 +1619,6 @@
           "display": "inline-block",
           "padding": "md",
           "paddingBottom": "6px",
-          "maxWidth": ["220px", "296px", "296px"],
           "width": "100%",
           "header": {
             "flexDirection": "column",
@@ -1638,10 +1637,8 @@
               "marginTop": "4px"
             },
             "borderTop": "none",
-            "paddingTop": "0px",
-            "paddingBottom": "0px",
-            "marginTop": "12px",
-            "marginBottom": "12px"
+            "paddingY": "0px",
+            "marginY": "12px"
           },
           "icon": {
             "backgroundColor": "transparent",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2385,7 +2385,8 @@
         },
         "linkBlock": {
           "boxShadow": "0px 0px 8px rgba(0, 0, 0, 0.45)",
-          "width": ["220px", "296px", "296px"],
+          "maxWidth": ["220px", "296px", "296px"],
+          "width": "100%",
           "display": "inline-block",
           "padding": "md",
           "header": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2385,7 +2385,6 @@
         },
         "linkBlock": {
           "boxShadow": "0px 0px 8px rgba(0, 0, 0, 0.45)",
-          "maxWidth": ["220px", "296px", "296px"],
           "width": "100%",
           "display": "inline-block",
           "padding": "md",
@@ -2409,8 +2408,7 @@
             "borderTop": "none",
             "paddingTop": "0px",
             "paddingBottom": "0px",
-            "marginTop": "12px",
-            "marginBottom": "12px"
+            "marginY": "12px"
           },
           "icon": {
             "backgroundColor": "transparent",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2391,7 +2391,8 @@
           "paddingBottom": "6px",
           "h3": {
             "color": "primary",
-            "fontSize": "sm"
+            "fontSize": "sm",
+            "fontWeight": "xbold"
           },
           "header": {
             "flexDirection": "column",

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2406,8 +2406,7 @@
               "marginTop": "4px"
             },
             "borderTop": "none",
-            "paddingTop": "0px",
-            "paddingBottom": "0px",
+            "paddingY": "0px",
             "marginY": "12px"
           },
           "icon": {

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2389,6 +2389,11 @@
           "width": "100%",
           "display": "inline-block",
           "padding": "md",
+          "paddingBottom": "6px",
+          "h3": {
+            "color": "primary",
+            "fontSize": "sm"
+          },
           "header": {
             "flexDirection": "column",
             "alignItems": "start"
@@ -2398,7 +2403,14 @@
             "textDecoration": "underline"
           },
           "li": {
-            "borderTop": "none"
+            ":first-of-type": {
+              "marginTop": "4px"
+            },
+            "borderTop": "none",
+            "paddingTop": "0px",
+            "paddingBottom": "0px",
+            "marginTop": "12px",
+            "marginBottom": "12px"
           },
           "icon": {
             "backgroundColor": "transparent",


### PR DESCRIPTION
# Description

Link block variant for link-list had responsive fixed width; this caused issues when multiple link blocks were displayed next to each other, and did not fit their container width-wise. This PR makes them take up 100% of the container.

### uswitch
![Screenshot from 2021-12-09 17-50-38](https://user-images.githubusercontent.com/453033/145449634-1a8205fb-bb61-4ac2-84fc-61cbdf610d13.png)

### money
![Screenshot from 2021-12-09 17-55-28](https://user-images.githubusercontent.com/453033/145450165-77f1afc0-d22f-463a-bc6c-58ef3a968bbc.png)

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [x] If introducing a new component behaviour, added a story to cover that case.
