### PR TITLE
fix(link-list/linkBlock): specify explicit font size and weight

### DIFF
--- a/src/themes/money/theme.json
+++ b/src/themes/money/theme.json
@@ -1626,8 +1626,8 @@
           },
           "h3": {
             "color": "text",
-            "fontSize": "md",
-            "fontWeight": "xbold"
+            "fontSize": ["18px", "18px", "18px"],
+            "fontWeight": ["600", "600", "600"]
           },
           "a": {
             "marginBottom": 0,

--- a/src/themes/uswitch/theme.json
+++ b/src/themes/uswitch/theme.json
@@ -2393,8 +2393,8 @@
           "paddingBottom": "6px",
           "h3": {
             "color": "primary",
-            "fontSize": "sm",
-            "fontWeight": "xbold"
+            "fontSize": ["18px", "18px", "18px"],
+            "fontWeight": ["600", "600", "600"]
           },
           "header": {
             "flexDirection": "column",


### PR DESCRIPTION
# Description

If size and weight are specified as a single value, they will apply only to the mobile view - and on larger sizes will be overridden. This issue is not observable when running storybook locally, but can be seen when the component is rendered in the context of `fs-core`:

![Screenshot from 2021-12-14 15-47-15](https://user-images.githubusercontent.com/453033/146037333-babe2552-e5d8-44c5-94a7-9aafbcfaa352.png)

After applying changes in this PR:

![Screenshot from 2021-12-14 16-20-42](https://user-images.githubusercontent.com/453033/146037571-f4d81c01-7828-4090-a89d-4d16b545803f.png)


# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [x] Includes theme changes for both Uswitch and money
- [x] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [x] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
