### PR TITLE
Migrate to fastly IO CDNs

### DIFF
--- a/src/compounds/billboard/src/stories.tsx
+++ b/src/compounds/billboard/src/stories.tsx
@@ -231,7 +231,7 @@ export const ExamplePromoBanner = () => {
       breadcrumbs={breadcrumbs}
       primaryContent={primaryPromoContent}
       bgImage={
-        'https://money.imgix.net/uswitch-assets-eu/amp/images/product/credit-cards/barclaycard_platinum_2021.png'
+        'https://img.money.co.uk/s3/uswitch-assets-eu/amp/images/product/credit-cards/barclaycard_platinum_2021.png'
       }
       showImageOnMobile
       imagePosition={'center center'}


### PR DESCRIPTION
This change migrates use from an imgix subdomain to a uswitch or money subdomain
`img.[brand].com` uses [Fastly IO](https://developer.fastly.com/reference/io/) to perform image optimisation and caching. 

💀 Be warned! The query parameters _are_ different between imgix & Fastly IO. 
We have tried our best to map the the [values between each](https://github.com/uswitch/terrafying-fastly/blob/master/specs/snippets/imgix_to_io_mapper.vcl) so you don't need to update anything, but you should check each image loads as expected. If not, you may need to modify the query params or the image itself.

In particular, look out for

- `invert=true`
- `fit=clamp`
- `trim=color`

Documentation on the mapping can be found [here](https://www.notion.so/rvu/Create-a-table-with-all-the-Imgix-to-Fastly-params-851e1da264ff42149a51e23839c49b0c)

[_Created by Sourcegraph batch change `Bradpullen/s3-uswitch-assets-to-fastly-io`._](https://rvu.sourcegraph.com/users/Bradpullen/batch-changes/s3-uswitch-assets-to-fastly-io)