### PR TITLE
Migrate to Uswitch images CDN img.uswitch.com

### DIFF
--- a/src/compounds/ad-banner/src/stories.tsx
+++ b/src/compounds/ad-banner/src/stories.tsx
@@ -19,7 +19,7 @@ export const ExampleWithKnobs = () => {
   )
 
   const url =
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/3OTEiajt8kWEUm8QcWI8w8/aab828afa135b4591375dc71d6a6584d/Logo_-_samsung.png?auto=compress&trim=color&invert=true&sat=-100&con=100'
+    'https://img.uswitch.com/kf81nsuntxeb/3OTEiajt8kWEUm8QcWI8w8/aab828afa135b4591375dc71d6a6584d/Logo_-_samsung.png?auto=compress&trim=color&invert=true&sat=-100&con=100'
 
   const usp = text('usp', 'Free Galaxy Buds+ worth £159')
   const sponsorLogo = text('Sponsor Logo', url)

--- a/src/compounds/sponsored-product/src/stories.tsx
+++ b/src/compounds/sponsored-product/src/stories.tsx
@@ -25,7 +25,7 @@ export const ExampleWithKnobs = () => {
   const sponsorName = text('Sponsor name', 'Three')
   const sponsorSrc = text(
     'Sponsor url',
-    'https://uswitch-mobiles-contentful.imgix.net/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
+    'https://img.uswitch.com/kf81nsuntxeb/5eyE4LyswwqIYk0mIsE820/dc0774e3e62d7b39ddeb1729d823a8da/Logo_-_three.png'
   )
   const award = text('Award', 'Uswitch Manufacturer of the Year')
   const enhanced = text(

--- a/src/elements/accordion/src/stories.tsx
+++ b/src/elements/accordion/src/stories.tsx
@@ -178,15 +178,15 @@ export const AccordionGroupWithTitleIcons = () => {
   const content = text('First content', 'This is some example content')
   const icon = text(
     'icon url',
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/6zc6CVHzsVn3xs0N8loxl9/763a957760ec5b183cf4f5a05fa9e4ae/Banking.svg'
+    'https://img.uswitch.com/t014ej9w3ur1/6zc6CVHzsVn3xs0N8loxl9/763a957760ec5b183cf4f5a05fa9e4ae/Banking.svg'
   )
 
   const mortgagesIcon =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/5pFgZgswDdVCcPXyXB83Iq/aab9f93ca6b1940186b548c443fb7026/mortgages.svg'
+    'https://img.uswitch.com/t014ej9w3ur1/5pFgZgswDdVCcPXyXB83Iq/aab9f93ca6b1940186b548c443fb7026/mortgages.svg'
   const motoringIcon =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/1aMIa9HTc8Lj61Jux1WTfc/a695decb14508cfe239e53e45ad3ddc3/Group_137.svg'
+    'https://img.uswitch.com/t014ej9w3ur1/1aMIa9HTc8Lj61Jux1WTfc/a695decb14508cfe239e53e45ad3ddc3/Group_137.svg'
   const travelIcon =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/1Ruz9BZ8aLaThxgyjUO1QL/3d19715177a7e1c5d81ddac7becea350/travel_money.svg'
+    'https://img.uswitch.com/t014ej9w3ur1/1Ruz9BZ8aLaThxgyjUO1QL/3d19715177a7e1c5d81ddac7becea350/travel_money.svg'
 
   return (
     <Accordion.Group>

--- a/src/elements/card/src/stories.tsx
+++ b/src/elements/card/src/stories.tsx
@@ -31,7 +31,7 @@ export const VerticalCards = () => {
   )
 
   const img =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
+    'https://img.uswitch.com/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
 
   const imgColumnSizes =
     '(max-width: 768px) 100vw, (max-width: 992px) 50vw, 400px'
@@ -136,7 +136,7 @@ export const HorizontalCards = () => {
   )
 
   const img =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
+    'https://img.uswitch.com/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
 
   return (
     <div>
@@ -195,7 +195,7 @@ export const BBDealsCard = () => {
   )
 
   const img =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
+    'https://img.uswitch.com/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
 
   return (
     <div>
@@ -229,7 +229,7 @@ export const HeaderChildrenExample = () => {
   )
 
   const img =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
+    'https://img.uswitch.com/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
 
   return (
     <div>
@@ -272,7 +272,7 @@ export const VariantsExample = () => {
   )
 
   const img =
-    'https://uswitch-contentful.imgix.net/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
+    'https://img.uswitch.com/t014ej9w3ur1/YPnGDSG9aTIPmg1rlWsZu/94483e7cec0dd6ac947e1f974650210f/800.jpg'
 
   return (
     <div>


### PR DESCRIPTION
This change migrates use from an imgix subdomain to a uswitch subdomain
`img.uswitch.com` uses [Fastly IO](https://developer.fastly.com/reference/io/) to perform image optimisation and caching. 

💀 Be warned! The query parameters _are_ different between imgix & Fastly IO. 
We have tried our best to map the the [values between each](https://github.com/uswitch/terrafying-fastly/blob/master/specs/snippets/imgix_to_io_mapper.vcl) so you don't need to update anything, but you should check each image loads as expected. If not, you may need to modify the query params or the image itself.

In particular, look out for

- `invert=true`
- `crop=faces`
- `fit=clamp`
- `trim=color`

Documentation on the mapping can be found [here](https://www.notion.so/rvu/Create-a-table-with-all-the-Imgix-to-Fastly-params-851e1da264ff42149a51e23839c49b0c)

[_Created by Sourcegraph batch change `domtronn/swap_image_cdn_domain`._](https://rvu.sourcegraph.com/users/domtronn/batch-changes/swap_image_cdn_domain)