### PR TITLE
feat: added trim color to be white

### DIFF
--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.8.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.7.5...@uswitch/trustyle.sponsored-product@3.8.0) (2021-12-13)
+
+
+### Features
+
+* added trim color to be white ([07cccfb](https://github.com/uswitch/trustyle/commit/07cccfb))
+
+
+
+
+
 ## [3.7.5](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.7.4...@uswitch/trustyle.sponsored-product@3.7.5) (2021-12-13)
 
 **Note:** Version bump only for package @uswitch/trustyle.sponsored-product

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.10.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.9.0...@uswitch/trustyle.sponsored-product@3.10.0) (2021-12-13)
+
+
+### Features
+
+* bumped other deps ([6ad178d](https://github.com/uswitch/trustyle/commit/6ad178d))
+
+
+
+
+
 # [3.9.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.7.5...@uswitch/trustyle.sponsored-product@3.9.0) (2021-12-13)
 
 

--- a/src/compounds/sponsored-product/CHANGELOG.md
+++ b/src/compounds/sponsored-product/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.9.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.7.5...@uswitch/trustyle.sponsored-product@3.9.0) (2021-12-13)
+
+
+### Features
+
+* added trim color to be white ([07cccfb](https://github.com/uswitch/trustyle/commit/07cccfb))
+
+
+
+
+
 # [3.8.0](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.sponsored-product@3.7.5...@uswitch/trustyle.sponsored-product@3.8.0) (2021-12-13)
 
 

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@uswitch/trustyle.arrangement": "^2.0.22",
     "@uswitch/trustyle.badge": "^2.0.6",
-    "@uswitch/trustyle.button-link": "^3.3.1",
+    "@uswitch/trustyle.button-link": "^3.3.2",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.17",
     "@uswitch/trustyle.imgix-image": "^0.1.42",
@@ -28,6 +28,6 @@
     "@uswitch/trustyle.usp-broadband": "^0.2.1"
   },
   "devDependencies": {
-    "@uswitch/trustyle.icon": "^1.28.0"
+    "@uswitch/trustyle.icon": "^1.29.0"
   }
 }

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@uswitch/trustyle.arrangement": "^2.0.22",
     "@uswitch/trustyle.badge": "^2.0.6",
-    "@uswitch/trustyle.button-link": "^3.3.2",
+    "@uswitch/trustyle.button-link": "^3.3.1",
     "@uswitch/trustyle.flex-grid": "^0.2.1",
     "@uswitch/trustyle.grid": "^2.0.17",
     "@uswitch/trustyle.imgix-image": "^0.1.42",
@@ -28,6 +28,6 @@
     "@uswitch/trustyle.usp-broadband": "^0.2.1"
   },
   "devDependencies": {
-    "@uswitch/trustyle.icon": "^1.29.0"
+    "@uswitch/trustyle.icon": "^1.28.0"
   }
 }

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product/package.json
+++ b/src/compounds/sponsored-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.sponsored-product",
-  "version": "3.7.5",
+  "version": "3.8.0",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/compounds/sponsored-product/src/index.tsx
+++ b/src/compounds/sponsored-product/src/index.tsx
@@ -239,7 +239,11 @@ const SponsoredProduct: React.FC<Props> = ({
             <ImgixImage
               src={sponsorSrc}
               alt={sponsorName}
-              imgixParams={{ fit: 'clip', trim: 'color' }}
+              imgixParams={{
+                fit: 'clip',
+                trim: 'color',
+                'trim-color': 'white'
+              }}
               width={imgSrc ? 44 : 120}
               height={imgSrc ? 88 : 73}
               critical


### PR DESCRIPTION
# Description

Setting the trim color to be white, rather than the default top left pixel

This was set to black when handling the john lewis broadband logo, so it trimmed all of the black text

![image](https://user-images.githubusercontent.com/4699057/145803546-16f03d60-c948-44fe-9977-d8ee8beeea0e.png)


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [x] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
