### PR TITLE
fix: update author name to use h1 instead of h2

### DIFF
--- a/src/elements/author-profile/CHANGELOG.md
+++ b/src/elements/author-profile/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.16](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.author-profile@1.3.15...@uswitch/trustyle.author-profile@1.3.16) (2022-02-16)
+
+
+### Bug Fixes
+
+* update author name to use h1 instead of h2 ([47ecbaf](https://github.com/uswitch/trustyle/commit/47ecbaf4dc17bd264f6fc100bc01a7fea3b43804))
+
+
+
+
+
 ## [1.3.15](https://github.com/uswitch/trustyle/compare/@uswitch/trustyle.author-profile@1.3.14...@uswitch/trustyle.author-profile@1.3.15) (2021-12-17)
 
 **Note:** Version bump only for package @uswitch/trustyle.author-profile

--- a/src/elements/author-profile/package.json
+++ b/src/elements/author-profile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/trustyle.author-profile",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "license": "MIT",
   "main": "lib/index.js",
   "ts:main": "src/index.tsx",

--- a/src/elements/author-profile/src/index.tsx
+++ b/src/elements/author-profile/src/index.tsx
@@ -160,7 +160,7 @@ const AuthorProfile: React.FC<Props> = ({
           variant: styles('content')
         }}
       >
-        <Themed.h2
+        <Themed.h1
           sx={{
             marginTop: 0,
             marginBottom: 'xxs',
@@ -168,7 +168,7 @@ const AuthorProfile: React.FC<Props> = ({
             paddingBottom: 0,
             variant: styles('name')
           }}
-          as="h2"
+          as="h1"
         >
           <a
             href={authorUrl}
@@ -180,7 +180,7 @@ const AuthorProfile: React.FC<Props> = ({
             <span>{name}</span>
             <span sx={{ variant: styles('role') }}>{role}</span>
           </a>
-        </Themed.h2>
+        </Themed.h1>
         <BioElement
           sx={{
             fontSize: 'sm',


### PR DESCRIPTION
# Description

Update Author Name and Role to h1 instead of h2 on all Author Pages https://rvu.atlassian.net/browse/MONEY-1970

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [ ] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
