### PR TITLE
add ref prop to flex layout container

### DIFF
--- a/src/layout/flex-grid/src/index.tsx
+++ b/src/layout/flex-grid/src/index.tsx
@@ -38,6 +38,7 @@ const getValueFromBreakpointIndex = (arr: number[], index: number): number => {
 interface ContainerProps {
   cols?: number
   span?: number
+  ref?: React.MutableRefObject<HTMLDivElement | null>
 }
 
 export const Container: React.FC<ContainerProps &
@@ -45,6 +46,7 @@ export const Container: React.FC<ContainerProps &
   children,
   cols,
   span,
+  ref,
   className = '',
   ...props
 }) => {
@@ -67,6 +69,7 @@ export const Container: React.FC<ContainerProps &
           ),
         variant: 'compounds.container.flex'
       }}
+      ref={ref}
       {...props}
       className={classes}
     >


### PR DESCRIPTION
# Description
Add ref prop to flex container component. In mobiles frontend we have empty divs that only take ref (used for sticky filters manipulation) and it can be simplified with just adding refs to Container component. We benefit with less items on page and some future needed manipulation. 

# Checklist

Pull request contains:

- [ ] A new component
- [x] Component maintenance: improvement / bug fix / etc
- [ ] Component library change: storybook / webpack / etc

Definition of done:

- [ ] Includes theme changes for both Uswitch and money
- [ ] Work has been tested in multiple browsers
- [x] PR description includes description of change
- [ ] PR description includes screenshot of change
- [ ] If new component, designer has approved screenshot
- [ ] If the change will affect other teams, that team knows about this change
- [ ] If introducing a new component behaviour, added a story to cover that case.
